### PR TITLE
Reposition back button above market headings

### DIFF
--- a/src/Auction.tsx
+++ b/src/Auction.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { AuctionIsClosed } from "./AuctionIsClosed";
 import { AuctionIsOpen } from "./AuctionIsOpen";
 import { Tribe } from "./types";
-import styles from "./AuctionApp.module.css"; 
+import styles from "./AuctionApp.module.css";
 import { tribeAuctionHouse } from "./tribeAuctionHouse";
 import { tribeAuctionHouse2 } from "./tribeAuctionHouse2";
 import { tribeAuctionHouse3 } from "./tribeAuctionHouse3";
@@ -31,7 +31,7 @@ function getInitialIndices(tribes: Tribe[]): number[] {
   return numArr;
 }
 
-export function Auctions() {
+export function Auctions({ onBack }: { onBack?: () => void }) {
   const tribes = [tribeAuctionHouse, tribeAuctionHouse2, tribeAuctionHouse3, tribeAuctionHouse4, tribeAuctionHouse5 ];
   const [clicks, setClicks] = useState(getInitialClicks());
   const [indices, setIndices] = useState(getInitialIndices(tribes));
@@ -54,10 +54,11 @@ export function Auctions() {
           }}
           indices={indices}
           setIndices={(value) => {
-            scrollToTop(); 
+            scrollToTop();
             setIndices(value);
           }}
           tribes={tribes}
+          onBack={onBack}
         />
       </div>
     );
@@ -68,9 +69,10 @@ export function Auctions() {
       <div className={styles.backgroundImage}></div>
       <AuctionIsClosed
         setClicks={(value) => {
-          scrollToTop(); 
+          scrollToTop();
           setClicks(value);
         }}
+        onBack={onBack}
       />
     </div>
   );

--- a/src/AuctionIsClosed.tsx
+++ b/src/AuctionIsClosed.tsx
@@ -1,9 +1,11 @@
 import { useState } from "react";
+import { BackButton } from "./BackButton";
 
 const CORRECT_PASSWORD_HASH = 'ad698ac9653d25d2b386629439da8331d1cd01e59eeee63b9bf46e5e9803d383';
 
 export interface AuctionIsClosedProps {
   setClicks: (value: number) => void;
+  onBack?: () => void;
 }
 
 async function hashString(text: string) {
@@ -15,7 +17,7 @@ async function hashString(text: string) {
   return hashHex;
 }
 
-export function AuctionIsClosed({ setClicks }: AuctionIsClosedProps) {
+export function AuctionIsClosed({ setClicks, onBack }: AuctionIsClosedProps) {
   const [password, setPassword] = useState("");
   const [isPasswordCorrect, setIsPasswordCorrect] = useState<boolean | null>(
     null
@@ -59,6 +61,7 @@ export function AuctionIsClosed({ setClicks }: AuctionIsClosedProps) {
         width: '80%',
         maxWidth: '600px'
       }}>
+        <BackButton onClick={onBack} />
         <h1>Apologies Valued Adventurer</h1>
         <form onSubmit={handleSubmit}>
           <label>

--- a/src/AuctionIsOpen.tsx
+++ b/src/AuctionIsOpen.tsx
@@ -3,6 +3,7 @@ import { setCookie } from "./cookies";
 import { getIndices } from "./Goblins";
 import { Tribe } from "./types";
 import styles from "./AuctionApp.module.css"
+import { BackButton } from "./BackButton";
 
 interface AuctionIsOpenProps {
   clicks: number;
@@ -10,6 +11,7 @@ interface AuctionIsOpenProps {
   indices: number[];
   setIndices: (values: number[]) => void;
   tribes: Tribe[];
+  onBack?: () => void;
 }
 
 export function AuctionIsOpen({
@@ -18,6 +20,7 @@ export function AuctionIsOpen({
   indices,
   setIndices,
   tribes,
+  onBack,
 }: AuctionIsOpenProps) {
   const handleItemClick = () => {
 
@@ -31,6 +34,7 @@ export function AuctionIsOpen({
 
   return (
     <div className="App background-image">
+      <BackButton onClick={onBack} />
       <h1>Auction House is Open</h1>
 
       <div style={{ display: "flex", flexDirection: "column" }}>

--- a/src/BackButton.tsx
+++ b/src/BackButton.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+export function BackButton({ onClick }: { onClick?: () => void }) {
+  const handleClick = () => {
+    if (onClick) {
+      onClick();
+    } else if (typeof window !== "undefined") {
+      window.history.back();
+    }
+  };
+
+  return (
+    <button type="button" onClick={handleClick} style={styles.backButton}>
+      ← Return to the map
+    </button>
+  );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  backButton: {
+    alignSelf: "flex-start",
+    marginBottom: "1rem",
+    padding: "0.6rem 1.5rem",
+    fontSize: "1rem",
+    borderRadius: "999px",
+    border: "2px solid #333",
+    backgroundColor: "rgba(255, 255, 255, 0.9)",
+    boxShadow: "0 4px 10px rgba(0, 0, 0, 0.25)",
+    cursor: "pointer",
+    fontFamily: "'Times New Roman', serif",
+  },
+};

--- a/src/Black.tsx
+++ b/src/Black.tsx
@@ -6,7 +6,7 @@ import styles from "./BlackApp.module.css"; // Updated to use CSS Modules
 import { tribeBlackMarket } from "./tribeBlackMarket";
 import { tribeBlackMarket2 } from "./tribeBlackMarket2";
 import { tribeBlackMarket3 } from "./tribeBlackMarket3";
-import { tribeBlackMarket4 } from "./tribeBlackMarket4"; 
+import { tribeBlackMarket4 } from "./tribeBlackMarket4";
 import { tribeBlackMarket5 } from "./tribeBlackMarket5";
 import { getNextItem } from "./getNextItem";
 import { getCookie } from "./cookies";
@@ -31,7 +31,7 @@ function getInitialIndices(tribes: Tribe[]): number[] {
   return numArr;
 }
 
-export function Blacks() {
+export function Blacks({ onBack }: { onBack?: () => void }) {
   const tribes = [tribeBlackMarket, tribeBlackMarket2, tribeBlackMarket3, tribeBlackMarket4, tribeBlackMarket5];
 
   const [clicks, setClicks] = useState(getInitialClicks());
@@ -61,6 +61,7 @@ export function Blacks() {
             setIndices(value);
           }}
           tribes={tribes}
+          onBack={onBack}
         />
       </div>
     );
@@ -74,6 +75,7 @@ export function Blacks() {
           scrollToTop(); // Scroll to top on button click
           setClicks(value);
         }}
+        onBack={onBack}
       />
     </div>
   );

--- a/src/BlackIsClosed.tsx
+++ b/src/BlackIsClosed.tsx
@@ -1,9 +1,11 @@
 import { useState } from "react";
+import { BackButton } from "./BackButton";
 
 const CORRECT_PASSWORD_HASH = 'ad698ac9653d25d2b386629439da8331d1cd01e59eeee63b9bf46e5e9803d383';
 
 export interface BlackIsClosedProps {
   setClicks: (value: number) => void;
+  onBack?: () => void;
 }
 
 async function hashString(text: string) {
@@ -15,7 +17,7 @@ async function hashString(text: string) {
   return hashHex;
 }
 
-export function BlackIsClosed({ setClicks }: BlackIsClosedProps) {
+export function BlackIsClosed({ setClicks, onBack }: BlackIsClosedProps) {
   const [password, setPassword] = useState("");
   const [isPasswordCorrect, setIsPasswordCorrect] = useState<boolean | null>(
     null
@@ -57,12 +59,13 @@ export function BlackIsClosed({ setClicks }: BlackIsClosedProps) {
         boxShadow: '0 40px 8px rgba(.5, 0.5, 0.5, 0.54)',
         textAlign: 'center',
         width: '80%',
-        maxWidth: '600px'
-      }}>
+      maxWidth: '600px'
+    }}>
+        <BackButton onClick={onBack} />
         <h1>Didn't you hear me?</h1>
         <form onSubmit={handleSubmit}>
           <label>
-            Now get out of here bub, else your'll be counting to ten with your toes
+            Now get out of here, bub, or you'll be counting to ten with your toes
             <input
               type="password"
               value={password}
@@ -72,7 +75,7 @@ export function BlackIsClosed({ setClicks }: BlackIsClosedProps) {
           </label>
           <button type="submit">Submit</button>
         </form>
-        {isPasswordCorrect === false && <p>What did I say bub, get out of here before we do more then talk</p>}
+        {isPasswordCorrect === false && <p>What did I say, bub? Get out of here before we do more than talk.</p>}
       </div>
     </div>
   );

--- a/src/BlackIsOpen.tsx
+++ b/src/BlackIsOpen.tsx
@@ -3,6 +3,7 @@ import { setCookie } from "./cookies";
 import { getIndices } from "./Goblins";
 import { Tribe } from "./types";
 import styles from "./BlackApp.module.css"
+import { BackButton } from "./BackButton";
 
 interface BlackIsOpenProps {
   clicks: number;
@@ -10,6 +11,7 @@ interface BlackIsOpenProps {
   indices: number[];
   setIndices: (values: number[]) => void;
   tribes: Tribe[];
+  onBack?: () => void;
 }
 
 export function BlackIsOpen({
@@ -18,6 +20,7 @@ export function BlackIsOpen({
   indices,
   setIndices,
   tribes,
+  onBack,
 }: BlackIsOpenProps) {
   const handleItemClick = () => {
     setCookie("clicks", (clicks + 1).toString());
@@ -29,6 +32,7 @@ export function BlackIsOpen({
 
   return (
     <div className="App background-image">
+      <BackButton onClick={onBack} />
       <h1>Black Market is Open</h1>
 
       <div style={{ display: "flex", flexDirection: "column" }}>
@@ -43,9 +47,9 @@ export function BlackIsOpen({
       </div>
 
       <button className="button" onClick={handleItemClick}>
-        Got any thing else under the table?
+        Got anything else under the table?
         <br />
-        Number of looks you've gotten so far {clicks}.
+        You've checked under the table {clicks} times.
       </button>
     </div>
   );

--- a/src/GoblinIsClosed.tsx
+++ b/src/GoblinIsClosed.tsx
@@ -1,9 +1,11 @@
 import { useState } from "react";
+import { BackButton } from "./BackButton";
 
 const CORRECT_PASSWORD_HASH = 'ad698ac9653d25d2b386629439da8331d1cd01e59eeee63b9bf46e5e9803d383';
 
 export interface GoblinIsClosedProps {
   setClicks: (value: number) => void;
+  onBack?: () => void;
 }
 
 async function hashString(text: string) {
@@ -15,7 +17,7 @@ async function hashString(text: string) {
   return hashHex;
 }
 
-export function GoblinIsClosed({ setClicks }: GoblinIsClosedProps) {
+export function GoblinIsClosed({ setClicks, onBack }: GoblinIsClosedProps) {
   const [password, setPassword] = useState("");
   const [isPasswordCorrect, setIsPasswordCorrect] = useState<boolean | null>(
     null
@@ -59,6 +61,7 @@ export function GoblinIsClosed({ setClicks }: GoblinIsClosedProps) {
         width: '80%',
         maxWidth: '600px'
       }}>
+        <BackButton onClick={onBack} />
         <h1>Market is Closed</h1>
         <form onSubmit={handleSubmit}>
           <label>

--- a/src/GoblinIsOpen.tsx
+++ b/src/GoblinIsOpen.tsx
@@ -3,6 +3,7 @@ import { setCookie } from "./cookies";
 import { getIndices } from "./Goblins";
 import { Tribe } from "./types";
 import styles from "./GoblinApp.module.css"
+import { BackButton } from "./BackButton";
 
 interface GoblinIsOpenProps {
   clicks: number;
@@ -10,6 +11,7 @@ interface GoblinIsOpenProps {
   indices: number[];
   setIndices: (values: number[]) => void;
   tribes: Tribe[];
+  onBack?: () => void;
 }
 
 export function GoblinIsOpen({
@@ -18,6 +20,7 @@ export function GoblinIsOpen({
   indices,
   setIndices,
   tribes,
+  onBack,
 }: GoblinIsOpenProps) {
   const handleItemClick = () => {
     setCookie("clicks", (clicks + 1).toString());
@@ -29,6 +32,7 @@ export function GoblinIsOpen({
 
   return (
     <div className="App background-image">
+      <BackButton onClick={onBack} />
       <h1>Goblin Marketplace</h1>
 
       <div style={{ display: "flex", flexDirection: "column" }}>
@@ -43,7 +47,7 @@ export function GoblinIsOpen({
       </div>
 
       <button className="button" onClick={handleItemClick}>
-        Umm I don't like any of these can you check in the back, for me, Goober?
+        Um, I don't like any of these. Can you check in the back for me, Goober?
         <br />
         You have asked {clicks} times.
       </button>

--- a/src/Goblins.tsx
+++ b/src/Goblins.tsx
@@ -33,7 +33,7 @@ function getInitialIndices(tribes: Tribe[]): number[] {
   return numArr;
 }
 
-export function Goblins() {
+export function Goblins({ onBack }: { onBack?: () => void }) {
   const tribes = [tribe1, tribe2, tribe3, tribe4, tribe5, tribe6, tribe7];
 
   const [clicks, setClicks] = useState(getInitialClicks());
@@ -63,6 +63,7 @@ export function Goblins() {
             setIndices(value);
           }}
           tribes={tribes}
+          onBack={onBack}
         />
       </div>
     );
@@ -76,6 +77,7 @@ export function Goblins() {
           scrollToTop(); // Scroll to top on button click
           setClicks(value);
         }}
+        onBack={onBack}
       />
     </div>
   );

--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -8,11 +8,11 @@ export function Map() {
 
   switch (navigatedTo) {
     case "goblins":
-      return <Goblins />;
+      return <Goblins onBack={() => setNavigatedTo("")} />;
     case "Auction":
-      return <Auctions />;
+      return <Auctions onBack={() => setNavigatedTo("")} />;
     case "Black":
-      return <Blacks />;
+      return <Blacks onBack={() => setNavigatedTo("")} />;
     default:
       return (
         <div style={styles.wrapper}>
@@ -58,6 +58,7 @@ function FloatingButton({
 }) {
   return (
     <button
+      type="button"
       onClick={onClick}
       style={{
         ...styles.button,
@@ -107,14 +108,17 @@ const styles: Record<string, React.CSSProperties> = {
   },
 };
 
-// Inject slow floating animation into global styles
-const styleSheet = document.createElement("style");
-styleSheet.innerHTML = `
-@keyframes float {
-  0% { transform: translate(0px, 0px); }
-  25% { transform: translate(4px, -4px); }
-  50% { transform: translate(0px, -8px); }
-  75% { transform: translate(-4px, -4px); }
-  100% { transform: translate(0px, 0px); }
-}`;
-document.head.appendChild(styleSheet);
+// Inject slow floating animation into global styles (guarded for SSR)
+if (typeof document !== "undefined" && !document.getElementById("floating-keyframes")) {
+  const styleSheet = document.createElement("style");
+  styleSheet.id = "floating-keyframes";
+  styleSheet.innerHTML = `
+  @keyframes float {
+    0% { transform: translate(0px, 0px); }
+    25% { transform: translate(4px, -4px); }
+    50% { transform: translate(0px, -8px); }
+    75% { transform: translate(-4px, -4px); }
+    100% { transform: translate(0px, 0px); }
+  }`;
+  document.head.appendChild(styleSheet);
+}

--- a/src/tribeBlackMarket.ts
+++ b/src/tribeBlackMarket.ts
@@ -6,26 +6,26 @@ export const tribeBlackMarket: Tribe = {
   priceVariability: 30,
   insults: [
     "Sellers don’t meet buyers. That’s the rule—capisce?",
-    "The shop’s mobile, off the grid. I ain’t takin’ you there,",
-    "They work in shadows, not with tourists. Don’t ask again,",
-    "No faces, no follow-ups. That’s how they stay alive,",
-    "It’s too hot right now. Shop’s bein’ watched,",
-    "You don’t got the creds. Don’t waste my time,",
-    "They skipped town after someone got sloppy. Didn’t end pretty,",
-    "I can’t show ya what ain’t safe to see. That’s their call,",
-    "Last guy I brought? Curiosity cost 'em. You wanna be next?,",
-    "Some doors stay shut for a reason. This one’s welded,",
-    "Too many eyes in the alley today. Step off,",
-    "Shop’s locked down—heat’s too loud lately,",
-    "They don’t deal with strangers. You ain’t got a rep,",
-    "It’s invite-only. You ain’t on the list,",
-    "I ain’t takin’ you where you don’t belong,",
-    "Access needs guarantees. I ain’t puttin’ my neck on the line for you,",
-    "You’re on the outside. Best stay there,",
-    "Seller’s jumpy. You show up, we both got problems,",
-    "This route’s closed ‘cause they said so. I don’t argue,",
-    "Rules ain’t mine—I just enforce ‘em. You? You ain't gettin’ in,",
-    "We ain’t goin’. Guards are makin’ rounds. You wanna get pinched?,"
+    "The shop’s mobile, off the grid. I ain’t takin’ you there.",
+    "They work in shadows, not with tourists. Don’t ask again.",
+    "No faces, no follow-ups. That’s how they stay alive.",
+    "It’s too hot right now. Shop’s bein’ watched.",
+    "You don’t got the creds. Don’t waste my time.",
+    "They skipped town after someone got sloppy. Didn’t end pretty.",
+    "I can’t show ya what ain’t safe to see. That’s their call.",
+    "Last guy I brought? Curiosity cost 'em. You wanna be next?",
+    "Some doors stay shut for a reason. This one’s welded shut.",
+    "Too many eyes in the alley today. Step off.",
+    "Shop’s locked down—heat’s too loud lately.",
+    "They don’t deal with strangers. You ain’t got a rep.",
+    "It’s invite-only. You ain’t on the list.",
+    "I ain’t takin’ you where you don’t belong.",
+    "Access needs guarantees. I ain’t puttin’ my neck on the line for you.",
+    "You’re on the outside. Best stay there.",
+    "Seller’s jumpy. You show up, we both got problems.",
+    "This route’s closed ‘cause they said so. I don’t argue.",
+    "Rules ain’t mine—I just enforce ‘em. You? You ain't gettin’ in.",
+    "We ain’t goin’. Guards are makin’ rounds. You wanna get pinched?"
   ],
   items: [
     {
@@ -36,12 +36,12 @@ export const tribeBlackMarket: Tribe = {
     {
       name: "The Map of Lost Bounties",
       price: 8000,
-      description: "Tracks the location of forgotten criminals or fugitives in real time within a 10 mile radius, revealing their movements, stashes, and hideouts."
+      description: "Tracks the location of forgotten criminals or fugitives in real time within a 10-mile radius, revealing their movements, stashes, and hideouts."
     },
     {
-      name: "Book Bombs's Bootleg Death Note",
+      name: "Book Bomb's Bootleg Death Note",
       price: 7500,
-      description: "Write down someone's name, and they'll take 500 points of damage within the next week, no you do not choose when this will happen. Usable once per month."
+      description: "Write down someone's name, and they'll take 500 points of damage within the next week. No, you do not choose when this will happen. Usable once per month."
     },
     {
       name: "Void Shot Ammo",
@@ -51,17 +51,17 @@ export const tribeBlackMarket: Tribe = {
     {
       name: "Emblem of an Unfinished Goddess",
       price: 9000,
-      description: "While wearing this item you will be able to ___[add three words of your choice] as long as you are in the good graces of this deity."
+      description: "While wearing this item, you will be able to ___[add three words of your choice] as long as you are in the good graces of this deity."
     },
     {
       name: "Contract of Eternal Service",
       price: 8500,
-      description: "Draw up a contract that binds one of the signer's soul to serve the other. Until the contract is fulfilled they will be brought back from the grave to finish their task."
+      description: "Draw up a contract that binds one of the signer's souls to serve the other. Until the contract is fulfilled, they will be brought back from the grave to finish their task."
     },
     {
       name: "Refilling Tonic of a Criminal Mastermind",
       price: 6500,
-      description: "Predicts the next moves of law enforcement or bounty hunters for 30 days, allowing the user to evade capture. Cooldown 30 days."
+      description: "Predicts the next moves of law enforcement or bounty hunters for 30 days, allowing the user to evade capture. Cooldown: 30 days."
     },
     {
       name: "Hangman’s Noose",


### PR DESCRIPTION
## Summary
- place the reusable back button directly above each market page heading for easier navigation
- pass navigation handlers through open and closed market screens while styling the button for inline layout
- simplify map rendering now that sections render their own back control

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68f6bd25c6d8832988cf7961ca123037)