### PR TITLE
Add Book Bombs shop entry with sorted pricing

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,9 +1,16 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import App from './App';
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import App from "./App";
 
-test('renders learn react link', () => {
+test("renders hub map with shop buttons", () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+
+  expect(
+    screen.getByRole("heading", { name: /where would you like to go\?/i })
+  ).toBeInTheDocument();
+
+  expect(screen.getByRole("button", { name: /goblin stuff/i })).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: /auction house/i })).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: /black market/i })).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: /book bombs/i })).toBeInTheDocument();
 });

--- a/src/BookBombs.module.css
+++ b/src/BookBombs.module.css
@@ -1,0 +1,120 @@
+.app {
+  text-align: center;
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
+  background-color: #fefaf1;
+}
+
+.backgroundImage {
+  background: url('./book-bombs.svg') no-repeat center center fixed;
+  background-size: cover;
+  opacity: 0.4;
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 4rem 2rem 3rem;
+  align-items: center;
+  font-family: 'Times New Roman', serif;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  background: rgba(255, 246, 227, 0.8);
+  border: 3px solid #2f1f1d;
+  box-shadow: 8px 8px rgba(0, 0, 0, 0.35);
+  border-radius: 20px;
+  padding: 1.5rem 2rem;
+  max-width: 960px;
+  width: 100%;
+}
+
+.logo {
+  width: 140px;
+  height: 140px;
+  object-fit: contain;
+  border: 3px solid #2f1f1d;
+  border-radius: 16px;
+  background: #fff;
+  padding: 0.5rem;
+  box-shadow: 4px 6px rgba(0, 0, 0, 0.2);
+}
+
+.headerText {
+  text-align: left;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.4rem;
+  color: #2f1f1d;
+}
+
+.owner {
+  margin: 0.2rem 0;
+  font-size: 1.1rem;
+  color: #53372f;
+}
+
+.hint {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #725446;
+}
+
+.grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  width: 100%;
+  max-width: 1120px;
+}
+
+.card {
+  background: rgba(255, 255, 255, 0.92);
+  border: 3px solid #2f1f1d;
+  border-radius: 18px;
+  padding: 1.25rem;
+  box-shadow: 6px 6px rgba(0, 0, 0, 0.35);
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.cardTitle {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #3a211f;
+}
+
+.description {
+  margin: 0;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  color: #4b3a35;
+  font-size: 0.95rem;
+}
+
+.price {
+  margin: 0;
+  font-weight: bold;
+  color: #2f1f1d;
+}
+
+.footerNote {
+  margin: 0.5rem 0 0;
+  padding: 0.75rem 1.25rem;
+  background: rgba(255, 226, 168, 0.8);
+  border: 2px solid #2f1f1d;
+  border-radius: 12px;
+  box-shadow: 4px 4px rgba(0, 0, 0, 0.25);
+  color: #3a211f;
+}

--- a/src/BookBombs.tsx
+++ b/src/BookBombs.tsx
@@ -1,0 +1,67 @@
+import { useMemo } from "react";
+import styles from "./BookBombs.module.css";
+import bookBombsLogo from "./book-bombs.svg";
+import { tribeBookBombs } from "./tribeBookBombs";
+import { BackButton } from "./BackButton";
+import { Item } from "./types";
+
+type DisplayItem = Item & { finalPrice: number };
+
+function calculateAdjustedPrice(item: Item, priceVariability: number): number {
+  const variability =
+    ((Math.random() * priceVariability) / 100) * item.price;
+  const upOrDown = Math.random() < 0.5 ? -1 : 1;
+  const adjusted = item.price + upOrDown * variability;
+
+  return Math.max(0, Math.round(adjusted));
+}
+
+export function BookBombs({ onBack }: { onBack?: () => void }) {
+  const displayItems: DisplayItem[] = useMemo(() => {
+    return tribeBookBombs.items
+      .map((item) => ({
+        ...item,
+        finalPrice: calculateAdjustedPrice(item, tribeBookBombs.priceVariability),
+      }))
+      .sort((a, b) => a.finalPrice - b.finalPrice);
+  }, []);
+
+  return (
+    <div className={styles.app}>
+      <BackButton onClick={onBack} />
+      <div className={styles.backgroundImage} aria-hidden />
+      <main className={styles.content}>
+        <header className={styles.header}>
+          <img
+            src={bookBombsLogo}
+            alt="Book Bombs logo"
+            className={styles.logo}
+          />
+          <div className={styles.headerText}>
+            <h1 className={styles.title}>{tribeBookBombs.name}</h1>
+            <p className={styles.owner}>Shop Owner: {tribeBookBombs.owner}</p>
+            <p className={styles.hint}>
+              Prices fluctuate by up to {tribeBookBombs.priceVariability}%.
+            </p>
+          </div>
+        </header>
+
+        <section className={styles.grid} aria-label="Available items">
+          {displayItems.map((item) => (
+            <article key={item.name} className={styles.card}>
+              <h2 className={styles.cardTitle}>{item.name}</h2>
+              <p className={styles.description}>{item.description}</p>
+              <p className={styles.price}>
+                {item.finalPrice.toLocaleString()} Gold
+              </p>
+            </article>
+          ))}
+        </section>
+
+        <p className={styles.footerNote}>
+          {tribeBookBombs.insults[0]}
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -1,6 +1,8 @@
 import { Goblins } from "./Goblins";
 import { Auctions } from "./Auction";
 import { Blacks } from "./Black";
+import { BookBombs } from "./BookBombs";
+import bookBombsLogo from "./book-bombs.svg";
 import { useState } from "react";
 
 export function Map() {
@@ -14,6 +16,8 @@ export function Map() {
       return <Auctions onBack={() => setNavigatedTo("")} />;
     case "Black":
       return <Blacks onBack={() => setNavigatedTo("")} />;
+    case "BookBombs":
+      return <BookBombs onBack={() => setNavigatedTo("")} />;
     default:
       return (
         <div style={styles.wrapper}>
@@ -38,6 +42,13 @@ export function Map() {
               backgroundColor="rgba(0, 0, 0, 0.712)"
               color="white"
             />
+            <FloatingButton
+              label="Book Bombs"
+              onClick={() => setNavigatedTo("BookBombs")}
+              delay="12s"
+              backgroundColor="rgba(255, 226, 168, 0.9)"
+              imageSrc={bookBombsLogo}
+            />
           </div>
         </div>
       );
@@ -50,12 +61,14 @@ function FloatingButton({
   delay,
   backgroundColor,
   color = "#000",
+  imageSrc,
 }: {
   label: string;
   onClick: () => void;
   delay: string;
   backgroundColor: string;
   color?: string;
+  imageSrc?: string;
 }) {
   return (
     <button
@@ -68,7 +81,14 @@ function FloatingButton({
         color,
       }}
     >
-      {label}
+      {imageSrc ? (
+        <div style={styles.buttonContent}>
+          <img src={imageSrc} alt={`${label} logo`} style={styles.buttonImage} />
+          <span style={styles.buttonLabel}>{label}</span>
+        </div>
+      ) : (
+        label
+      )}
     </button>
   );
 }
@@ -99,13 +119,17 @@ const styles: Record<string, React.CSSProperties> = {
   button: {
     fontSize: "1.5rem",
     padding: "1rem 3rem",
-    borderRadius: "23px",               // Smooth rounded shape
-    border: "2px solid #333",           // Add subtle outline
-    boxShadow: "0 7px 12px rgba(0, 0, 0, 0.5)", // Add soft drop shadow
+    borderRadius: "23px",
+    border: "2px solid #333",
+    boxShadow: "0 7px 12px rgba(0, 0, 0, 0.5)",
     cursor: "pointer",
-    animation: "float 12s ease-in-out infinite", // Slower float
+    animation: "float 12s ease-in-out infinite",
     transition: "transform 0.3s ease",
     fontFamily: "'Times New Roman', serif",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    gap: "0.75rem",
   },
   backButton: {
     position: "fixed",
@@ -120,6 +144,24 @@ const styles: Record<string, React.CSSProperties> = {
     boxShadow: "0 4px 10px rgba(0, 0, 0, 0.25)",
     cursor: "pointer",
     fontFamily: "'Times New Roman', serif",
+  },
+  buttonContent: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    gap: "0.35rem",
+  },
+  buttonImage: {
+    width: "140px",
+    height: "140px",
+    objectFit: "contain",
+    borderRadius: "12px",
+    border: "2px solid rgba(0,0,0,0.6)",
+    backgroundColor: "rgba(255,255,255,0.85)",
+    boxShadow: "0 4px 8px rgba(0,0,0,0.35)",
+  },
+  buttonLabel: {
+    display: "block",
   },
 };
 

--- a/src/book-bombs.svg
+++ b/src/book-bombs.svg
@@ -1,0 +1,50 @@
+<svg width="640" height="640" viewBox="0 0 640 640" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="640" height="640" rx="32" fill="#FDF6E3"/>
+  <g filter="url(#shadow)">
+    <path d="M108 272C134 222 232 156 310 168C388 180 470 200 490 268C510 336 498 398 466 438C434 478 360 498 294 488C228 478 172 446 146 404C120 362 82 322 108 272Z" fill="#FFF7C2"/>
+    <path d="M170 184C228 172 284 184 326 194C368 204 386 214 404 228C422 242 438 260 454 274C470 288 486 298 496 320C506 342 508 376 504 402C500 428 486 446 462 462C438 478 404 492 362 492C320 492 270 482 226 470C182 458 142 444 124 410C106 376 110 322 124 280C138 238 154 196 170 184Z" fill="#FFD166"/>
+    <path d="M154 206C188 200 238 192 280 200C322 208 350 224 380 246C410 268 442 296 446 332C450 368 426 412 390 438C354 464 306 472 262 470C218 468 178 456 154 432C130 408 122 372 122 340C122 308 120 280 130 252C140 224 154 206 154 206Z" fill="#F4A261"/>
+  </g>
+  <g filter="url(#shadow)">
+    <path d="M180 190L310 160L358 188L220 226L180 190Z" fill="#EAE2D7"/>
+    <path d="M220 226L358 188L396 214L266 250L220 226Z" fill="#D1C8BD"/>
+    <path d="M266 250L396 214L432 240L304 276L266 250Z" fill="#BFB5AA"/>
+    <path d="M304 276L432 240L452 262L326 296L304 276Z" fill="#ADA297"/>
+    <path d="M326 296L452 262L468 288L340 320L326 296Z" fill="#9F9386"/>
+    <path d="M340 320L468 288L464 326L332 350L340 320Z" fill="#8E8377"/>
+    <path d="M332 350L464 326L452 360L324 382L332 350Z" fill="#7B6E62"/>
+    <path d="M324 382L452 360L434 392L306 414L324 382Z" fill="#695C50"/>
+    <path d="M306 414L434 392L392 430L272 450L306 414Z" fill="#55493D"/>
+    <path d="M220 226V430L392 430V214L220 226Z" fill="#EDE8DE"/>
+    <path d="M392 214V430L414 414V236L392 214Z" fill="#C7C0B6"/>
+    <path d="M220 226V430L198 414V212L220 226Z" fill="#C7C0B6"/>
+    <path d="M198 212L332 184V208L198 236V212Z" fill="#F2EDE4"/>
+    <path d="M332 184L416 214V236L332 208V184Z" fill="#D6D0C5"/>
+    <path d="M246 252C248 254 250 256 252 258C258 264 264 270 270 276C276 282 282 288 286 292C292 298 296 302 300 306C304 310 308 314 312 316C314 318 316 318 320 318C324 318 330 316 334 314C338 312 344 310 348 308C352 306 354 306 358 306C362 306 366 308 368 312C370 316 370 320 368 324C366 328 362 332 358 334C354 336 348 338 342 338C336 338 328 336 320 332C312 328 304 322 296 314C288 306 280 296 272 288C264 280 256 270 250 262C248 260 246 258 244 256C240 252 242 248 246 252Z" fill="#A33B2E"/>
+    <path d="M246 252C248 254 250 256 252 258C258 264 264 270 270 276C276 282 282 288 286 292C292 298 296 302 300 306C304 310 308 314 312 316C314 318 316 318 320 318C324 318 330 316 334 314C338 312 344 310 348 308C352 306 354 306 358 306C362 306 366 308 368 312C370 316 370 320 368 324C366 328 362 332 358 334C354 336 348 338 342 338C336 338 328 336 320 332C312 328 304 322 296 314C288 306 280 296 272 288C264 280 256 270 250 262C248 260 246 258 244 256C240 252 242 248 246 252Z" stroke="#321916" stroke-width="10" stroke-linecap="round"/>
+    <circle cx="352" cy="276" r="16" fill="#F25F5C" stroke="#2D1B1A" stroke-width="8"/>
+  </g>
+  <g filter="url(#glow)">
+    <circle cx="486" cy="160" r="22" fill="#FFDD76"/>
+    <circle cx="160" cy="150" r="18" fill="#FFE4A3"/>
+    <circle cx="114" cy="320" r="16" fill="#FFE89C"/>
+    <circle cx="510" cy="348" r="24" fill="#FFC857"/>
+  </g>
+  <defs>
+    <filter id="shadow" x="70" y="120" width="438" height="380" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset dx="6" dy="10"/>
+      <feGaussianBlur stdDeviation="18"/>
+      <feComposite in2="hardAlpha" operator="out"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.05 0 0 0 0 0.05 0 0 0 0 0.05 0 0 0 0.32 0"/>
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+    </filter>
+    <filter id="glow" x="86" y="122" width="446" height="274" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+      <feGaussianBlur stdDeviation="12" result="effect1_foregroundBlur"/>
+    </filter>
+  </defs>
+</svg>

--- a/src/tribeBookBombs.ts
+++ b/src/tribeBookBombs.ts
@@ -1,0 +1,40 @@
+import { Tribe } from "./types";
+
+export const tribeBookBombs: Tribe = {
+  name: "Book Bombs",
+  owner: "Bill",
+  percentAngry: 0,
+  priceVariability: 5,
+  insults: ["Oh sorry were sold out of that"],
+  items: [
+    {
+      name: "Traps and Treasures: Explosive Edition",
+      price: 20,
+      description:
+        "A guide on incorporating explosive traps into dungeons, homes, and safeguarding treasures.",
+    },
+    {
+      name: "Art of Fireworks",
+      price: 20,
+      description:
+        "A book on the creation and artistry behind magical and non magical fireworks.",
+    },
+    {
+      name: "Alchemy of Explosives",
+      price: 30,
+      description: "Gain proficiency with Alchemy & chemical-based explosives.",
+    },
+    {
+      name: "Explosive Runes for Dummies",
+      price: 30,
+      description:
+        "An introductory guide to magical runes that explode when read or triggered.",
+    },
+    {
+      name: "Cool people don't look at EXPLOSIONS",
+      price: 40,
+      description:
+        "Gain proficiency with all vehicles, but when you leave the vehicle it combusts.",
+    },
+  ],
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export interface Item {
 
 export interface Tribe {
   name: string;
+  owner?: string;
   percentAngry: number;
   priceVariability: number;
   items: Item[];


### PR DESCRIPTION
## Summary
- add the Book Bombs shop with sorted item listings, 5% price variability, and themed styling/background
- surface the Book Bombs logo/button on the map hub and adjust tests for the updated navigation
- extend the tribe type with optional ownership metadata for shop displays

## Testing
- npm test -- --watch=false

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c2b6fb13483299e4e81a03f7f25da)