### PR TITLE
Fix duplicate Book Bombs header

### DIFF
--- a/src/BookBombs.module.css
+++ b/src/BookBombs.module.css
@@ -36,6 +36,7 @@
 .header {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 1.5rem;
   background: rgba(255, 246, 227, 0.8);
   border: 3px solid #2f1f1d;
@@ -121,4 +122,3 @@
   font-weight: bold;
   color: #2f1f1d;
 }
-

--- a/src/BookBombs.tsx
+++ b/src/BookBombs.tsx
@@ -39,20 +39,6 @@ export function BookBombs({ onBack }: { onBack?: () => void }) {
           <div className={styles.headerText}>
             <h1 className={styles.title}>{tribeBookBombs.name}</h1>
             <p className={styles.owner}>Shop Owner: {tribeBookBombs.owner}</p>
-            </div>
-      <div className={styles.backgroundImage} aria-hidden />
-      {/* <main className={styles.content}>
-        <header className={styles.header}> */}
-          {/* <img
-            src={bookBombsLogo}
-            alt="Book Bombs logo"
-            className={styles.logo}
-          /> */}
-          <div className={styles.headerText}>
-            <h1 className={styles.title}>{tribeBookBombs.name}</h1>
-            <p className={styles.owner}>Shop Owner: {tribeBookBombs.owner}</p>
-            <p className={styles.hint}>
-            </p>
           </div>
         </header>
 


### PR DESCRIPTION
## Summary
- remove the duplicate Book Bombs header markup
- center the Book Bombs header content for clearer presentation

## Testing
- npm test -- --watch=false

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c4e92cd24832984f72395243d29dd)