### PR TITLE
Update Book Bombs styling

### DIFF
--- a/src/BookBombs.module.css
+++ b/src/BookBombs.module.css
@@ -6,17 +6,10 @@
 }
 
 .backgroundImage {
-  background: url('./book-bombs.svg') no-repeat center center fixed;
-  /* background-size: cover;  
-  opacity: 0.75;
-  margin: 25px;
-  z-index: -1;  */
-  display: flex;
-  background-size: cover; 
-  height: Fill;
-  opacity: 0.75;
-  margin: px;
-  z-index: -1; 
+  background: no-repeat center center fixed;
+  background-size: cover;
+  opacity: 0.8;
+  z-index: -1;
   position: absolute;
   top: 0;
   left: 0;
@@ -38,7 +31,7 @@
   align-items: center;
   justify-content: center;
   gap: 1.5rem;
-  background: rgba(255, 246, 227, 0.8);
+  background: #ffffff;
   border: 3px solid #2f1f1d;
   box-shadow: 8px 8px rgba(0, 0, 0, 0.35);
   border-radius: 20px;
@@ -89,7 +82,7 @@
 }
 
 .card {
-  background: rgba(255, 255, 255, 0.92);
+  background: #ffffff;
   border: 3px solid #2f1f1d;
   border-radius: 18px;
   padding: 1.5rem 1.25rem;

--- a/src/BookBombs.tsx
+++ b/src/BookBombs.tsx
@@ -3,7 +3,7 @@ import styles from "./BookBombs.module.css";
 import { tribeBookBombs } from "./tribeBookBombs";
 import { BackButton } from "./BackButton";
 import { Item } from "./types";
-import { bookBombDataUrl } from "./bookBombImage";
+import bookBombBackground from "./Book Bomb.png";
 
 type DisplayItem = Item & { finalPrice: number };
 
@@ -31,7 +31,7 @@ export function BookBombs({ onBack }: { onBack?: () => void }) {
       <BackButton onClick={onBack} />
       <div
         className={styles.backgroundImage}
-        style={{ backgroundImage: `url(${bookBombDataUrl})` }}
+        style={{ backgroundImage: `url(${bookBombBackground})` }}
         aria-hidden
       />
       <main className={styles.content}>


### PR DESCRIPTION
## Summary
- set the Book Bombs view to use the Book Bomb.png asset for its background image
- make the Book Bombs header and item cards use solid white styling for the text boxes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c50bce8a88329b6d64416ebbc8d58)