### PR TITLE
Add Applegarth Guild shop variant

### DIFF
--- a/src/ApplegarthGuild.module.css
+++ b/src/ApplegarthGuild.module.css
@@ -1,0 +1,130 @@
+.app {
+  text-align: center;
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
+}
+
+.backgroundImage {
+  background: url('./Applegarth.webp') no-repeat center center fixed;
+  display: flex;
+  background-size: cover;
+  height: Fill;
+  opacity: 0.75;
+  margin: px;
+  z-index: -1;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 4rem 2rem 3rem;
+  align-items: center;
+  font-family: 'Times New Roman', serif;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  background: #ffffff;
+  border: 3px solid #2f1f1d;
+  box-shadow: 8px 8px rgba(0, 0, 0, 0.35);
+  border-radius: 20px;
+  padding: 1.5rem 2rem;
+  max-width: 360px;
+  width: 100%;
+}
+
+.logo {
+  width: 140px;
+  height: 140px;
+  object-fit: contain;
+  border: 3px solid #2f1f1d;
+  border-radius: 16px;
+  background: #fff;
+  padding: 0.5rem;
+  box-shadow: 4px 6px rgba(0, 0, 0, 0.2);
+}
+
+.headerText {
+  text-align: center;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.4rem;
+  color: #2f1f1d;
+}
+
+.owner {
+  margin: 0.2rem 0;
+  font-size: 1.1rem;
+  color: #b94c2e;
+}
+
+.hint {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #ff5100;
+}
+
+.grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: 1fr;
+  width: 100%;
+  max-width: 640px;
+}
+
+.card {
+  background: #ffffff;
+  border: 3px solid #2f1f1d;
+  border-radius: 18px;
+  padding: 1.5rem 1.25rem;
+  color: #ffffff;
+  font-family: monospace; 
+  font-size: 24px;
+  font-weight: bolder;
+  width: fit-content;
+  max-width: 600px;
+  text-align: center;
+  margin-left: auto;
+  margin-right: auto;
+  border-radius: 50% 20% / 10% 40%;
+  box-shadow: 5px 5px rgba(0, 0, 0, 0.67);
+  border: 5px solid rgb(0, 0, 0);
+}
+
+.cardTitle {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #3a211f;
+}
+
+.description {
+  margin: 0;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  color: #4b3a35;
+  font-size: 0.95rem;
+  text-align: center;
+}
+
+.price {
+  margin: 0;
+  font-weight: bold;
+  color: #2f1f1d;
+}
+
+.footerNote {
+  margin: 0;
+  font-weight: bold;
+  color: #2f1f1d;
+}

--- a/src/ApplegarthGuild.tsx
+++ b/src/ApplegarthGuild.tsx
@@ -1,0 +1,68 @@
+import { useMemo } from "react";
+import styles from "./ApplegarthGuild.module.css";
+import { tribeApplegarthGuild } from "./tribeApplegarthGuild";
+import { BackButton } from "./BackButton";
+import { Item } from "./types";
+import applegarthBackground from "./Applegarth.webp";
+
+type GuildItem = Item & { priceLabel?: string };
+type DisplayItem = GuildItem & { finalPrice?: number };
+
+function calculateAdjustedPrice(item: Item, priceVariability: number): number {
+  const variability = ((Math.random() * priceVariability) / 100) * item.price;
+  const upOrDown = Math.random() < 0.5 ? -1 : 1;
+  const adjusted = item.price + upOrDown * variability;
+
+  return Math.max(0, Math.round(adjusted));
+}
+
+export function ApplegarthGuild({ onBack }: { onBack?: () => void }) {
+  const displayItems: DisplayItem[] = useMemo(() => {
+    return tribeApplegarthGuild.items
+      .map((item) => {
+        if (item.priceLabel) {
+          return { ...item, finalPrice: undefined };
+        }
+
+        return {
+          ...item,
+          finalPrice: calculateAdjustedPrice(item, tribeApplegarthGuild.priceVariability),
+        };
+      })
+      .sort((a, b) => (a.finalPrice ?? Number.MAX_SAFE_INTEGER) - (b.finalPrice ?? Number.MAX_SAFE_INTEGER));
+  }, []);
+
+  return (
+    <div className={styles.app}>
+      <BackButton onClick={onBack} />
+      <div
+        className={styles.backgroundImage}
+        style={{ backgroundImage: `url(${applegarthBackground})` }}
+      />
+      <main className={styles.content}>
+        <header className={styles.header}>
+          <div className={styles.headerText}>
+            <h1 className={styles.title}>{tribeApplegarthGuild.name}</h1>
+            <p className={styles.owner}>Shop Owner: {tribeApplegarthGuild.owner}</p>
+          </div>
+        </header>
+
+        <section className={styles.grid} aria-label="Available items">
+          {displayItems.map((item) => {
+            const priceText = item.priceLabel ?? `${(item.finalPrice ?? item.price).toLocaleString()} Gold`;
+
+            return (
+              <article key={item.name} className={styles.card}>
+                <h2 className={styles.cardTitle}>{item.name}</h2>
+                <p className={styles.description}>{item.description}</p>
+                <p className={styles.price}>{priceText}</p>
+              </article>
+            );
+          })}
+        </section>
+
+        <p className={styles.footerNote}>{tribeApplegarthGuild.insults[0]}</p>
+      </main>
+    </div>
+  );
+}

--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -2,10 +2,12 @@ import { Goblins } from "./Goblins";
 import { Auctions } from "./Auction";
 import { Blacks } from "./Black";
 import { BookBombs } from "./BookBombs";
+import { ApplegarthGuild } from "./ApplegarthGuild";
 import { bookBombDataUrl } from "./bookBombImage";
 import bookBombsLogo from "./book-bombs.svg";
 // Use the uploaded PNG asset (filename contains a space)
 import bookBombPng from "./Book Bomb.png";
+import applegarthImage from "./Applegarth.webp";
 import { useEffect, useState } from "react";
 
 // Remove stray whitespace/newlines from data URIs (defensive)
@@ -64,6 +66,8 @@ export function Map() {
       return <Blacks onBack={() => setNavigatedTo("")} />;
     case "BookBombs":
       return <BookBombs onBack={() => setNavigatedTo("")} />;
+    case "ApplegarthGuild":
+      return <ApplegarthGuild onBack={() => setNavigatedTo("")} />;
     default:
       return (
         <div style={styles.wrapper}>
@@ -97,6 +101,13 @@ export function Map() {
               // the cleaned embedded data URI, then the canvas-rendered text.
               imageSrc={bookBombPng ?? cleanedBookBomb ?? bookBombImageFromText}
               // imageSrc={bookBombsLogo}
+            />
+            <FloatingButton
+              label="Applegarth Guild"
+              onClick={() => setNavigatedTo("ApplegarthGuild")}
+              delay="15s"
+              backgroundColor="rgba(255, 255, 255, 0.9)"
+              imageSrc={applegarthImage}
             />
           </div>
         </div>

--- a/src/tribeApplegarthGuild.ts
+++ b/src/tribeApplegarthGuild.ts
@@ -1,0 +1,76 @@
+import { Item, Tribe } from "./types";
+
+interface ApplegarthItem extends Item {
+  priceLabel?: string;
+}
+
+interface ApplegarthTribe extends Omit<Tribe, "items"> {
+  items: ApplegarthItem[];
+}
+
+export const tribeApplegarthGuild: ApplegarthTribe = {
+  name: "Applegarth Guild",
+  owner: "John Applegarth",
+  percentAngry: 0,
+  priceVariability: 5,
+  insults: [""],
+  items: [
+    {
+      name: "Charon's Token",
+      description: "Teleport to a town you have previously visited, one time use.",
+      price: 50,
+    },
+    {
+      name: "Hire for a month a Servent",
+      description: "Novice service tier.",
+      price: 25,
+    },
+    {
+      name: "Hire for a month a Maid",
+      description: "Apprentice service tier.",
+      price: 50,
+    },
+    {
+      name: "Hire for a month a Butler",
+      description: "Master service tier.",
+      price: 100,
+    },
+    {
+      name: "Hire a Bounty Hunter for a job",
+      description: "Apprentice contract level.",
+      price: 100,
+    },
+    {
+      name: "Hire a Lawyer for a case",
+      description: "Apprentice contract level.",
+      price: 150,
+    },
+    {
+      name: "Hire an Engineer for a project",
+      description: "Apprentice contract level.",
+      price: 250,
+    },
+    {
+      name: "Contact a Sage to stay in your town for one year",
+      description: "One-year residency for an expert sage.",
+      price: 2000,
+    },
+    {
+      name: "Contact a Master Craftsmen to stay in your town for one year",
+      description: "One-year residency for a master craftsperson.",
+      price: 5000,
+    },
+    {
+      name: "Contact a Harrold to stay in your town for one year",
+      description: "One-year residency for a herald.",
+      price: 1000,
+    },
+    {
+      name:
+        "Guild Contract hire Applegarth, Archivist, Dungeon Crawler, Navigation, or Jewelry Guild for a reasonable long-term job (please message me about what you would like so we can hash out the details)",
+      description: "Custom contract terms available upon request.",
+      price: 0,
+      priceLabel: "Price may vary",
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- create an Applegarth Guild shop view modeled after Book Bombs with Applegarth branding and pricing labels
- add Applegarth Guild shop data mirroring provided offerings and display gold or custom price text
- wire the new shop into the map navigation with its own launch button

## Testing
- npm test -- --watch=false


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c898bac4c8329b4bf81faf868b223)