### PR TITLE
Add Archives Guild shop interface

### DIFF
--- a/src/ArchivesGuild.module.css
+++ b/src/ArchivesGuild.module.css
@@ -1,0 +1,128 @@
+.app {
+  text-align: center;
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
+}
+
+.backgroundImage {
+  background: url('./Archives Guild.png') no-repeat center center fixed; 
+  display: flex;
+  background-size: cover; 
+  height: Fill;
+  opacity: 0.75;
+  margin: px;
+  z-index: -1; 
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 4rem 2rem 3rem;
+  align-items: center;
+  font-family: 'Times New Roman', serif;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  background: #ffffff;
+  border: 3px solid #2f1f1d;
+  box-shadow: 8px 8px rgba(0, 0, 0, 0.35);
+  border-radius: 20px;
+  padding: 1.5rem 2rem;
+  max-width: 360px;
+  width: 100%;
+}
+
+.logo {
+  width: 140px;
+  height: 140px;
+  object-fit: contain;
+  border: 3px solid #2f1f1d;
+  border-radius: 16px;
+  background: #fff;
+  padding: 0.5rem;
+  box-shadow: 4px 6px rgba(0, 0, 0, 0.2);
+}
+
+.headerText {
+  text-align: center;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.4rem;
+  color: #2f1f1d;
+}
+
+.owner {
+  margin: 0.2rem 0;
+  font-size: 1.1rem;
+  color: #b94c2e;
+}
+
+.hint {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #ff5100;
+}
+
+.grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: 1fr;
+  width: 100%;
+  max-width: 640px;
+}
+
+.card {
+  background: #ffffff;
+  border: 3px solid #2f1f1d;
+  border-radius: 18px;
+  padding: 1.5rem 1.25rem;
+  color: #ffffff;
+  font-family: monospace; 
+  font-size: 24px;
+  font-weight: bolder;
+  width: fit-content;
+  max-width: 600px;
+  text-align: center;
+  margin-left: auto;
+  margin-right: auto;
+  border-radius: 50% 20% / 10% 40%;
+  box-shadow: 5px 5px rgba(0, 0, 0, 0.67);
+  border: 5px solid rgb(0, 0, 0);
+}
+
+.cardTitle {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #3a211f;
+}
+
+.description {
+  margin: 0;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  color: #4b3a35;
+  font-size: 0.95rem;
+  text-align: center;
+}
+
+.price {
+  margin: 0;
+  font-weight: bold;
+  color: #2f1f1d;
+}
+
+.footerNote {
+  margin: 0;
+}

--- a/src/ArchivesGuild.tsx
+++ b/src/ArchivesGuild.tsx
@@ -1,0 +1,61 @@
+import { useMemo } from "react";
+import styles from "./ArchivesGuild.module.css";
+import { tribeArchivesGuild } from "./tribeArchivesGuild";
+import { BackButton } from "./BackButton";
+import { Item } from "./types";
+import archivesGuildBackground from "./Archives Guild.png";
+
+type DisplayItem = Item & { finalPrice: number };
+
+function calculateAdjustedPrice(item: Item, priceVariability: number): number {
+  const variability = ((Math.random() * priceVariability) / 100) * item.price;
+  const upOrDown = Math.random() < 0.5 ? -1 : 1;
+  const adjusted = item.price + upOrDown * variability;
+
+  return Math.max(0, Math.round(adjusted));
+}
+
+export function ArchivesGuild({ onBack }: { onBack?: () => void }) {
+  const displayItems: DisplayItem[] = useMemo(() => {
+    return tribeArchivesGuild.items
+      .map((item) => ({
+        ...item,
+        finalPrice: calculateAdjustedPrice(item, tribeArchivesGuild.priceVariability),
+      }))
+      .sort((a, b) => a.finalPrice - b.finalPrice);
+  }, []);
+
+  return (
+    <div className={styles.app}>
+      <BackButton onClick={onBack} />
+      <div
+        className={styles.backgroundImage}
+        style={{ backgroundImage: `url(${archivesGuildBackground})` }}
+      />
+      <main className={styles.content}>
+        <header className={styles.header}>
+          <div className={styles.headerText}>
+            <h1 className={styles.title}>{tribeArchivesGuild.name}</h1>
+            <p className={styles.owner}>Shop Owner: {tribeArchivesGuild.owner}</p>
+          </div>
+        </header>
+
+        <section className={styles.grid} aria-label="Available items">
+          {displayItems.map((item) => (
+            <article key={item.name} className={styles.card}>
+              <h2 className={styles.cardTitle}>{item.name}</h2>
+              <p className={styles.description}>{item.description}</p>
+              <p className={styles.price}>
+                {item.finalPrice.toLocaleString()} Gold
+              </p>
+            </article>
+          ))}
+        </section>
+
+        <p className={styles.footerNote}>
+          {tribeArchivesGuild.insults[0]}
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -3,11 +3,12 @@ import { Auctions } from "./Auction";
 import { Blacks } from "./Black";
 import { BookBombs } from "./BookBombs";
 import { ApplegarthGuild } from "./ApplegarthGuild";
+import { ArchivesGuild } from "./ArchivesGuild";
 import { bookBombDataUrl } from "./bookBombImage";
-import bookBombsLogo from "./book-bombs.svg";
 // Use the uploaded PNG asset (filename contains a space)
 import bookBombPng from "./Book Bomb.png";
 import applegarthImage from "./Applegarth.webp";
+import archivesGuildImage from "./Archives Guild.png";
 import { useEffect, useState } from "react";
 
 // Remove stray whitespace/newlines from data URIs (defensive)
@@ -68,6 +69,8 @@ export function Map() {
       return <BookBombs onBack={() => setNavigatedTo("")} />;
     case "ApplegarthGuild":
       return <ApplegarthGuild onBack={() => setNavigatedTo("")} />;
+    case "ArchivesGuild":
+      return <ArchivesGuild onBack={() => setNavigatedTo("")} />;
     default:
       return (
         <div style={styles.wrapper}>
@@ -108,6 +111,13 @@ export function Map() {
               delay="15s"
               backgroundColor="rgba(255, 255, 255, 0.9)"
               imageSrc={applegarthImage}
+            />
+            <FloatingButton
+              label="Archives Guild"
+              onClick={() => setNavigatedTo("ArchivesGuild")}
+              delay="18s"
+              backgroundColor="rgba(255, 255, 255, 0.9)"
+              imageSrc={archivesGuildImage}
             />
           </div>
         </div>

--- a/src/tribeArchivesGuild.ts
+++ b/src/tribeArchivesGuild.ts
@@ -1,0 +1,36 @@
+import { Tribe } from "./types";
+
+export const tribeArchivesGuild: Tribe = {
+  name: "Archives Guild",
+  owner: "Andrew Vr 2",
+  percentAngry: 0,
+  priceVariability: 0,
+  insults: [""],
+  items: [
+    {
+      name: "Sell a Common Item",
+      price: 10,
+      description: "",
+    },
+    {
+      name: "Sell a Uncommon Item",
+      price: 20,
+      description: "",
+    },
+    {
+      name: "Sell a Rare Item",
+      price: 30,
+      description: "",
+    },
+    {
+      name: "Sell a Very Rare Item",
+      price: 50,
+      description: "",
+    },
+    {
+      name: "Sell a Legendary Item",
+      price: 5000,
+      description: "",
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- add an Archives Guild shop page mirroring the Book Bombs layout with its own background
- define Archives Guild inventory data with gold prices
- link the Archives Guild from the map navigation alongside existing locations

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c8bab6a6c832997ca746b9a43d487)