### PR TITLE
Add Bullets, Buffs, & Beyond shop

### DIFF
--- a/src/BulletsBuffsBeyond.module.css
+++ b/src/BulletsBuffsBeyond.module.css
@@ -1,0 +1,130 @@
+.app {
+  text-align: center;
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
+}
+
+.backgroundImage {
+  background: url("./Bullets Buffs and Beyond.webp") no-repeat center center fixed;
+  display: flex;
+  background-size: cover;
+  height: 100%;
+  opacity: 0.75;
+  margin: 0;
+  z-index: -1;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 4rem 2rem 3rem;
+  align-items: center;
+  font-family: "Times New Roman", serif;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  background: #ffffff;
+  border: 3px solid #2f1f1d;
+  box-shadow: 8px 8px rgba(0, 0, 0, 0.35);
+  border-radius: 20px;
+  padding: 1.5rem 2rem;
+  max-width: 360px;
+  width: 100%;
+}
+
+.logo {
+  width: 140px;
+  height: 140px;
+  object-fit: contain;
+  border: 3px solid #2f1f1d;
+  border-radius: 16px;
+  background: #fff;
+  padding: 0.5rem;
+  box-shadow: 4px 6px rgba(0, 0, 0, 0.2);
+}
+
+.headerText {
+  text-align: center;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.4rem;
+  color: #2f1f1d;
+}
+
+.owner {
+  margin: 0.2rem 0;
+  font-size: 1.1rem;
+  color: #b94c2e;
+}
+
+.hint {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #ff5100;
+}
+
+.grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: 1fr;
+  width: 100%;
+  max-width: 640px;
+}
+
+.card {
+  background: #ffffff;
+  border: 3px solid #2f1f1d;
+  border-radius: 18px;
+  padding: 1.5rem 1.25rem;
+  color: #ffffff;
+  font-family: monospace;
+  font-size: 24px;
+  font-weight: bolder;
+  width: fit-content;
+  max-width: 600px;
+  text-align: center;
+  margin-left: auto;
+  margin-right: auto;
+  border-radius: 50% 20% / 10% 40%;
+  box-shadow: 5px 5px rgba(0, 0, 0, 0.67);
+  border: 5px solid rgb(0, 0, 0);
+}
+
+.cardTitle {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #3a211f;
+}
+
+.description {
+  margin: 0;
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  color: #4b3a35;
+  font-size: 0.95rem;
+  text-align: center;
+}
+
+.price {
+  margin: 0;
+  font-weight: bold;
+  color: #2f1f1d;
+}
+
+.footerNote {
+  margin: 0;
+  font-weight: bold;
+  color: #2f1f1d;
+}

--- a/src/BulletsBuffsBeyond.tsx
+++ b/src/BulletsBuffsBeyond.tsx
@@ -1,0 +1,71 @@
+import { useMemo } from "react";
+import styles from "./BulletsBuffsBeyond.module.css";
+import { tribeBulletsBuffsBeyond } from "./tribeBulletsBuffsBeyond";
+import { BackButton } from "./BackButton";
+import { Item } from "./types";
+import bulletsBuffsBeyondBackground from "./Bullets Buffs and Beyond.webp";
+
+type BulletsBuffsBeyondItem = Item & { priceLabel?: string };
+type DisplayItem = BulletsBuffsBeyondItem & { finalPrice?: number };
+
+function calculateAdjustedPrice(item: Item, priceVariability: number): number {
+  const variability =
+    ((Math.random() * priceVariability) / 100) * item.price;
+  const upOrDown = Math.random() < 0.5 ? -1 : 1;
+  const adjusted = item.price + upOrDown * variability;
+
+  return Math.max(0, Math.round(adjusted));
+}
+
+export function BulletsBuffsBeyond({ onBack }: { onBack?: () => void }) {
+  const displayItems: DisplayItem[] = useMemo(() => {
+    return tribeBulletsBuffsBeyond.items
+      .map((item) => {
+        if ("priceLabel" in item && item.priceLabel) {
+          return { ...item, finalPrice: undefined };
+        }
+
+        return {
+          ...item,
+          finalPrice: calculateAdjustedPrice(item, tribeBulletsBuffsBeyond.priceVariability),
+        };
+      })
+      .sort((a, b) => (a.finalPrice ?? Number.MAX_SAFE_INTEGER) - (b.finalPrice ?? Number.MAX_SAFE_INTEGER));
+  }, []);
+
+  return (
+    <div className={styles.app}>
+      <BackButton onClick={onBack} />
+      <div
+        className={styles.backgroundImage}
+        style={{ backgroundImage: `url(${bulletsBuffsBeyondBackground})` }}
+      />
+      <main className={styles.content}>
+        <header className={styles.header}>
+          <div className={styles.headerText}>
+            <h1 className={styles.title}>{tribeBulletsBuffsBeyond.name}</h1>
+            <p className={styles.owner}>Shop Owner: {tribeBulletsBuffsBeyond.owner}</p>
+          </div>
+        </header>
+
+        <section className={styles.grid} aria-label="Available items">
+          {displayItems.map((item) => {
+            const priceText = item.priceLabel ?? `${(item.finalPrice ?? item.price).toLocaleString()} Gold`;
+
+            return (
+              <article key={item.name} className={styles.card}>
+                <h2 className={styles.cardTitle}>{item.name}</h2>
+                <p className={styles.description}>{item.description}</p>
+                <p className={styles.price}>{priceText}</p>
+              </article>
+            );
+          })}
+        </section>
+
+        <p className={styles.footerNote}>
+          {tribeBulletsBuffsBeyond.insults[0]}
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -2,11 +2,13 @@ import { Goblins } from "./Goblins";
 import { Auctions } from "./Auction";
 import { Blacks } from "./Black";
 import { BookBombs } from "./BookBombs";
+import { BulletsBuffsBeyond } from "./BulletsBuffsBeyond";
 import { ApplegarthGuild } from "./ApplegarthGuild";
 import { ArchivesGuild } from "./ArchivesGuild";
 import { bookBombDataUrl } from "./bookBombImage";
 // Use the uploaded PNG asset (filename contains a space)
 import bookBombPng from "./Book Bomb.png";
+import bulletsBuffsBeyondImage from "./Bullets Buffs and Beyond.webp";
 import applegarthImage from "./Applegarth.webp";
 import archivesGuildImage from "./Archives Guild.png";
 import { useEffect, useState } from "react";
@@ -67,6 +69,8 @@ export function Map() {
       return <Blacks onBack={() => setNavigatedTo("")} />;
     case "BookBombs":
       return <BookBombs onBack={() => setNavigatedTo("")} />;
+    case "BulletsBuffsBeyond":
+      return <BulletsBuffsBeyond onBack={() => setNavigatedTo("")} />;
     case "ApplegarthGuild":
       return <ApplegarthGuild onBack={() => setNavigatedTo("")} />;
     case "ArchivesGuild":
@@ -118,6 +122,13 @@ export function Map() {
               // the cleaned embedded data URI, then the canvas-rendered text.
               imageSrc={bookBombPng ?? cleanedBookBomb ?? bookBombImageFromText}
               // imageSrc={bookBombsLogo}
+            />
+            <FloatingButton
+              label="Bullets, Buffs, & Beyond"
+              onClick={() => setNavigatedTo("BulletsBuffsBeyond")}
+              delay="21s"
+              backgroundColor="rgba(255, 255, 255, 0.9)"
+              imageSrc={bulletsBuffsBeyondImage}
             />
           </div>
         </div>

--- a/src/tribeBulletsBuffsBeyond.ts
+++ b/src/tribeBulletsBuffsBeyond.ts
@@ -1,0 +1,63 @@
+import { Item, Tribe } from "./types";
+
+interface BulletsBuffsBeyondItem extends Item {
+  priceLabel?: string;
+}
+
+interface BulletsBuffsBeyondTribe extends Omit<Tribe, "items"> {
+  items: BulletsBuffsBeyondItem[];
+}
+
+export const tribeBulletsBuffsBeyond: BulletsBuffsBeyondTribe = {
+  name: "Bullets, Buffs, & Beyond",
+  owner: "Bob",
+  percentAngry: 0,
+  priceVariability: 5,
+  insults: [""],
+  items: [
+    {
+      name: "Killer's Ammo",
+      description: "Can only use one ammo type at a time, doubles damage dice rolled.",
+      price: 500,
+    },
+    {
+      name: "Hunter's Ammo",
+      description: "Can only use one ammo type at a time, triple's range of weapon.",
+      price: 700,
+    },
+    {
+      name: "Protective Father's Ammo",
+      description:
+        "Can only use one ammo type at a time, when you shoot a close friend you heal instead of hurt.",
+      price: 900,
+    },
+    {
+      name: "Mother's Revenge Ammo",
+      description:
+        "Can only use one ammo type at a time, add an additional dice to the weapon for every five HP you are below maximum.",
+      price: 1000,
+    },
+    {
+      name: "Get down Armor Wax",
+      description: "Can only use one wax  at a time, +3 to AC when next to an ally.",
+      price: 1500,
+    },
+    {
+      name: "Harden Stance Sheild Wax",
+      description:
+        "Can only use one wax  at a time, not using any movement speed on your turn will add +15 to AC.",
+      price: 2000,
+    },
+    {
+      name: "Medical Wax",
+      description: "Can only use one wax  at a time, heal 5HP during your turn.",
+      price: 3000,
+    },
+    {
+      name: "Got anything... out back",
+      description: "please message me about what you would like so we can hash out the details",
+      price: 0,
+      priceLabel: "Price may vary",
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- add Bullets, Buffs, & Beyond data set with price-label support for variable-cost items
- create dedicated shop page and styling using the Bullets Buffs and Beyond background
- wire the new shop into the map navigation with a floating button entry

## Testing
- CI=true npm test -- --watch=false


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c8e5a951083298ac8d4ebc1cff234)