### PR TITLE
Add Changing Church and Necromancy Insurance Company shops

### DIFF
--- a/src/ChangingChurch.module.css
+++ b/src/ChangingChurch.module.css
@@ -1,0 +1,124 @@
+.app {
+  text-align: center;
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
+}
+
+.backgroundImage {
+  background: url('./Changing Church.png') no-repeat center center fixed; 
+  display: flex;
+  background-size: cover; 
+  height: Fill;
+  opacity: 0.75;
+  margin: px;
+  z-index: -1; 
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 4rem 2rem 3rem;
+  align-items: center;
+  font-family: 'Times New Roman', serif;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  background: #ffffff;
+  border: 3px solid #2f1f1d;
+  box-shadow: 8px 8px rgba(0, 0, 0, 0.35);
+  border-radius: 20px;
+  padding: 1.5rem 2rem;
+  max-width: 360px;
+  width: 100%;
+}
+
+.logo {
+  width: 140px;
+  height: 140px;
+  object-fit: contain;
+  border: 3px solid #2f1f1d;
+  border-radius: 16px;
+  background: #fff;
+  padding: 0.5rem;
+  box-shadow: 4px 6px rgba(0, 0, 0, 0.2);
+}
+
+.headerText {
+  text-align: center;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.4rem;
+  color: #2f1f1d;
+}
+
+.owner {
+  margin: 0.2rem 0;
+  font-size: 1.1rem;
+  color: #b94c2e;
+}
+
+.hint {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #ff5100;
+}
+
+.grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: 1fr;
+  width: 100%;
+  max-width: 640px;
+}
+
+.card {
+  background: #ffffff;
+  border: 3px solid #2f1f1d;
+  border-radius: 18px;
+  padding: 1.5rem 1.25rem;
+  color: #ffffff;
+  font-family: monospace; 
+  font-size: 24px;
+  font-weight: bolder;
+  width: fit-content;
+  max-width: 600px;
+  text-align: center;
+  margin-left: auto;
+  margin-right: auto;
+  border-radius: 50% 20% / 10% 40%;
+  box-shadow: 5px 5px rgba(0, 0, 0, 0.67);
+  border: 5px solid rgb(0, 0, 0);
+}
+
+.cardTitle {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #3a211f;
+}
+
+.description {
+  margin: 0;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  color: #4b3a35;
+  font-size: 0.95rem;
+  text-align: center;
+}
+
+.price {
+  margin: 0;
+  font-weight: bold;
+  color: #2f1f1d;
+}

--- a/src/ChangingChurch.tsx
+++ b/src/ChangingChurch.tsx
@@ -1,0 +1,62 @@
+import { useMemo } from "react";
+import styles from "./ChangingChurch.module.css";
+import { tribeChangingChurch } from "./tribeChangingChurch";
+import { BackButton } from "./BackButton";
+import { Item } from "./types";
+import changingChurchBackground from "./Changing Church.png";
+
+type DisplayItem = Item & { finalPrice: number };
+
+function calculateAdjustedPrice(item: Item, priceVariability: number): number {
+  const variability =
+    ((Math.random() * priceVariability) / 100) * item.price;
+  const upOrDown = Math.random() < 0.5 ? -1 : 1;
+  const adjusted = item.price + upOrDown * variability;
+
+  return Math.max(0, Math.round(adjusted));
+}
+
+export function ChangingChurch({ onBack }: { onBack?: () => void }) {
+  const displayItems: DisplayItem[] = useMemo(() => {
+    return tribeChangingChurch.items
+      .map((item) => ({
+        ...item,
+        finalPrice: calculateAdjustedPrice(item, tribeChangingChurch.priceVariability),
+      }))
+      .sort((a, b) => a.finalPrice - b.finalPrice);
+  }, []);
+
+  return (
+    <div className={styles.app}>
+      <BackButton onClick={onBack} />
+      <div
+        className={styles.backgroundImage}
+        style={{ backgroundImage: `url(${changingChurchBackground})` }}
+      />
+      <main className={styles.content}>
+        <header className={styles.header}>
+          <div className={styles.headerText}>
+            <h1 className={styles.title}>{tribeChangingChurch.name}</h1>
+            <p className={styles.owner}>Shop Owner: {tribeChangingChurch.owner}</p>
+          </div>
+        </header>
+
+        <section className={styles.grid} aria-label="Available items">
+          {displayItems.map((item) => (
+            <article key={item.name} className={styles.card}>
+              <h2 className={styles.cardTitle}>{item.name}</h2>
+              <p className={styles.description}>{item.description}</p>
+              <p className={styles.price}>
+                {item.finalPrice.toLocaleString()} Gold
+              </p>
+            </article>
+          ))}
+        </section>
+
+        <p className={styles.footerNote}>
+          {tribeChangingChurch.insults[0]}
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -11,6 +11,10 @@ import bookBombPng from "./Book Bomb.png";
 import bulletsBuffsBeyondImage from "./Bullets Buffs and Beyond.webp";
 import applegarthImage from "./Applegarth.webp";
 import archivesGuildImage from "./Archives Guild.png";
+import { ChangingChurch } from "./ChangingChurch";
+import { NecromancyInsuranceCompany } from "./NecromancyInsuranceCompany";
+import changingChurchImage from "./Changing Church.png";
+import necromancyInsuranceImage from "./NecromanyInsuranceCo-ezgif.com-webp-to-png-converter.png";
 import { useEffect, useState } from "react";
 
 // Remove stray whitespace/newlines from data URIs (defensive)
@@ -75,6 +79,10 @@ export function Map() {
       return <ApplegarthGuild onBack={() => setNavigatedTo("")} />;
     case "ArchivesGuild":
       return <ArchivesGuild onBack={() => setNavigatedTo("")} />;
+    case "ChangingChurch":
+      return <ChangingChurch onBack={() => setNavigatedTo("")} />;
+    case "NecromancyInsuranceCompany":
+      return <NecromancyInsuranceCompany onBack={() => setNavigatedTo("")} />;
     default:
       return (
         <div style={styles.wrapper}>
@@ -129,6 +137,20 @@ export function Map() {
               delay="21s"
               backgroundColor="rgba(255, 255, 255, 0.9)"
               imageSrc={bulletsBuffsBeyondImage}
+            />
+            <FloatingButton
+              label="Changing Church"
+              onClick={() => setNavigatedTo("ChangingChurch")}
+              delay="24s"
+              backgroundColor="rgba(255, 255, 255, 0.9)"
+              imageSrc={changingChurchImage}
+            />
+            <FloatingButton
+              label="Necromancy Insurance Company"
+              onClick={() => setNavigatedTo("NecromancyInsuranceCompany")}
+              delay="27s"
+              backgroundColor="rgba(255, 255, 255, 0.9)"
+              imageSrc={necromancyInsuranceImage}
             />
           </div>
         </div>

--- a/src/NecromancyInsuranceCompany.module.css
+++ b/src/NecromancyInsuranceCompany.module.css
@@ -1,0 +1,124 @@
+.app {
+  text-align: center;
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
+}
+
+.backgroundImage {
+  background: url('./NecromanyInsuranceCo-ezgif.com-webp-to-png-converter.png') no-repeat center center fixed; 
+  display: flex;
+  background-size: cover; 
+  height: Fill;
+  opacity: 0.75;
+  margin: px;
+  z-index: -1; 
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 4rem 2rem 3rem;
+  align-items: center;
+  font-family: 'Times New Roman', serif;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  background: #ffffff;
+  border: 3px solid #2f1f1d;
+  box-shadow: 8px 8px rgba(0, 0, 0, 0.35);
+  border-radius: 20px;
+  padding: 1.5rem 2rem;
+  max-width: 360px;
+  width: 100%;
+}
+
+.logo {
+  width: 140px;
+  height: 140px;
+  object-fit: contain;
+  border: 3px solid #2f1f1d;
+  border-radius: 16px;
+  background: #fff;
+  padding: 0.5rem;
+  box-shadow: 4px 6px rgba(0, 0, 0, 0.2);
+}
+
+.headerText {
+  text-align: center;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.4rem;
+  color: #2f1f1d;
+}
+
+.owner {
+  margin: 0.2rem 0;
+  font-size: 1.1rem;
+  color: #b94c2e;
+}
+
+.hint {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #ff5100;
+}
+
+.grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: 1fr;
+  width: 100%;
+  max-width: 640px;
+}
+
+.card {
+  background: #ffffff;
+  border: 3px solid #2f1f1d;
+  border-radius: 18px;
+  padding: 1.5rem 1.25rem;
+  color: #ffffff;
+  font-family: monospace; 
+  font-size: 24px;
+  font-weight: bolder;
+  width: fit-content;
+  max-width: 600px;
+  text-align: center;
+  margin-left: auto;
+  margin-right: auto;
+  border-radius: 50% 20% / 10% 40%;
+  box-shadow: 5px 5px rgba(0, 0, 0, 0.67);
+  border: 5px solid rgb(0, 0, 0);
+}
+
+.cardTitle {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #3a211f;
+}
+
+.description {
+  margin: 0;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  color: #4b3a35;
+  font-size: 0.95rem;
+  text-align: center;
+}
+
+.price {
+  margin: 0;
+  font-weight: bold;
+  color: #2f1f1d;
+}

--- a/src/NecromancyInsuranceCompany.tsx
+++ b/src/NecromancyInsuranceCompany.tsx
@@ -1,0 +1,62 @@
+import { useMemo } from "react";
+import styles from "./NecromancyInsuranceCompany.module.css";
+import { tribeNecromancyInsuranceCompany } from "./tribeNecromancyInsuranceCompany";
+import { BackButton } from "./BackButton";
+import { Item } from "./types";
+import necromancyInsuranceBackground from "./NecromanyInsuranceCo-ezgif.com-webp-to-png-converter.png";
+
+type DisplayItem = Item & { finalPrice: number };
+
+function calculateAdjustedPrice(item: Item, priceVariability: number): number {
+  const variability =
+    ((Math.random() * priceVariability) / 100) * item.price;
+  const upOrDown = Math.random() < 0.5 ? -1 : 1;
+  const adjusted = item.price + upOrDown * variability;
+
+  return Math.max(0, Math.round(adjusted));
+}
+
+export function NecromancyInsuranceCompany({ onBack }: { onBack?: () => void }) {
+  const displayItems: DisplayItem[] = useMemo(() => {
+    return tribeNecromancyInsuranceCompany.items
+      .map((item) => ({
+        ...item,
+        finalPrice: calculateAdjustedPrice(item, tribeNecromancyInsuranceCompany.priceVariability),
+      }))
+      .sort((a, b) => a.finalPrice - b.finalPrice);
+  }, []);
+
+  return (
+    <div className={styles.app}>
+      <BackButton onClick={onBack} />
+      <div
+        className={styles.backgroundImage}
+        style={{ backgroundImage: `url(${necromancyInsuranceBackground})` }}
+      />
+      <main className={styles.content}>
+        <header className={styles.header}>
+          <div className={styles.headerText}>
+            <h1 className={styles.title}>{tribeNecromancyInsuranceCompany.name}</h1>
+            <p className={styles.owner}>Shop Owner: {tribeNecromancyInsuranceCompany.owner}</p>
+          </div>
+        </header>
+
+        <section className={styles.grid} aria-label="Available items">
+          {displayItems.map((item) => (
+            <article key={item.name} className={styles.card}>
+              <h2 className={styles.cardTitle}>{item.name}</h2>
+              <p className={styles.description}>{item.description}</p>
+              <p className={styles.price}>
+                {item.finalPrice.toLocaleString()} Gold
+              </p>
+            </article>
+          ))}
+        </section>
+
+        <p className={styles.footerNote}>
+          {tribeNecromancyInsuranceCompany.insults[0]}
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/src/tribeChangingChurch.ts
+++ b/src/tribeChangingChurch.ts
@@ -1,0 +1,57 @@
+import { Tribe } from "./types";
+
+export const tribeChangingChurch: Tribe = {
+  name: "Changing Church",
+  owner: "All Father",
+  percentAngry: 0,
+  priceVariability: 5,
+  insults: [""],
+  items: [
+    {
+      name: "Minor Blessing",
+      price: 10,
+      description:
+        "Roll a d6 to and gain one of the following effects; if you have another blessing that blessing is removed and replaced with this one. " +
+        "Light's Guidance: For the next hour, you emit a soft glow, shedding bright light in a 10-foot radius and dim light for an additional 10 feet. " +
+        "Blessed Aura: For the next hour, you and allies within 5 feet gain a +1 bonus to AC. " +
+        "Divine Whisper: Gain advantage on your next Wisdom (Perception) check as a deity guides your senses for the next 24 hours. " +
+        "Celestial Light: A soft, radiant light surrounds you for 1 hour, providing bright light in a 10-foot radius. " +
+        "Purifying Presence: For the next hour, food and drink you touch are purified of poison and disease. " +
+        "Guardian's Grace: For the next 24 hours, the first time you drop to 0 hit points, you instead drop to 1 hit point and are teleported to the last place you slept.",
+    },
+    {
+      name: "Healing",
+      price: 10,
+      description: "Go back up to maximum HP.",
+    },
+    {
+      name: "Alright Blessing",
+      price: 50,
+      description:
+        "Roll a d6 to and gain one of the following effects; if you have another blessing that blessing is removed and replaced with this one. " +
+        "1- Holy Vigor: Gain temporary hit points equal to your level + your Charisma modifier for the next 8 hours. " +
+        "2- Divine Speed: Your movement speed is doubled for the next 10 minutes. " +
+        "3- Sacred Shield: For the next hour, gain resistance to necrotic and poison damage. " +
+        "4- Celestial Vision: For the next 8 hours, gain darkvision out to a range of 60 feet, or an additional 60 feet if you already have darkvision. " +
+        "5- Enduring Light: Your ability to see in darkness, both magical and non-magical, permanently increases by 30 feet. " +
+        "6- Sacred Health: Permanently gain +1 bonus to Constitution saving throws.",
+    },
+    {
+      name: "Cruse/Hex Removal",
+      price: 250,
+      description: "Remove a curse or hex.",
+    },
+    {
+      name: "Omega Blessing",
+      price: 500,
+      description:
+        "Roll a d6 to and gain one of the following effects; if you have another blessing that blessing is removed and replaced with this one. " +
+        "1- Eternal Blessing: Choose one skill or tool. You gain permanent proficiency with that skill or tool. If you already have proficiency you gain expertise. " +
+        "2- Hallowed Healer: When you cast a spell that heals hit points, add an additional d8 for each level you currently have. " +
+        "3- Heavenly Aura: You permanently gain the ability to cast Sanctuary on yourself once per long rest without using a spell slot. " +
+        "4- Celestial Resilience: You permanently gain resistance to necrotic and radiant damage. " +
+        "5- Archangel's Wings: You gain the ability to sprout ethereal wings, granting you a flying speed of 60 feet for up to 1 hour, once per long rest. " +
+        "6- Celestial Companion: You gain the spell familiar as a cantrip; the creature type is celestial and takes on traits to represent that.",
+    },
+  ],
+};

--- a/src/tribeNecromancyInsuranceCompany.ts
+++ b/src/tribeNecromancyInsuranceCompany.ts
@@ -1,0 +1,36 @@
+import { Tribe } from "./types";
+
+export const tribeNecromancyInsuranceCompany: Tribe = {
+  name: "Necromancy Insurance Company",
+  owner: "Nex (Neddy) Redrockson",
+  percentAngry: 0,
+  priceVariability: 5,
+  insults: [""],
+  items: [
+    {
+      name: "Corpse Collection, Child",
+      price: 10,
+      description: "",
+    },
+    {
+      name: "Corpse Collection, Teen",
+      price: 20,
+      description: "",
+    },
+    {
+      name: "Corpse Collection, Adult",
+      price: 40,
+      description: "",
+    },
+    {
+      name: "Corpse Collection, Boss",
+      price: 100,
+      description: "",
+    },
+    {
+      name: "Second Chance Plan",
+      price: 200,
+      description: "",
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- add a Changing Church shop variant mirroring the Book Bombs layout with the provided blessing and healing offerings
- add a Necromancy Insurance Company shop variant with the requested corpse collection and insurance plans
- expose both new shops in the map navigation with their respective background art

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c90b2f9308329a3f2489d7c0efb8c)