### PR TITLE
Add new shop templates for oracle readings, ropes, relay, and oath

### DIFF
--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -15,6 +15,14 @@ import { ChangingChurch } from "./ChangingChurch";
 import { NecromancyInsuranceCompany } from "./NecromancyInsuranceCompany";
 import changingChurchImage from "./Changing Church.png";
 import necromancyInsuranceImage from "./NecromanyInsuranceCo-ezgif.com-webp-to-png-converter.png";
+import { OPapiesOracleReadings } from "./OPapiesOracleReadings";
+import { RobinsRopes } from "./RobinsRopes";
+import { RunestoneRelay } from "./RunestoneRelay";
+import { SilentOath } from "./SilentOath";
+import oPapiesOracleReadingsImage from "./O Papies Oracle Readings.png";
+import robinsRopesImage from "./Robins Ropes.png";
+import runestoneRelayImage from "./Runestone Relay.png";
+import silentOathImage from "./Silent Oath.png";
 import { useEffect, useState } from "react";
 
 // Remove stray whitespace/newlines from data URIs (defensive)
@@ -83,6 +91,14 @@ export function Map() {
       return <ChangingChurch onBack={() => setNavigatedTo("")} />;
     case "NecromancyInsuranceCompany":
       return <NecromancyInsuranceCompany onBack={() => setNavigatedTo("")} />;
+    case "OPapiesOracleReadings":
+      return <OPapiesOracleReadings onBack={() => setNavigatedTo("")} />;
+    case "RobinsRopes":
+      return <RobinsRopes onBack={() => setNavigatedTo("")} />;
+    case "RunestoneRelay":
+      return <RunestoneRelay onBack={() => setNavigatedTo("")} />;
+    case "SilentOath":
+      return <SilentOath onBack={() => setNavigatedTo("")} />;
     default:
       return (
         <div style={styles.wrapper}>
@@ -151,6 +167,34 @@ export function Map() {
               delay="27s"
               backgroundColor="rgba(255, 255, 255, 0.9)"
               imageSrc={necromancyInsuranceImage}
+            />
+            <FloatingButton
+              label="O-Papies Oracle Readings"
+              onClick={() => setNavigatedTo("OPapiesOracleReadings")}
+              delay="30s"
+              backgroundColor="rgba(255, 255, 255, 0.9)"
+              imageSrc={oPapiesOracleReadingsImage}
+            />
+            <FloatingButton
+              label="Robin's Ropes"
+              onClick={() => setNavigatedTo("RobinsRopes")}
+              delay="33s"
+              backgroundColor="rgba(255, 255, 255, 0.9)"
+              imageSrc={robinsRopesImage}
+            />
+            <FloatingButton
+              label="Runestone Relay"
+              onClick={() => setNavigatedTo("RunestoneRelay")}
+              delay="36s"
+              backgroundColor="rgba(255, 255, 255, 0.9)"
+              imageSrc={runestoneRelayImage}
+            />
+            <FloatingButton
+              label="Silent Oath"
+              onClick={() => setNavigatedTo("SilentOath")}
+              delay="39s"
+              backgroundColor="rgba(255, 255, 255, 0.9)"
+              imageSrc={silentOathImage}
             />
           </div>
         </div>

--- a/src/OPapiesOracleReadings.tsx
+++ b/src/OPapiesOracleReadings.tsx
@@ -1,0 +1,13 @@
+import { ShopTemplate } from "./ShopTemplate";
+import { tribeOPapiesOracleReadings } from "./tribeOPapiesOracleReadings";
+import oPapiesBackground from "./O Papies Oracle Readings.png";
+
+export function OPapiesOracleReadings({ onBack }: { onBack?: () => void }) {
+  return (
+    <ShopTemplate
+      tribe={tribeOPapiesOracleReadings}
+      backgroundImage={oPapiesBackground}
+      onBack={onBack}
+    />
+  );
+}

--- a/src/RobinsRopes.tsx
+++ b/src/RobinsRopes.tsx
@@ -1,0 +1,13 @@
+import { ShopTemplate } from "./ShopTemplate";
+import { tribeRobinsRopes } from "./tribeRobinsRopes";
+import robinsRopesBackground from "./Robins Ropes.png";
+
+export function RobinsRopes({ onBack }: { onBack?: () => void }) {
+  return (
+    <ShopTemplate
+      tribe={tribeRobinsRopes}
+      backgroundImage={robinsRopesBackground}
+      onBack={onBack}
+    />
+  );
+}

--- a/src/RunestoneRelay.tsx
+++ b/src/RunestoneRelay.tsx
@@ -1,0 +1,13 @@
+import { ShopTemplate } from "./ShopTemplate";
+import { tribeRunestoneRelay } from "./tribeRunestoneRelay";
+import runestoneRelayBackground from "./Runestone Relay.png";
+
+export function RunestoneRelay({ onBack }: { onBack?: () => void }) {
+  return (
+    <ShopTemplate
+      tribe={tribeRunestoneRelay}
+      backgroundImage={runestoneRelayBackground}
+      onBack={onBack}
+    />
+  );
+}

--- a/src/ShopTemplate.tsx
+++ b/src/ShopTemplate.tsx
@@ -1,0 +1,73 @@
+import { useMemo } from "react";
+import styles from "./BookBombs.module.css";
+import { BackButton } from "./BackButton";
+import { Item, Tribe } from "./types";
+
+type DisplayItem = Item & { finalPrice: number };
+
+function calculateAdjustedPrice(item: Item, priceVariability: number): number {
+  const variability = ((Math.random() * priceVariability) / 100) * item.price;
+  const upOrDown = Math.random() < 0.5 ? -1 : 1;
+  const adjusted = item.price + upOrDown * variability;
+
+  return Math.max(0, Math.round(adjusted));
+}
+
+export function ShopTemplate({
+  tribe,
+  backgroundImage,
+  onBack,
+}: {
+  tribe: Tribe;
+  backgroundImage: string;
+  onBack?: () => void;
+}) {
+  const displayItems: DisplayItem[] = useMemo(() => {
+    return tribe.items
+      .map((item) => ({
+        ...item,
+        finalPrice: calculateAdjustedPrice(item, tribe.priceVariability),
+      }))
+      .sort((a, b) => a.finalPrice - b.finalPrice);
+  }, [tribe]);
+
+  return (
+    <div className={styles.app}>
+      <BackButton onClick={onBack} />
+      <div
+        className={styles.backgroundImage}
+        style={{ backgroundImage: `url(${backgroundImage})` }}
+      />
+      <main className={styles.content}>
+        <header className={styles.header}>
+          <div className={styles.headerText}>
+            <h1 className={styles.title}>{tribe.name}</h1>
+            {tribe.owner && (
+              <p className={styles.owner}>Shop Owner: {tribe.owner}</p>
+            )}
+          </div>
+        </header>
+
+        <section className={styles.grid} aria-label="Available items">
+          {displayItems.map((item) => (
+            <article key={item.name} className={styles.card}>
+              <h2 className={styles.cardTitle}>{item.name}</h2>
+              {item.description && (
+                <p className={styles.description}>{item.description}</p>
+              )}
+              <p className={styles.price}>
+                {item.finalPrice.toLocaleString()} Gold
+              </p>
+            </article>
+          ))}
+        </section>
+
+        {tribe.insults[0] && (
+          <p className={styles.footerNote}>
+            {tribe.insults[0]}
+          </p>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/SilentOath.tsx
+++ b/src/SilentOath.tsx
@@ -1,0 +1,13 @@
+import { ShopTemplate } from "./ShopTemplate";
+import { tribeSilentOath } from "./tribeSilentOath";
+import silentOathBackground from "./Silent Oath.png";
+
+export function SilentOath({ onBack }: { onBack?: () => void }) {
+  return (
+    <ShopTemplate
+      tribe={tribeSilentOath}
+      backgroundImage={silentOathBackground}
+      onBack={onBack}
+    />
+  );
+}

--- a/src/tribeOPapiesOracleReadings.ts
+++ b/src/tribeOPapiesOracleReadings.ts
@@ -1,0 +1,37 @@
+import { Tribe } from "./types";
+
+export const tribeOPapiesOracleReadings: Tribe = {
+  name: "O-Papies Oracle Readings",
+  owner: "Papy",
+  percentAngry: 0,
+  priceVariability: 0,
+  insults: [""],
+  items: [
+    {
+      name: "Near Future Reading",
+      price: 100,
+      description: "Get a vague hint as to what is going to happend this session",
+    },
+    {
+      name: "Compatible Reading",
+      price: 150,
+      description: "",
+    },
+    {
+      name: "Far Future Reading",
+      price: 200,
+      description: "Get a vague hint as to what is going to happen in the next could of sessions",
+    },
+    {
+      name: "Near Future Blessing",
+      price: 300,
+      description: "",
+    },
+    {
+      name: "Far Future Blessing",
+      price: 400,
+      description:
+        "Get a vague hint as three of the possible endings to the current campaign the worst, the best and the current",
+    },
+  ],
+};

--- a/src/tribeRobinsRopes.ts
+++ b/src/tribeRobinsRopes.ts
@@ -1,0 +1,36 @@
+import { Tribe } from "./types";
+
+export const tribeRobinsRopes: Tribe = {
+  name: "Robin's Ropes",
+  owner: "Robin",
+  percentAngry: 0,
+  priceVariability: 0,
+  insults: [""],
+  items: [
+    {
+      name: "Normal Rope (50 feet)",
+      price: 1,
+      description: "",
+    },
+    {
+      name: "Silk Rope (25 feet per)",
+      price: 5,
+      description: "",
+    },
+    {
+      name: "Enchanted Climbing Rope (50 feet with hook)",
+      price: 20,
+      description: "",
+    },
+    {
+      name: "Enchanted Entanglement Rope (25 feet)",
+      price: 45,
+      description: "",
+    },
+    {
+      name: "Net (100 feet)",
+      price: 15,
+      description: "",
+    },
+  ],
+};

--- a/src/tribeRunestoneRelay.ts
+++ b/src/tribeRunestoneRelay.ts
@@ -1,0 +1,36 @@
+import { Tribe } from "./types";
+
+export const tribeRunestoneRelay: Tribe = {
+  name: "Runestone Relay",
+  owner: "Pat Redrockson",
+  percentAngry: 0,
+  priceVariability: 0,
+  insults: [""],
+  items: [
+    {
+      name: "Message Delivery",
+      price: 5,
+      description: "Sending simple messages on runestones to local destinations",
+    },
+    {
+      name: "Package Delivery",
+      price: 5,
+      description: "Hold onto an item to be delivered at certain time & place",
+    },
+    {
+      name: "A year-long subscription to the Daily Newspaper",
+      price: 5,
+      description: "",
+    },
+    {
+      name: "Urgent Message",
+      price: 5,
+      description: "Will literally hunt the target down to hand deliver them a message",
+    },
+    {
+      name: "Singing Telegram",
+      price: 100,
+      description: "",
+    },
+  ],
+};

--- a/src/tribeSilentOath.ts
+++ b/src/tribeSilentOath.ts
@@ -1,0 +1,36 @@
+import { Tribe } from "./types";
+
+export const tribeSilentOath: Tribe = {
+  name: "Silent Oath",
+  owner: "Nacho",
+  percentAngry: 0,
+  priceVariability: 0,
+  insults: [""],
+  items: [
+    {
+      name: "Intel Gathering Contract",
+      price: 100,
+      description: "",
+    },
+    {
+      name: "Safe Passage Contract",
+      price: 200,
+      description: "",
+    },
+    {
+      name: "Curse & Hex Contract",
+      price: 30,
+      description: "",
+    },
+    {
+      name: "Disposal Contract",
+      price: 400,
+      description: "",
+    },
+    {
+      name: "Assassination Contract",
+      price: 1500,
+      description: "",
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- add reusable shop template to render name, owner, item list, and prices
- create new shops for O-Papies Oracle Readings, Robin's Ropes, Runestone Relay, and Silent Oath with their inventories
- wire new shops into the map with corresponding button entries and images

## Testing
- npm test -- --watch=false

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cb13d32288329a229254e1ea18c9c)