### PR TITLE
Add Robin's Ropes specific styling

### DIFF
--- a/src/RobinsRopes.module.css
+++ b/src/RobinsRopes.module.css
@@ -1,0 +1,128 @@
+.app {
+  text-align: center;
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
+}
+
+.backgroundImage {
+  background: url('./Robins Ropes.png') no-repeat center center fixed; 
+  /* background-size: cover;  
+  opacity: 0.75;
+  margin: 25px;
+  z-index: -1;  */
+  display: flex;
+  background-size: cover; 
+  height: Fill;
+  opacity: 0.75;
+  margin: px;
+  z-index: -1; 
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 4rem 2rem 3rem;
+  align-items: center;
+  font-family: 'Times New Roman', serif;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  background: #ffffff;
+  border: 3px solid #2f1f1d;
+  box-shadow: 8px 8px rgba(0, 0, 0, 0.35);
+  border-radius: 20px;
+  padding: 1.5rem 2rem;
+  max-width: 360px;
+  width: 100%;
+}
+
+.logo {
+  width: 140px;
+  height: 140px;
+  object-fit: contain;
+  border: 3px solid #2f1f1d;
+  border-radius: 16px;
+  background: #fff;
+  padding: 0.5rem;
+  box-shadow: 4px 6px rgba(0, 0, 0, 0.2);
+}
+
+.headerText {
+  text-align: center;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.4rem;
+  color: #2f1f1d;
+}
+
+.owner {
+  margin: 0.2rem 0;
+  font-size: 1.1rem;
+  color: #b94c2e;
+}
+
+.hint {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #ff5100;
+}
+
+.grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: 1fr;
+  width: 100%;
+  max-width: 640px;
+}
+
+.card {
+  background: #ffffff;
+  border: 3px solid #2f1f1d;
+  border-radius: 18px;
+  padding: 1.5rem 1.25rem;
+  color: #ffffff;
+  font-family: monospace; 
+  font-size: 24px;
+  font-weight: bolder;
+  width: fit-content;
+  max-width: 600px;
+  text-align: center;
+  margin-left: auto;
+  margin-right: auto;
+  border-radius: 50% 20% / 10% 40%;
+  box-shadow: 5px 5px rgba(0, 0, 0, 0.67);
+  border: 5px solid rgb(0, 0, 0);
+}
+
+.cardTitle {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #3a211f;
+}
+
+.description {
+  margin: 0;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  color: #4b3a35;
+  font-size: 0.95rem;
+  text-align: center;
+}
+
+.price {
+  margin: 0;
+  font-weight: bold;
+  color: #2f1f1d;
+}

--- a/src/RobinsRopes.tsx
+++ b/src/RobinsRopes.tsx
@@ -1,12 +1,14 @@
 import { ShopTemplate } from "./ShopTemplate";
 import { tribeRobinsRopes } from "./tribeRobinsRopes";
 import robinsRopesBackground from "./Robins Ropes.png";
+import robinsRopesStyles from "./RobinsRopes.module.css";
 
 export function RobinsRopes({ onBack }: { onBack?: () => void }) {
   return (
     <ShopTemplate
       tribe={tribeRobinsRopes}
       backgroundImage={robinsRopesBackground}
+      styles={robinsRopesStyles}
       onBack={onBack}
     />
   );

--- a/src/ShopTemplate.tsx
+++ b/src/ShopTemplate.tsx
@@ -1,9 +1,10 @@
 import { useMemo } from "react";
-import styles from "./BookBombs.module.css";
+import defaultStyles from "./BookBombs.module.css";
 import { BackButton } from "./BackButton";
 import { Item, Tribe } from "./types";
 
 type DisplayItem = Item & { finalPrice: number };
+type ShopTemplateStyles = typeof defaultStyles;
 
 function calculateAdjustedPrice(item: Item, priceVariability: number): number {
   const variability = ((Math.random() * priceVariability) / 100) * item.price;
@@ -17,10 +18,12 @@ export function ShopTemplate({
   tribe,
   backgroundImage,
   onBack,
+  styles = defaultStyles,
 }: {
   tribe: Tribe;
   backgroundImage: string;
   onBack?: () => void;
+  styles?: ShopTemplateStyles;
 }) {
   const displayItems: DisplayItem[] = useMemo(() => {
     return tribe.items


### PR DESCRIPTION
## Summary
- add a Robin's Ropes-specific stylesheet referencing the rope shop artwork
- allow the shared ShopTemplate to receive shop-specific styles
- update Robin's Ropes to render with its dedicated styling

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e0b688e8483298a9a0407073ddeba)