### PR TITLE
Add Runestone Relay custom styling

### DIFF
--- a/src/RunestoneRelay.module.css
+++ b/src/RunestoneRelay.module.css
@@ -1,0 +1,128 @@
+.app {
+  text-align: center;
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
+}
+
+.backgroundImage {
+  background: url('./Runestone Relay.png') no-repeat center center fixed; 
+  /* background-size: cover;  
+  opacity: 0.75;
+  margin: 25px;
+  z-index: -1;  */
+  display: flex;
+  background-size: cover; 
+  height: Fill;
+  opacity: 0.75;
+  margin: px;
+  z-index: -1; 
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 4rem 2rem 3rem;
+  align-items: center;
+  font-family: 'Times New Roman', serif;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  background: #ffffff;
+  border: 3px solid #2f1f1d;
+  box-shadow: 8px 8px rgba(0, 0, 0, 0.35);
+  border-radius: 20px;
+  padding: 1.5rem 2rem;
+  max-width: 360px;
+  width: 100%;
+}
+
+.logo {
+  width: 140px;
+  height: 140px;
+  object-fit: contain;
+  border: 3px solid #2f1f1d;
+  border-radius: 16px;
+  background: #fff;
+  padding: 0.5rem;
+  box-shadow: 4px 6px rgba(0, 0, 0, 0.2);
+}
+
+.headerText {
+  text-align: center;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.4rem;
+  color: #2f1f1d;
+}
+
+.owner {
+  margin: 0.2rem 0;
+  font-size: 1.1rem;
+  color: #b94c2e;
+}
+
+.hint {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #ff5100;
+}
+
+.grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: 1fr;
+  width: 100%;
+  max-width: 640px;
+}
+
+.card {
+  background: #ffffff;
+  border: 3px solid #2f1f1d;
+  border-radius: 18px;
+  padding: 1.5rem 1.25rem;
+  color: #ffffff;
+  font-family: monospace; 
+  font-size: 24px;
+  font-weight: bolder;
+  width: fit-content;
+  max-width: 600px;
+  text-align: center;
+  margin-left: auto;
+  margin-right: auto;
+  border-radius: 50% 20% / 10% 40%;
+  box-shadow: 5px 5px rgba(0, 0, 0, 0.67);
+  border: 5px solid rgb(0, 0, 0);
+}
+
+.cardTitle {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #3a211f;
+}
+
+.description {
+  margin: 0;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  color: #4b3a35;
+  font-size: 0.95rem;
+  text-align: center;
+}
+
+.price {
+  margin: 0;
+  font-weight: bold;
+  color: #2f1f1d;
+}

--- a/src/RunestoneRelay.tsx
+++ b/src/RunestoneRelay.tsx
@@ -1,13 +1,65 @@
-import { ShopTemplate } from "./ShopTemplate";
+import { useMemo } from "react";
+import styles from "./RunestoneRelay.module.css";
 import { tribeRunestoneRelay } from "./tribeRunestoneRelay";
+import { BackButton } from "./BackButton";
+import { Item } from "./types";
 import runestoneRelayBackground from "./Runestone Relay.png";
 
+type DisplayItem = Item & { finalPrice: number };
+
+function calculateAdjustedPrice(item: Item, priceVariability: number): number {
+  const variability = ((Math.random() * priceVariability) / 100) * item.price;
+  const upOrDown = Math.random() < 0.5 ? -1 : 1;
+  const adjusted = item.price + upOrDown * variability;
+
+  return Math.max(0, Math.round(adjusted));
+}
+
 export function RunestoneRelay({ onBack }: { onBack?: () => void }) {
+  const displayItems: DisplayItem[] = useMemo(() => {
+    return tribeRunestoneRelay.items
+      .map((item) => ({
+        ...item,
+        finalPrice: calculateAdjustedPrice(
+          item,
+          tribeRunestoneRelay.priceVariability,
+        ),
+      }))
+      .sort((a, b) => a.finalPrice - b.finalPrice);
+  }, []);
+
   return (
-    <ShopTemplate
-      tribe={tribeRunestoneRelay}
-      backgroundImage={runestoneRelayBackground}
-      onBack={onBack}
-    />
+    <div className={styles.app}>
+      <BackButton onClick={onBack} />
+      <div
+        className={styles.backgroundImage}
+        style={{ backgroundImage: `url(${runestoneRelayBackground})` }}
+        aria-
+      />
+      <main className={styles.content}>
+        <header className={styles.header}>
+          <div className={styles.headerText}>
+            <h1 className={styles.title}>{tribeRunestoneRelay.name}</h1>
+            <p className={styles.owner}>
+              Shop Owner: {tribeRunestoneRelay.owner}
+            </p>
+          </div>
+        </header>
+
+        <section className={styles.grid} aria-label="Available items">
+          {displayItems.map((item) => (
+            <article key={item.name} className={styles.card}>
+              <h2 className={styles.cardTitle}>{item.name}</h2>
+              <p className={styles.description}>{item.description}</p>
+              <p className={styles.price}>
+                {item.finalPrice.toLocaleString()} Gold
+              </p>
+            </article>
+          ))}
+        </section>
+
+        <p className={styles.footerNote}>{tribeRunestoneRelay.insults[0]}</p>
+      </main>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a Runestone Relay-specific module stylesheet based on the Book Bombs layout and imagery
- update the Runestone Relay component to render with its dedicated styles and background

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e0d41b650832992103bdf7f09d893)