### PR TITLE
Add themed styling for O-Papies Oracle Readings

### DIFF
--- a/src/OPapiesOracleReadings.module.css
+++ b/src/OPapiesOracleReadings.module.css
@@ -1,0 +1,133 @@
+.app {
+  text-align: center;
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
+}
+
+.backgroundImage {
+  background: url('./O Papies Oracle Readings.png') no-repeat center center fixed;
+  display: flex;
+  background-size: cover;
+  opacity: 0.7;
+  margin: 0;
+  z-index: -1;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 4rem 2.5rem 3rem;
+  align-items: center;
+  font-family: 'Georgia', 'Times New Roman', serif;
+  color: #210c2e;
+  text-shadow: 0 1px 2px rgba(255, 255, 255, 0.6);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  background: rgba(255, 255, 255, 0.92);
+  border: 2px solid #6f3d8f;
+  box-shadow: 0 12px 35px rgba(45, 17, 53, 0.25);
+  border-radius: 24px;
+  padding: 1.75rem 2.5rem;
+  max-width: 460px;
+  width: 100%;
+}
+
+.logo {
+  width: 140px;
+  height: 140px;
+  object-fit: contain;
+  border: 3px solid #2f1f1d;
+  border-radius: 16px;
+  background: #fff;
+  padding: 0.5rem;
+  box-shadow: 4px 6px rgba(0, 0, 0, 0.2);
+}
+
+.headerText {
+  text-align: center;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.6rem;
+  color: #2d1135;
+  letter-spacing: 1px;
+}
+
+.owner {
+  margin: 0.2rem 0;
+  font-size: 1.15rem;
+  color: #e1b44b;
+  font-weight: bold;
+  letter-spacing: 0.5px;
+}
+
+.hint {
+  margin: 0;
+  font-size: 1rem;
+  color: #7ac1ff;
+}
+
+.grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: 1fr;
+  width: 100%;
+  max-width: 640px;
+}
+
+.card {
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.96), rgba(240, 228, 255, 0.94));
+  border: 2px solid #6f3d8f;
+  border-radius: 24px;
+  padding: 1.75rem 1.5rem;
+  color: #210c2e;
+  font-family: 'Georgia', 'Times New Roman', serif;
+  font-size: 1.05rem;
+  font-weight: 600;
+  width: 100%;
+  max-width: 620px;
+  text-align: center;
+  margin-left: auto;
+  margin-right: auto;
+  box-shadow: 0 12px 28px rgba(33, 12, 46, 0.25);
+}
+
+.cardTitle {
+  margin: 0;
+  font-size: 1.4rem;
+  color: #2d1135;
+}
+
+.description {
+  margin: 0;
+  font-family: 'Georgia', 'Times New Roman', serif;
+  color: #3a264d;
+  font-size: 1rem;
+  text-align: center;
+}
+
+.price {
+  margin: 0;
+  font-weight: bold;
+  color: #e1b44b;
+  font-size: 1.1rem;
+}
+
+.footerNote {
+  margin: 0;
+  font-weight: bold;
+  color: #2d1135;
+}

--- a/src/OPapiesOracleReadings.tsx
+++ b/src/OPapiesOracleReadings.tsx
@@ -1,12 +1,14 @@
 import { ShopTemplate } from "./ShopTemplate";
 import { tribeOPapiesOracleReadings } from "./tribeOPapiesOracleReadings";
 import oPapiesBackground from "./O Papies Oracle Readings.png";
+import styles from "./OPapiesOracleReadings.module.css";
 
 export function OPapiesOracleReadings({ onBack }: { onBack?: () => void }) {
   return (
     <ShopTemplate
       tribe={tribeOPapiesOracleReadings}
       backgroundImage={oPapiesBackground}
+      styles={styles}
       onBack={onBack}
     />
   );


### PR DESCRIPTION
## Summary
- add a dedicated CSS module themed for the O-Papies Oracle Readings shop with its own background
- switch the O-Papies Oracle Readings component to use the new styles with the existing shop template

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e0dbde8888329bca31b5665da7ffc)