### PR TITLE
Add Auntie Patty's Pies shop

### DIFF
--- a/src/AuntiePattysPies.module.css
+++ b/src/AuntiePattysPies.module.css
@@ -1,0 +1,111 @@
+.app {
+  text-align: center;
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
+}
+
+.backgroundImage {
+  background: url('./Aunt Pattie Pie.png') no-repeat center center fixed;
+  display: flex;
+  background-size: cover;
+  opacity: 0.75;
+  margin: 0;
+  z-index: -1;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 4rem 2rem 3rem;
+  align-items: center;
+  font-family: 'Times New Roman', serif;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  background: #ffffff;
+  border: 3px solid #5c1a1a;
+  box-shadow: 8px 8px rgba(0, 0, 0, 0.35);
+  border-radius: 20px;
+  padding: 1.5rem 2rem;
+  max-width: 360px;
+  width: 100%;
+}
+
+.headerText {
+  text-align: center;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.4rem;
+  color: #5c1a1a;
+}
+
+.owner {
+  margin: 0.2rem 0;
+  font-size: 1.1rem;
+  color: #b94c2e;
+}
+
+.grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: 1fr;
+  width: 100%;
+  max-width: 640px;
+}
+
+.card {
+  background: linear-gradient(135deg, #fff5f5, #ffe7e7);
+  border: 4px solid #a01818;
+  padding: 2rem 1.5rem;
+  color: #2f1f1d;
+  font-family: monospace;
+  font-size: 24px;
+  font-weight: bolder;
+  width: fit-content;
+  max-width: 600px;
+  text-align: center;
+  margin-left: auto;
+  margin-right: auto;
+  position: relative;
+  clip-path: polygon(25% 6%, 75% 6%, 94% 50%, 75% 94%, 25% 94%, 6% 50%);
+  box-shadow: 6px 6px rgba(0, 0, 0, 0.55);
+}
+
+.cardTitle {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #5c1a1a;
+}
+
+.description {
+  margin: 0.35rem 0 0.5rem;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  color: #4b3a35;
+  font-size: 1rem;
+  text-align: center;
+}
+
+.price {
+  margin: 0;
+  font-weight: bold;
+  color: #a01818;
+}
+
+.footerNote {
+  margin: 0.5rem 0 0;
+  color: #5c1a1a;
+  font-weight: bold;
+}

--- a/src/AuntiePattysPies.tsx
+++ b/src/AuntiePattysPies.tsx
@@ -1,0 +1,62 @@
+import { useMemo } from "react";
+import styles from "./AuntiePattysPies.module.css";
+import { tribeAuntiePattysPies } from "./tribeAuntiePattysPies";
+import { BackButton } from "./BackButton";
+import { Item } from "./types";
+import auntPattiePieBackground from "./Aunt Pattie Pie.png";
+
+type DisplayItem = Item & { finalPrice: number };
+
+function calculateAdjustedPrice(item: Item, priceVariability: number): number {
+  const variability =
+    ((Math.random() * priceVariability) / 100) * item.price;
+  const upOrDown = Math.random() < 0.5 ? -1 : 1;
+  const adjusted = item.price + upOrDown * variability;
+
+  return Math.max(0, Math.round(adjusted));
+}
+
+export function AuntiePattysPies({ onBack }: { onBack?: () => void }) {
+  const displayItems: DisplayItem[] = useMemo(() => {
+    return tribeAuntiePattysPies.items
+      .map((item) => ({
+        ...item,
+        finalPrice: calculateAdjustedPrice(item, tribeAuntiePattysPies.priceVariability),
+      }))
+      .sort((a, b) => a.finalPrice - b.finalPrice);
+  }, []);
+
+  return (
+    <div className={styles.app}>
+      <BackButton onClick={onBack} />
+      <div
+        className={styles.backgroundImage}
+        style={{ backgroundImage: `url(${auntPattiePieBackground})` }}
+      />
+      <main className={styles.content}>
+        <header className={styles.header}>
+          <div className={styles.headerText}>
+            <h1 className={styles.title}>{tribeAuntiePattysPies.name}</h1>
+            <p className={styles.owner}>Shop Owner: {tribeAuntiePattysPies.owner}</p>
+          </div>
+        </header>
+
+        <section className={styles.grid} aria-label="Available items">
+          {displayItems.map((item) => (
+            <article key={item.name} className={styles.card}>
+              <h2 className={styles.cardTitle}>{item.name}</h2>
+              <p className={styles.description}>{item.description}</p>
+              <p className={styles.price}>
+                {item.finalPrice.toLocaleString()} Gold
+              </p>
+            </article>
+          ))}
+        </section>
+
+        <p className={styles.footerNote}>
+          {tribeAuntiePattysPies.insults[0]}
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -6,11 +6,13 @@ import { BulletsBuffsBeyond } from "./BulletsBuffsBeyond";
 import { ApplegarthGuild } from "./ApplegarthGuild";
 import { ArchivesGuild } from "./ArchivesGuild";
 import { bookBombDataUrl } from "./bookBombImage";
+import { AuntiePattysPies } from "./AuntiePattysPies";
 // Use the uploaded PNG asset (filename contains a space)
 import bookBombPng from "./Book Bomb.png";
 import bulletsBuffsBeyondImage from "./Bullets Buffs and Beyond.webp";
 import applegarthImage from "./Applegarth.webp";
 import archivesGuildImage from "./Archives Guild.png";
+import auntPattiePieImage from "./Aunt Pattie Pie.png";
 import { ChangingChurch } from "./ChangingChurch";
 import { NecromancyInsuranceCompany } from "./NecromancyInsuranceCompany";
 import changingChurchImage from "./Changing Church.png";
@@ -85,6 +87,8 @@ export function Map() {
       return <Blacks onBack={() => setNavigatedTo("")} />;
     case "BookBombs":
       return <BookBombs onBack={() => setNavigatedTo("")} />;
+    case "AuntiePattysPies":
+      return <AuntiePattysPies onBack={() => setNavigatedTo("")} />;
     case "BulletsBuffsBeyond":
       return <BulletsBuffsBeyond onBack={() => setNavigatedTo("")} />;
     case "ApplegarthGuild":
@@ -154,6 +158,13 @@ export function Map() {
               // the cleaned embedded data URI, then the canvas-rendered text.
               imageSrc={bookBombPng ?? cleanedBookBomb ?? bookBombImageFromText}
               // imageSrc={bookBombsLogo}
+            />
+            <FloatingButton
+              label="Auntie Patty's Pies"
+              onClick={() => setNavigatedTo("AuntiePattysPies")}
+              delay="13s"
+              backgroundColor="rgba(220, 38, 38, 0.9)"
+              imageSrc={auntPattiePieImage}
             />
             <FloatingButton
               label="Bullets, Buffs, & Beyond"

--- a/src/tribeAuntiePattysPies.ts
+++ b/src/tribeAuntiePattysPies.ts
@@ -1,0 +1,38 @@
+import { Tribe } from "./types";
+
+export const tribeAuntiePattysPies: Tribe = {
+  name: "Auntie Patty's Pies",
+  owner: "Patty",
+  percentAngry: 0,
+  priceVariability: 5,
+  insults: [""],
+  items: [
+    {
+      name: "Goblin Berry Tart",
+      price: 5,
+      description: "Advantage on next stealth check",
+    },
+    {
+      name: "Blueberry Pie of Night Vision",
+      price: 10,
+      description: "Gives darkvision for 2 hours",
+    },
+    {
+      name: "Pumpkin Pie of Warmth",
+      price: 15,
+      description:
+        "Keeps the eater comfortably warm, warding off natural cold for 2 hours",
+    },
+    {
+      name: "Strawberry Pie of Friendship",
+      price: 20,
+      description:
+        "Eating a slice gives a +1 bonus to Animal Handling checks for 1 hour",
+    },
+    {
+      name: "Pear Pie",
+      price: 25,
+      description: "Increase walking speed by 5ft until next rest, non stackable",
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- add the Auntie Patty's Pies shop patterned after Book Bombs with themed pricing and owner details
- style the new shop with the Aunt Pattie Pie artwork and hexagonal cards plus a red navigation button
- link the new shop into the map navigation flow

## Testing
- npm test -- --watch=false


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e14a7280883299fa87af4cdccd863)