### PR TITLE
Add Dungeon Crawler Guild storefront experience

### DIFF
--- a/src/DungeonCrawlerGuild.module.css
+++ b/src/DungeonCrawlerGuild.module.css
@@ -1,0 +1,131 @@
+.app {
+  text-align: center;
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
+}
+
+.backgroundImage {
+  background: url("./Dungeon Crawler's Guild.png") no-repeat center center fixed;
+  display: flex;
+  background-size: cover;
+  opacity: 0.75;
+  margin: 0;
+  z-index: -1;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 4rem 2rem 3rem;
+  align-items: center;
+  font-family: 'Times New Roman', serif;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  background: #ffffff;
+  border: 3px solid #113b6f;
+  box-shadow: 8px 8px rgba(0, 0, 0, 0.35);
+  border-radius: 20px;
+  padding: 1.5rem 2rem;
+  max-width: 360px;
+  width: 100%;
+}
+
+.headerText {
+  text-align: center;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.4rem;
+  color: #0d2a4a;
+}
+
+.owner {
+  margin: 0.2rem 0;
+  font-size: 1.1rem;
+  color: #1f5b99;
+}
+
+.grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: 1fr;
+  width: 100%;
+  max-width: 640px;
+}
+
+.card {
+  position: relative;
+  display: inline-block;
+  max-width: 600px;
+  padding: 2.25rem 2.75rem;
+  margin-left: auto;
+  margin-right: auto;
+
+  background: transparent;
+  border: 0;
+  color: #0b1c33;
+  font-family: monospace;
+  font-size: 24px;
+  font-weight: bolder;
+  text-align: center;
+
+  filter: drop-shadow(6px 6px rgba(0, 0, 0, 0.55));
+}
+
+.card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, #f0f6ff, #dbe9ff);
+  border: 4px solid #1f5b99;
+
+  clip-path: polygon(
+    18% 4%,  82% 4%,
+    96% 50%,
+    82% 96%, 18% 96%,
+    4% 50%
+  );
+
+  z-index: -1;
+  pointer-events: none;
+}
+
+
+.cardTitle {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #0d2a4a;
+}
+
+.description {
+  margin: 0.35rem 0 0.5rem;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  color: #143c66;
+  font-size: 1rem;
+  text-align: center;
+}
+
+.price {
+  margin: 0;
+  font-weight: bold;
+  color: #1f5b99;
+}
+
+.footerNote {
+  margin: 0.5rem 0 0;
+  color: #0d2a4a;
+  font-weight: bold;
+}

--- a/src/DungeonCrawlerGuild.tsx
+++ b/src/DungeonCrawlerGuild.tsx
@@ -1,0 +1,62 @@
+import { useMemo } from "react";
+import styles from "./DungeonCrawlerGuild.module.css";
+import { tribeDungeonCrawlerGuild } from "./tribeDungeonCrawlerGuild";
+import { BackButton } from "./BackButton";
+import { Item } from "./types";
+import dungeonCrawlerGuildBackground from "./Dungeon Crawler's Guild.png";
+
+type DisplayItem = Item & { finalPrice: number };
+
+function calculateAdjustedPrice(item: Item, priceVariability: number): number {
+  const variability =
+    ((Math.random() * priceVariability) / 100) * item.price;
+  const upOrDown = Math.random() < 0.5 ? -1 : 1;
+  const adjusted = item.price + upOrDown * variability;
+
+  return Math.max(0, Math.round(adjusted));
+}
+
+export function DungeonCrawlerGuild({ onBack }: { onBack?: () => void }) {
+  const displayItems: DisplayItem[] = useMemo(() => {
+    return tribeDungeonCrawlerGuild.items
+      .map((item) => ({
+        ...item,
+        finalPrice: calculateAdjustedPrice(item, tribeDungeonCrawlerGuild.priceVariability),
+      }))
+      .sort((a, b) => a.finalPrice - b.finalPrice);
+  }, []);
+
+  return (
+    <div className={styles.app}>
+      <BackButton onClick={onBack} />
+      <div
+        className={styles.backgroundImage}
+        style={{ backgroundImage: `url(${dungeonCrawlerGuildBackground})` }}
+      />
+      <main className={styles.content}>
+        <header className={styles.header}>
+          <div className={styles.headerText}>
+            <h1 className={styles.title}>{tribeDungeonCrawlerGuild.name}</h1>
+            <p className={styles.owner}>Shop Owner: {tribeDungeonCrawlerGuild.owner}</p>
+          </div>
+        </header>
+
+        <section className={styles.grid} aria-label="Available items">
+          {displayItems.map((item) => (
+            <article key={item.name} className={styles.card}>
+              <h2 className={styles.cardTitle}>{item.name}</h2>
+              <p className={styles.description}>{item.description}</p>
+              <p className={styles.price}>
+                {item.finalPrice.toLocaleString()} Gold
+              </p>
+            </article>
+          ))}
+        </section>
+
+        <p className={styles.footerNote}>
+          {tribeDungeonCrawlerGuild.insults[0]}
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -7,12 +7,14 @@ import { ApplegarthGuild } from "./ApplegarthGuild";
 import { ArchivesGuild } from "./ArchivesGuild";
 import { bookBombDataUrl } from "./bookBombImage";
 import { AuntiePattysPies } from "./AuntiePattysPies";
+import { DungeonCrawlerGuild } from "./DungeonCrawlerGuild";
 // Use the uploaded PNG asset (filename contains a space)
 import bookBombPng from "./Book Bomb.png";
 import bulletsBuffsBeyondImage from "./Bullets Buffs and Beyond.webp";
 import applegarthImage from "./Applegarth.webp";
 import archivesGuildImage from "./Archives Guild.png";
 import auntPattiePieImage from "./Aunt Pattie Pie.png";
+import dungeonCrawlerGuildImage from "./Dungeon Crawler's Guild.png";
 import { ChangingChurch } from "./ChangingChurch";
 import { NecromancyInsuranceCompany } from "./NecromancyInsuranceCompany";
 import changingChurchImage from "./Changing Church.png";
@@ -89,6 +91,8 @@ export function Map() {
       return <BookBombs onBack={() => setNavigatedTo("")} />;
     case "AuntiePattysPies":
       return <AuntiePattysPies onBack={() => setNavigatedTo("")} />;
+    case "DungeonCrawlerGuild":
+      return <DungeonCrawlerGuild onBack={() => setNavigatedTo("")} />;
     case "BulletsBuffsBeyond":
       return <BulletsBuffsBeyond onBack={() => setNavigatedTo("")} />;
     case "ApplegarthGuild":
@@ -165,6 +169,13 @@ export function Map() {
               delay="13s"
               backgroundColor="rgba(220, 38, 38, 0.9)"
               imageSrc={auntPattiePieImage}
+            />
+            <FloatingButton
+              label="Dungeon Crawler Guild"
+              onClick={() => setNavigatedTo("DungeonCrawlerGuild")}
+              delay="14s"
+              backgroundColor="rgba(64, 102, 155, 0.9)"
+              imageSrc={dungeonCrawlerGuildImage}
             />
             <FloatingButton
               label="Bullets, Buffs, & Beyond"

--- a/src/tribeDungeonCrawlerGuild.ts
+++ b/src/tribeDungeonCrawlerGuild.ts
@@ -1,0 +1,31 @@
+import { Tribe } from "./types";
+
+export const tribeDungeonCrawlerGuild: Tribe = {
+  name: "Dungeon Crawler Guild",
+  owner: "Doug",
+  percentAngry: 0,
+  priceVariability: 5,
+  insults: [""],
+  items: [
+    {
+      name: "Basic Information about Dungeon",
+      price: 10,
+    },
+    {
+      name: "Retrieval Team",
+      price: 20,
+    },
+    {
+      name: "Premium Membership (10% less tax)",
+      price: 50,
+    },
+    {
+      name: "Escort Quest (50% less tax)",
+      price: 100,
+    },
+    {
+      name: "Premium Plus Membership (Tax-free)",
+      price: 1000,
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- add a Dungeon Crawler Guild shop using the guild art asset and pricing converted to Gold
- style the new storefront with a dedicated background and guild-colored cards
- link the new shop from the hub map with a floating button

## Testing
- CI=true npm test -- --watch=false

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e194338e08329bc61dbe1882b72c8)