### PR TITLE
Add Find a Friend shop

### DIFF
--- a/src/FindAFriend.module.css
+++ b/src/FindAFriend.module.css
@@ -1,0 +1,131 @@
+.app {
+  text-align: center;
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
+}
+
+.backgroundImage {
+  background: url('./Find a Friend.png') no-repeat center center fixed;
+  display: flex;
+  background-size: cover;
+  opacity: 0.75;
+  margin: 0;
+  z-index: -1;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 4rem 2rem 3rem;
+  align-items: center;
+  font-family: 'Times New Roman', serif;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  background: #ffffff;
+  border: 3px solid #5c1a1a;
+  box-shadow: 8px 8px rgba(0, 0, 0, 0.35);
+  border-radius: 20px;
+  padding: 1.5rem 2rem;
+  max-width: 360px;
+  width: 100%;
+}
+
+.headerText {
+  text-align: center;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.4rem;
+  color: #5c1a1a;
+}
+
+.owner {
+  margin: 0.2rem 0;
+  font-size: 1.1rem;
+  color: #b94c2e;
+}
+
+.grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: 1fr;
+  width: 100%;
+  max-width: 640px;
+}
+
+.card {
+  position: relative;
+  display: inline-block;
+  max-width: 600px;
+  padding: 2.25rem 2.75rem;          /* a touch more breathing room */
+  margin-left: auto;
+  margin-right: auto;
+
+  background: transparent;
+  border: 0;
+  color: #2f1f1d;
+  font-family: monospace;
+  font-size: 24px;
+  font-weight: bolder;
+  text-align: center;
+
+  filter: drop-shadow(6px 6px rgba(0, 0, 0, 0.55));
+}
+
+.card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, #fff5f5, #ffe7e7);
+  border: 4px solid #a01818;
+
+  /* "bigger radius" / less aggressive cut-ins */
+  clip-path: polygon(
+    18% 4%,  82% 4%,
+    96% 50%,
+    82% 96%, 18% 96%,
+    4% 50%
+  );
+
+  z-index: -1;
+  pointer-events: none;
+}
+
+.cardTitle {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #5c1a1a;
+}
+
+.description {
+  margin: 0.35rem 0 0.5rem;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  color: #4b3a35;
+  font-size: 1rem;
+  text-align: center;
+}
+
+.price {
+  margin: 0;
+  font-weight: bold;
+  color: #a01818;
+}
+
+.footerNote {
+  margin: 0.5rem 0 0;
+  color: #5c1a1a;
+  font-weight: bold;
+}

--- a/src/FindAFriend.tsx
+++ b/src/FindAFriend.tsx
@@ -1,0 +1,66 @@
+import { useMemo } from "react";
+import styles from "./FindAFriend.module.css";
+import { tribeFindAFriend } from "./tribeFindAFriend";
+import { BackButton } from "./BackButton";
+import findAFriendBackground from "./Find a Friend.png";
+import { Item } from "./types";
+
+type DisplayItem = Item & { finalPrice: number };
+
+function calculateAdjustedPrice(item: Item, priceVariability: number): number {
+  const variability =
+    ((Math.random() * priceVariability) / 100) * item.price;
+  const upOrDown = Math.random() < 0.5 ? -1 : 1;
+  const adjusted = item.price + upOrDown * variability;
+
+  return Math.max(0, Math.round(adjusted));
+}
+
+function formatPrice(value: number) {
+  return value === 0 ? "Free" : `${value.toLocaleString()} Gold`;
+}
+
+export function FindAFriend({ onBack }: { onBack?: () => void }) {
+  const displayItems: DisplayItem[] = useMemo(() => {
+    return tribeFindAFriend.items
+      .map((item) => ({
+        ...item,
+        finalPrice: calculateAdjustedPrice(item, tribeFindAFriend.priceVariability),
+      }))
+      .sort((a, b) => a.finalPrice - b.finalPrice);
+  }, []);
+
+  return (
+    <div className={styles.app}>
+      <BackButton onClick={onBack} />
+      <div
+        className={styles.backgroundImage}
+        style={{ backgroundImage: `url(${findAFriendBackground})` }}
+      />
+      <main className={styles.content}>
+        <header className={styles.header}>
+          <div className={styles.headerText}>
+            <h1 className={styles.title}>{tribeFindAFriend.name}</h1>
+            <p className={styles.owner}>Shop Owner: {tribeFindAFriend.owner}</p>
+          </div>
+        </header>
+
+        <section className={styles.grid} aria-label="Available items">
+          {displayItems.map((item) => (
+            <article key={item.name} className={styles.card}>
+              <h2 className={styles.cardTitle}>{item.name}</h2>
+              <p className={styles.description}>{item.description}</p>
+              <p className={styles.price}>
+                {formatPrice(item.finalPrice)}
+              </p>
+            </article>
+          ))}
+        </section>
+
+        <p className={styles.footerNote}>
+          {tribeFindAFriend.insults[0]}
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -7,6 +7,7 @@ import { ApplegarthGuild } from "./ApplegarthGuild";
 import { ArchivesGuild } from "./ArchivesGuild";
 import { bookBombDataUrl } from "./bookBombImage";
 import { AuntiePattysPies } from "./AuntiePattysPies";
+import { FindAFriend } from "./FindAFriend";
 import { DungeonCrawlerGuild } from "./DungeonCrawlerGuild";
 // Use the uploaded PNG asset (filename contains a space)
 import bookBombPng from "./Book Bomb.png";
@@ -14,6 +15,7 @@ import bulletsBuffsBeyondImage from "./Bullets Buffs and Beyond.webp";
 import applegarthImage from "./Applegarth.webp";
 import archivesGuildImage from "./Archives Guild.png";
 import auntPattiePieImage from "./Aunt Pattie Pie.png";
+import findAFriendImage from "./Find a Friend.png";
 import dungeonCrawlerGuildImage from "./Dungeon Crawler's Guild.png";
 import { ChangingChurch } from "./ChangingChurch";
 import { NecromancyInsuranceCompany } from "./NecromancyInsuranceCompany";
@@ -91,6 +93,8 @@ export function Map() {
       return <BookBombs onBack={() => setNavigatedTo("")} />;
     case "AuntiePattysPies":
       return <AuntiePattysPies onBack={() => setNavigatedTo("")} />;
+    case "FindAFriend":
+      return <FindAFriend onBack={() => setNavigatedTo("")} />;
     case "DungeonCrawlerGuild":
       return <DungeonCrawlerGuild onBack={() => setNavigatedTo("")} />;
     case "BulletsBuffsBeyond":
@@ -169,6 +173,13 @@ export function Map() {
               delay="13s"
               backgroundColor="rgba(220, 38, 38, 0.9)"
               imageSrc={auntPattiePieImage}
+            />
+            <FloatingButton
+              label="Find a Friend"
+              onClick={() => setNavigatedTo("FindAFriend")}
+              delay="16s"
+              backgroundColor="rgba(220, 38, 38, 0.9)"
+              imageSrc={findAFriendImage}
             />
             <FloatingButton
               label="Dungeon Crawler Guild"

--- a/src/tribeFindAFriend.ts
+++ b/src/tribeFindAFriend.ts
@@ -1,0 +1,71 @@
+import { Tribe } from "./types";
+
+export const tribeFindAFriend: Tribe = {
+  name: "Find a Friend",
+  owner: "Fran",
+  percentAngry: 0,
+  priceVariability: 0,
+  insults: [""],
+  items: [
+    {
+      name: "Amber",
+      price: 0,
+      description: "Kalashtar, Appreciate",
+    },
+    {
+      name: "Dandelion Duchess",
+      price: 0,
+      description: "Floral Dragon, Bard",
+    },
+    {
+      name: "Ebony",
+      price: 0,
+      description: "Dark Elf, Thief",
+    },
+    {
+      name: "Gwain",
+      price: 0,
+      description: "Human V, Feruchemist",
+    },
+    {
+      name: "Jade",
+      price: 0,
+      description: "Teoran, Bodyguard",
+    },
+    {
+      name: "John Jon",
+      price: 0,
+      description: "Dwarf, Monster Ecologist",
+    },
+    {
+      name: "Kip",
+      price: 0,
+      description: "Half-Orc, News Reporter",
+    },
+    {
+      name: "Phil & Bill",
+      price: 0,
+      description: "Halfling, Henchmen",
+    },
+    {
+      name: "Swaine",
+      price: 0,
+      description: "Human V, Radiant Knight",
+    },
+    {
+      name: "Twain",
+      price: 0,
+      description: "Human V, Allomancer",
+    },
+    {
+      name: "Warlock Homes",
+      price: 0,
+      description: "Human, Detective",
+    },
+    {
+      name: "Wilford",
+      price: 0,
+      description: "Tortle, Familiar Face",
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- add the Find a Friend shop with Fran’s roster of free companions and gold display adjustments
- reuse the pies layout with a new background image and free price formatting
- wire the map to link to Find a Friend with a red button and shop view

## Testing
- npm test -- --watch=false


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e1b406b5c832986721a5b973f5aab)