### PR TITLE
Add Pearl's Potions shop

### DIFF
--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -7,6 +7,7 @@ import { ApplegarthGuild } from "./ApplegarthGuild";
 import { ArchivesGuild } from "./ArchivesGuild";
 import { bookBombDataUrl } from "./bookBombImage";
 import { AuntiePattysPies } from "./AuntiePattysPies";
+import { PearlsPotions } from "./PearlsPotions";
 import { FindAFriend } from "./FindAFriend";
 import { ComedyGold } from "./ComedyGold";
 import { DungeonCrawlerGuild } from "./DungeonCrawlerGuild";
@@ -16,6 +17,7 @@ import bulletsBuffsBeyondImage from "./Bullets Buffs and Beyond.webp";
 import applegarthImage from "./Applegarth.webp";
 import archivesGuildImage from "./Archives Guild.png";
 import auntPattiePieImage from "./Aunt Pattie Pie.png";
+import pearlsPotionsImage from "./Pearls Potions.png";
 import findAFriendImage from "./Find a Friend.png";
 import comedyGoldImage from "./Comedy Gold.png";
 import dungeonCrawlerGuildImage from "./Dungeon Crawler's Guild.png";
@@ -95,6 +97,8 @@ export function Map() {
       return <BookBombs onBack={() => setNavigatedTo("")} />;
     case "AuntiePattysPies":
       return <AuntiePattysPies onBack={() => setNavigatedTo("")} />;
+    case "PearlsPotions":
+      return <PearlsPotions onBack={() => setNavigatedTo("")} />;
     case "FindAFriend":
       return <FindAFriend onBack={() => setNavigatedTo("")} />;
     case "ComedyGold":
@@ -177,6 +181,13 @@ export function Map() {
               delay="13s"
               backgroundColor="rgba(220, 38, 38, 0.9)"
               imageSrc={auntPattiePieImage}
+            />
+            <FloatingButton
+              label="Pearl's Potions"
+              onClick={() => setNavigatedTo("PearlsPotions")}
+              delay="13.5s"
+              backgroundColor="rgba(220, 38, 38, 0.9)"
+              imageSrc={pearlsPotionsImage}
             />
             <FloatingButton
               label="Find a Friend"

--- a/src/PearlsPotions.module.css
+++ b/src/PearlsPotions.module.css
@@ -1,0 +1,130 @@
+.app {
+  text-align: center;
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
+}
+
+.backgroundImage {
+  background: url('./Pearls Potions.png') no-repeat center center fixed;
+  display: flex;
+  background-size: cover;
+  opacity: 0.75;
+  margin: 0;
+  z-index: -1;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 4rem 2rem 3rem;
+  align-items: center;
+  font-family: 'Times New Roman', serif;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  background: #ffffff;
+  border: 3px solid #5c1a1a;
+  box-shadow: 8px 8px rgba(0, 0, 0, 0.35);
+  border-radius: 20px;
+  padding: 1.5rem 2rem;
+  max-width: 360px;
+  width: 100%;
+}
+
+.headerText {
+  text-align: center;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.4rem;
+  color: #5c1a1a;
+}
+
+.owner {
+  margin: 0.2rem 0;
+  font-size: 1.1rem;
+  color: #b94c2e;
+}
+
+.grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: 1fr;
+  width: 100%;
+  max-width: 640px;
+}
+
+.card {
+  position: relative;
+  display: inline-block;
+  max-width: 600px;
+  padding: 2.25rem 2.75rem;
+  margin-left: auto;
+  margin-right: auto;
+
+  background: transparent;
+  border: 0;
+  color: #2f1f1d;
+  font-family: monospace;
+  font-size: 24px;
+  font-weight: bolder;
+  text-align: center;
+
+  filter: drop-shadow(6px 6px rgba(0, 0, 0, 0.55));
+}
+
+.card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, #fff5f5, #ffe7e7);
+  border: 4px solid #a01818;
+
+  clip-path: polygon(
+    18% 4%,  82% 4%,
+    96% 50%,
+    82% 96%, 18% 96%,
+    4% 50%
+  );
+
+  z-index: -1;
+  pointer-events: none;
+}
+
+.cardTitle {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #5c1a1a;
+}
+
+.description {
+  margin: 0.35rem 0 0.5rem;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  color: #4b3a35;
+  font-size: 1rem;
+  text-align: center;
+}
+
+.price {
+  margin: 0;
+  font-weight: bold;
+  color: #a01818;
+}
+
+.footerNote {
+  margin: 0.5rem 0 0;
+  color: #5c1a1a;
+  font-weight: bold;
+}

--- a/src/PearlsPotions.tsx
+++ b/src/PearlsPotions.tsx
@@ -1,0 +1,57 @@
+import { useMemo } from "react";
+import styles from "./PearlsPotions.module.css";
+import { tribePearlsPotions } from "./tribePearlsPotions";
+import { BackButton } from "./BackButton";
+import { Item } from "./types";
+import pearlsPotionsBackground from "./Pearls Potions.png";
+
+type DisplayItem = Item & { finalPrice: number };
+
+function calculateAdjustedPrice(item: Item, priceVariability: number): number {
+  const variability = ((Math.random() * priceVariability) / 100) * item.price;
+  const upOrDown = Math.random() < 0.5 ? -1 : 1;
+  const adjusted = item.price + upOrDown * variability;
+
+  return Math.max(0, Math.round(adjusted));
+}
+
+export function PearlsPotions({ onBack }: { onBack?: () => void }) {
+  const displayItems: DisplayItem[] = useMemo(() => {
+    return tribePearlsPotions.items
+      .map((item) => ({
+        ...item,
+        finalPrice: calculateAdjustedPrice(item, tribePearlsPotions.priceVariability),
+      }))
+      .sort((a, b) => a.finalPrice - b.finalPrice);
+  }, []);
+
+  return (
+    <div className={styles.app}>
+      <BackButton onClick={onBack} />
+      <div
+        className={styles.backgroundImage}
+        style={{ backgroundImage: `url(${pearlsPotionsBackground})` }}
+      />
+      <main className={styles.content}>
+        <header className={styles.header}>
+          <div className={styles.headerText}>
+            <h1 className={styles.title}>{tribePearlsPotions.name}</h1>
+            <p className={styles.owner}>Shop Owner: {tribePearlsPotions.owner}</p>
+          </div>
+        </header>
+
+        <section className={styles.grid} aria-label="Available items">
+          {displayItems.map((item) => (
+            <article key={item.name} className={styles.card}>
+              <h2 className={styles.cardTitle}>{item.name}</h2>
+              <p className={styles.description}>{item.description}</p>
+              <p className={styles.price}>{item.finalPrice.toLocaleString()} Gold</p>
+            </article>
+          ))}
+        </section>
+
+        <p className={styles.footerNote}>{tribePearlsPotions.insults[0]}</p>
+      </main>
+    </div>
+  );
+}

--- a/src/tribePearlsPotions.ts
+++ b/src/tribePearlsPotions.ts
@@ -1,0 +1,61 @@
+import { Tribe } from "./types";
+
+export const tribePearlsPotions: Tribe = {
+  name: "Pearl's Potions",
+  owner: "Pearl",
+  percentAngry: 0,
+  priceVariability: 5,
+  insults: [""],
+  items: [
+    {
+      name: "Greater Health",
+      description: "Heals 4d4+4",
+      price: 25,
+    },
+    {
+      name: "Poison",
+      description: "Deals 3d6 & lasts 1 hour",
+      price: 35,
+    },
+    {
+      name: "Antidote",
+      description: "Cures Basic Poisons",
+      price: 35,
+    },
+    {
+      name: "Invisible",
+      description: "Lasts for 1 hour",
+      price: 50,
+    },
+    {
+      name: "Sleep",
+      description: "Dependent upon target's sleep cycle",
+      price: 50,
+    },
+    {
+      name: "Hill Giant's Strength",
+      description: "Make your STR +6 for 1 hour",
+      price: 75,
+    },
+    {
+      name: "Shadow Dancer's Nimbleness",
+      description: "Make your DEX +6 for 1 hour",
+      price: 75,
+    },
+    {
+      name: "Deva's Enlightenment",
+      description: "Make your INT +6 for 1 hour",
+      price: 75,
+    },
+    {
+      name: "Unicorn's Empathy",
+      description: "Make your WISH +6 for 1 hour",
+      price: 75,
+    },
+    {
+      name: "Potion of Sphinx's Grace",
+      description: "Make your CHR +6 for 1 hour",
+      price: 75,
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- add Pearl's Potions tribe data with potion details and gold pricing
- create Pearl's Potions page mirroring Auntie Patty's Pies styling and imagery
- wire new Pearl's Potions navigation button into the map

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e1d00d3a08329953a5810e0d26363)