### PR TITLE
Add Navigation Guild shop

### DIFF
--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -7,6 +7,7 @@ import { ApplegarthGuild } from "./ApplegarthGuild";
 import { ArchivesGuild } from "./ArchivesGuild";
 import { bookBombDataUrl } from "./bookBombImage";
 import { AuntiePattysPies } from "./AuntiePattysPies";
+import { NavigationGuild } from "./NavigationGuild";
 import { FindAFriend } from "./FindAFriend";
 import { ComedyGold } from "./ComedyGold";
 import { DungeonCrawlerGuild } from "./DungeonCrawlerGuild";
@@ -16,6 +17,7 @@ import bulletsBuffsBeyondImage from "./Bullets Buffs and Beyond.webp";
 import applegarthImage from "./Applegarth.webp";
 import archivesGuildImage from "./Archives Guild.png";
 import auntPattiePieImage from "./Aunt Pattie Pie.png";
+import navigationGuildImage from "./NavigationGuild-ezgif.com-webp-to-png-converter.png";
 import findAFriendImage from "./Find a Friend.png";
 import comedyGoldImage from "./Comedy Gold.png";
 import dungeonCrawlerGuildImage from "./Dungeon Crawler's Guild.png";
@@ -95,6 +97,8 @@ export function Map() {
       return <BookBombs onBack={() => setNavigatedTo("")} />;
     case "AuntiePattysPies":
       return <AuntiePattysPies onBack={() => setNavigatedTo("")} />;
+    case "NavigationGuild":
+      return <NavigationGuild onBack={() => setNavigatedTo("")} />;
     case "FindAFriend":
       return <FindAFriend onBack={() => setNavigatedTo("")} />;
     case "ComedyGold":
@@ -177,6 +181,13 @@ export function Map() {
               delay="13s"
               backgroundColor="rgba(220, 38, 38, 0.9)"
               imageSrc={auntPattiePieImage}
+            />
+            <FloatingButton
+              label="Navigation Guild"
+              onClick={() => setNavigatedTo("NavigationGuild")}
+              delay="13.5s"
+              backgroundColor="rgba(220, 38, 38, 0.9)"
+              imageSrc={navigationGuildImage}
             />
             <FloatingButton
               label="Find a Friend"

--- a/src/NavigationGuild.module.css
+++ b/src/NavigationGuild.module.css
@@ -1,0 +1,132 @@
+.app {
+  text-align: center;
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
+}
+
+.backgroundImage {
+  background: url('./NavigationGuild-ezgif.com-webp-to-png-converter.png') no-repeat center center fixed;
+  display: flex;
+  background-size: cover;
+  opacity: 0.75;
+  margin: 0;
+  z-index: -1;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 4rem 2rem 3rem;
+  align-items: center;
+  font-family: 'Times New Roman', serif;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  background: #ffffff;
+  border: 3px solid #5c1a1a;
+  box-shadow: 8px 8px rgba(0, 0, 0, 0.35);
+  border-radius: 20px;
+  padding: 1.5rem 2rem;
+  max-width: 360px;
+  width: 100%;
+}
+
+.headerText {
+  text-align: center;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.4rem;
+  color: #5c1a1a;
+}
+
+.owner {
+  margin: 0.2rem 0;
+  font-size: 1.1rem;
+  color: #b94c2e;
+}
+
+.grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: 1fr;
+  width: 100%;
+  max-width: 640px;
+}
+
+.card {
+  position: relative;
+  display: inline-block;
+  max-width: 600px;
+  padding: 2.25rem 2.75rem;          /* a touch more breathing room */
+  margin-left: auto;
+  margin-right: auto;
+
+  background: transparent;
+  border: 0;
+  color: #2f1f1d;
+  font-family: monospace;
+  font-size: 24px;
+  font-weight: bolder;
+  text-align: center;
+
+  filter: drop-shadow(6px 6px rgba(0, 0, 0, 0.55));
+}
+
+.card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, #fff5f5, #ffe7e7);
+  border: 4px solid #a01818;
+
+  /* "bigger radius" / less aggressive cut-ins */
+  clip-path: polygon(
+    18% 4%,  82% 4%,
+    96% 50%,
+    82% 96%, 18% 96%,
+    4% 50%
+  );
+
+  z-index: -1;
+  pointer-events: none;
+}
+
+
+.cardTitle {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #5c1a1a;
+}
+
+.description {
+  margin: 0.35rem 0 0.5rem;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  color: #4b3a35;
+  font-size: 1rem;
+  text-align: center;
+}
+
+.price {
+  margin: 0;
+  font-weight: bold;
+  color: #a01818;
+}
+
+.footerNote {
+  margin: 0.5rem 0 0;
+  color: #5c1a1a;
+  font-weight: bold;
+}

--- a/src/NavigationGuild.tsx
+++ b/src/NavigationGuild.tsx
@@ -1,0 +1,15 @@
+import { ShopTemplate } from "./ShopTemplate";
+import styles from "./NavigationGuild.module.css";
+import navigationGuildBackground from "./NavigationGuild-ezgif.com-webp-to-png-converter.png";
+import { tribeNavigationGuild } from "./tribeNavigationGuild";
+
+export function NavigationGuild({ onBack }: { onBack?: () => void }) {
+  return (
+    <ShopTemplate
+      tribe={tribeNavigationGuild}
+      backgroundImage={navigationGuildBackground}
+      onBack={onBack}
+      styles={styles}
+    />
+  );
+}

--- a/src/tribeNavigationGuild.ts
+++ b/src/tribeNavigationGuild.ts
@@ -1,0 +1,36 @@
+import { Tribe } from "./types";
+
+export const tribeNavigationGuild: Tribe = {
+  name: "Navigation Guild",
+  owner: "Nate",
+  percentAngry: 0,
+  priceVariability: 0,
+  insults: [""],
+  items: [
+    {
+      name: "One town over",
+      price: 5,
+      description: "A straightforward route to the neighboring town.",
+    },
+    {
+      name: "Two towns over",
+      price: 10,
+      description: "Guidance for a two-town journey with reliable stops.",
+    },
+    {
+      name: "Three towns over",
+      price: 20,
+      description: "Safe passage recommendations across three towns.",
+    },
+    {
+      name: "Four towns over",
+      price: 40,
+      description: "Charted directions spanning four towns' worth of travel.",
+    },
+    {
+      name: "Five towns over",
+      price: 80,
+      description: "An extended itinerary covering five towns of distance.",
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- add Navigation Guild tribe data and themed shop screen using the shared template
- apply matching styles and background image for the Navigation Guild storefront
- surface a red Navigation Guild button on the map that routes to the new shop

## Testing
- CI=true npm test -- --watch=false


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e1ccd3cd08329a0d9cd7d398c588b)