### PR TITLE
Add Piggy Bank shop modeled on Auntie Patty's Pies

### DIFF
--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -7,6 +7,7 @@ import { ApplegarthGuild } from "./ApplegarthGuild";
 import { ArchivesGuild } from "./ArchivesGuild";
 import { bookBombDataUrl } from "./bookBombImage";
 import { AuntiePattysPies } from "./AuntiePattysPies";
+import { PiggyBank } from "./PiggyBank";
 import { NavigationGuild } from "./NavigationGuild";
 import { PearlsPotions } from "./PearlsPotions";
 import { FindAFriend } from "./FindAFriend";
@@ -39,6 +40,7 @@ import runestoneRelayImage from "./Runestone Relay.png";
 import silentOathImage from "./Silent Oath.png";
 import supremeSmithyImage from "./Supreme Smithy.png";
 import willsWeaponsImage from "./Wills Weapons.png";
+import piggyBankImage from "./Piggy Bank.png";
 import { useEffect, useState } from "react";
 
 // Remove stray whitespace/newlines from data URIs (defensive)
@@ -99,6 +101,8 @@ export function Map() {
       return <BookBombs onBack={() => setNavigatedTo("")} />;
     case "AuntiePattysPies":
       return <AuntiePattysPies onBack={() => setNavigatedTo("")} />;
+    case "PiggyBank":
+      return <PiggyBank onBack={() => setNavigatedTo("")} />;
     case "NavigationGuild":
       return <NavigationGuild onBack={() => setNavigatedTo("")} />;
     case "PearlsPotions":
@@ -185,6 +189,13 @@ export function Map() {
               delay="13s"
               backgroundColor="rgba(220, 38, 38, 0.9)"
               imageSrc={auntPattiePieImage}
+            />
+            <FloatingButton
+              label="The Piggy Bank"
+              onClick={() => setNavigatedTo("PiggyBank")}
+              delay="13.25s"
+              backgroundColor="rgba(220, 38, 38, 0.9)"
+              imageSrc={piggyBankImage}
             />
             <FloatingButton
               label="Navigation Guild"

--- a/src/PiggyBank.module.css
+++ b/src/PiggyBank.module.css
@@ -1,0 +1,145 @@
+.app {
+  text-align: center;
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
+}
+
+.backgroundImage {
+  background: url('./Piggy Bank.png') no-repeat center center fixed;
+  display: flex;
+  background-size: cover;
+  opacity: 0.65;
+  margin: 0;
+  z-index: -1;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  filter: saturate(1.15);
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 4rem 2rem 3rem;
+  align-items: center;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  background: linear-gradient(135deg, rgba(255, 247, 231, 0.95), rgba(229, 247, 255, 0.95));
+  border: 3px solid #f0b429;
+  box-shadow: 8px 10px 18px rgba(34, 57, 67, 0.35);
+  border-radius: 18px;
+  padding: 1.5rem 2rem;
+  max-width: 420px;
+  width: 100%;
+  backdrop-filter: blur(4px);
+}
+
+.headerText {
+  text-align: center;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.35rem;
+  color: #8a3d91;
+  text-shadow: 1px 2px rgba(0, 0, 0, 0.15);
+}
+
+.owner {
+  margin: 0.2rem 0;
+  font-size: 1.1rem;
+  color: #2d728f;
+}
+
+.grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: 1fr;
+  width: 100%;
+  max-width: 700px;
+}
+
+.card {
+  position: relative;
+  display: inline-block;
+  max-width: 640px;
+  padding: 2.2rem 2.5rem;
+  margin-left: auto;
+  margin-right: auto;
+
+  background: transparent;
+  border: 0;
+  color: #253237;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  font-size: 22px;
+  font-weight: 700;
+  text-align: center;
+
+  filter: drop-shadow(6px 10px rgba(0, 0, 0, 0.45));
+}
+
+.card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(145deg, rgba(255, 236, 210, 0.96), rgba(213, 236, 255, 0.96));
+  border: 4px solid #f08c42;
+  box-shadow: inset 0 0 0 4px rgba(255, 255, 255, 0.3);
+
+  clip-path: polygon(
+    16% 6%, 84% 6%,
+    95% 50%,
+    84% 94%, 16% 94%,
+    5% 50%
+  );
+
+  z-index: -1;
+  pointer-events: none;
+}
+
+.card::after {
+  content: "";
+  position: absolute;
+  inset: 10px;
+  border-radius: 12px;
+  background: radial-gradient(circle at 25% 25%, rgba(255, 255, 255, 0.4), transparent 55%);
+  mix-blend-mode: screen;
+  z-index: -1;
+  pointer-events: none;
+}
+
+.cardTitle {
+  margin: 0;
+  font-size: 1.3rem;
+  color: #7a2c8b;
+}
+
+.description {
+  margin: 0.35rem 0 0.5rem;
+  color: #3b5560;
+  font-size: 1rem;
+  text-align: center;
+}
+
+.price {
+  margin: 0;
+  font-weight: 800;
+  color: #c05b10;
+  letter-spacing: 0.5px;
+}
+
+.footerNote {
+  margin: 0.5rem 0 0;
+  color: #2d728f;
+  font-weight: bold;
+}

--- a/src/PiggyBank.tsx
+++ b/src/PiggyBank.tsx
@@ -1,0 +1,68 @@
+import { useMemo } from "react";
+import styles from "./PiggyBank.module.css";
+import { BackButton } from "./BackButton";
+import piggyBankBackground from "./Piggy Bank.png";
+import { PiggyBankItem, tribePiggyBank } from "./tribePiggyBank";
+
+type DisplayItem = PiggyBankItem & { finalPrice?: number; displayPrice: string };
+
+function calculateAdjustedPrice(item: PiggyBankItem, priceVariability: number): number {
+  const variability = ((Math.random() * priceVariability) / 100) * item.price;
+  const upOrDown = Math.random() < 0.5 ? -1 : 1;
+  const adjusted = item.price + upOrDown * variability;
+
+  return Math.max(0, Math.round(adjusted));
+}
+
+export function PiggyBank({ onBack }: { onBack?: () => void }) {
+  const displayItems: DisplayItem[] = useMemo(() => {
+    return tribePiggyBank.items.map((item) => {
+      if (item.priceLabel) {
+        return { ...item, displayPrice: item.priceLabel };
+      }
+
+      const finalPrice = calculateAdjustedPrice(item, tribePiggyBank.priceVariability);
+      return {
+        ...item,
+        finalPrice,
+        displayPrice: `${finalPrice.toLocaleString()} Gold`,
+      };
+    });
+  }, []);
+
+  return (
+    <div className={styles.app}>
+      <BackButton onClick={onBack} />
+      <div
+        className={styles.backgroundImage}
+        style={{ backgroundImage: `url(${piggyBankBackground})` }}
+      />
+      <main className={styles.content}>
+        <header className={styles.header}>
+          <div className={styles.headerText}>
+            <h1 className={styles.title}>{tribePiggyBank.name}</h1>
+            {tribePiggyBank.owner && (
+              <p className={styles.owner}>Shop Owner: {tribePiggyBank.owner}</p>
+            )}
+          </div>
+        </header>
+
+        <section className={styles.grid} aria-label="Available items">
+          {displayItems.map((item) => (
+            <article key={item.name} className={styles.card}>
+              <h2 className={styles.cardTitle}>{item.name}</h2>
+              {item.description && (
+                <p className={styles.description}>{item.description}</p>
+              )}
+              <p className={styles.price}>{item.displayPrice}</p>
+            </article>
+          ))}
+        </section>
+
+        {tribePiggyBank.insults[0] && (
+          <p className={styles.footerNote}>{tribePiggyBank.insults[0]}</p>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/tribePiggyBank.ts
+++ b/src/tribePiggyBank.ts
@@ -1,0 +1,41 @@
+import { Item, Tribe } from "./types";
+
+export interface PiggyBankItem extends Item {
+  priceLabel?: string;
+}
+
+interface PiggyBankTribe extends Omit<Tribe, "items"> {
+  items: PiggyBankItem[];
+}
+
+export const tribePiggyBank: PiggyBankTribe = {
+  name: "The Piggy Bank, no hammers inside.",
+  owner: "???",
+  percentAngry: 0,
+  priceVariability: 5,
+  insults: [""],
+  items: [
+    {
+      name: "Set up an account",
+      price: 0,
+      priceLabel: "Free",
+    },
+    {
+      name: "Shop Quest",
+      price: 0,
+      priceLabel: "Earn Stamps",
+    },
+    {
+      name: "Local Quests",
+      price: 50,
+    },
+    {
+      name: "Guild Quest",
+      price: 100,
+    },
+    {
+      name: "Town Quest",
+      price: 150,
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- create Piggy Bank shop data and component mirroring Auntie Patty's flow with gold-labeled pricing
- style the new shop with a piggy-bank-inspired palette for standout cards and header
- add a map entry so the Piggy Bank is reachable alongside the existing Auntie Patty's Pies location

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e1f8b07b08329b680c231e314f279)