### PR TITLE
Refine guild card color palettes

### DIFF
--- a/src/ComedyGold.module.css
+++ b/src/ComedyGold.module.css
@@ -33,9 +33,9 @@
   align-items: center;
   justify-content: center;
   gap: 1.5rem;
-  background: #ffffff;
-  border: 3px solid #0c3b6a;
-  box-shadow: 8px 8px rgba(0, 0, 0, 0.35);
+  background: #fff9ef;
+  border: 3px solid #b86a0f;
+  box-shadow: 8px 8px rgba(80, 38, 2, 0.35);
   border-radius: 20px;
   padding: 1.5rem 2rem;
   max-width: 360px;
@@ -49,13 +49,13 @@
 .title {
   margin: 0;
   font-size: 2.4rem;
-  color: #0c3b6a;
+  color: #8b3a00;
 }
 
 .owner {
   margin: 0.2rem 0;
   font-size: 1.1rem;
-  color: #1f6bc0;
+  color: #d8891b;
 }
 
 .grid {
@@ -90,7 +90,8 @@
   position: absolute;
   inset: 0;
   background: linear-gradient(135deg, #f2f7ff, #dbe8ff);
-  border: 4px solid #1c4f91;
+  border: 4px solid #b86a0f;
+  background: linear-gradient(135deg, #fff2c9, #f2c178);
 
   clip-path: polygon(
     18% 4%,  82% 4%,
@@ -106,13 +107,13 @@
 .cardTitle {
   margin: 0;
   font-size: 1.25rem;
-  color: #0c3b6a;
+  color: #8b3a00;
 }
 
 .description {
   margin: 0.35rem 0 0.5rem;
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  color: #0d1b2a;
+  color: #4c2a08;
   font-size: 1rem;
   text-align: center;
 }
@@ -120,11 +121,11 @@
 .price {
   margin: 0;
   font-weight: bold;
-  color: #1c4f91;
+  color: #d8891b;
 }
 
 .footerNote {
   margin: 0.5rem 0 0;
-  color: #0c3b6a;
+  color: #8b3a00;
   font-weight: bold;
 }

--- a/src/DungeonCrawlerGuild.module.css
+++ b/src/DungeonCrawlerGuild.module.css
@@ -33,9 +33,9 @@
   align-items: center;
   justify-content: center;
   gap: 1.5rem;
-  background: #ffffff;
-  border: 3px solid #113b6f;
-  box-shadow: 8px 8px rgba(0, 0, 0, 0.35);
+  background: #f0fbff;
+  border: 3px solid #2f6f7b;
+  box-shadow: 8px 8px rgba(5, 40, 54, 0.35);
   border-radius: 20px;
   padding: 1.5rem 2rem;
   max-width: 360px;
@@ -49,13 +49,13 @@
 .title {
   margin: 0;
   font-size: 2.4rem;
-  color: #0d2a4a;
+  color: #1f4d57;
 }
 
 .owner {
   margin: 0.2rem 0;
   font-size: 1.1rem;
-  color: #1f5b99;
+  color: #4a8d9b;
 }
 
 .grid {
@@ -82,15 +82,15 @@
   font-weight: bolder;
   text-align: center;
 
-  filter: drop-shadow(6px 6px rgba(0, 0, 0, 0.55));
+  filter: drop-shadow(6px 6px rgba(6, 47, 72, 0.45));
 }
 
 .card::before {
   content: "";
   position: absolute;
   inset: 0;
-  background: linear-gradient(135deg, #f0f6ff, #dbe9ff);
-  border: 4px solid #1f5b99;
+  background: linear-gradient(135deg, #e5f7ff, #cdebe0);
+  border: 4px solid #4a8d9b;
 
   clip-path: polygon(
     18% 4%,  82% 4%,
@@ -107,13 +107,13 @@
 .cardTitle {
   margin: 0;
   font-size: 1.25rem;
-  color: #0d2a4a;
+  color: #1f4d57;
 }
 
 .description {
   margin: 0.35rem 0 0.5rem;
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  color: #143c66;
+  color: #285f6b;
   font-size: 1rem;
   text-align: center;
 }
@@ -121,11 +121,11 @@
 .price {
   margin: 0;
   font-weight: bold;
-  color: #1f5b99;
+  color: #4a8d9b;
 }
 
 .footerNote {
   margin: 0.5rem 0 0;
-  color: #0d2a4a;
+  color: #1f4d57;
   font-weight: bold;
 }

--- a/src/FindAFriend.module.css
+++ b/src/FindAFriend.module.css
@@ -33,9 +33,9 @@
   align-items: center;
   justify-content: center;
   gap: 1.5rem;
-  background: #ffffff;
-  border: 3px solid #5c1a1a;
-  box-shadow: 8px 8px rgba(0, 0, 0, 0.35);
+  background: #e8f3ff;
+  border: 3px solid #1d62a5;
+  box-shadow: 8px 8px rgba(9, 33, 61, 0.35);
   border-radius: 20px;
   padding: 1.5rem 2rem;
   max-width: 360px;
@@ -49,13 +49,13 @@
 .title {
   margin: 0;
   font-size: 2.4rem;
-  color: #5c1a1a;
+  color: #0f3d6e;
 }
 
 .owner {
   margin: 0.2rem 0;
   font-size: 1.1rem;
-  color: #b94c2e;
+  color: #3f82c9;
 }
 
 .grid {
@@ -76,21 +76,21 @@
 
   background: transparent;
   border: 0;
-  color: #2f1f1d;
+  color: #0f2340;
   font-family: monospace;
   font-size: 24px;
   font-weight: bolder;
   text-align: center;
 
-  filter: drop-shadow(6px 6px rgba(0, 0, 0, 0.55));
+  filter: drop-shadow(6px 6px rgba(8, 34, 72, 0.45));
 }
 
 .card::before {
   content: "";
   position: absolute;
   inset: 0;
-  background: linear-gradient(135deg, #fff5f5, #ffe7e7);
-  border: 4px solid #a01818;
+  background: linear-gradient(135deg, #e3f0ff, #c2ddff);
+  border: 4px solid #1d62a5;
 
   /* "bigger radius" / less aggressive cut-ins */
   clip-path: polygon(
@@ -107,13 +107,13 @@
 .cardTitle {
   margin: 0;
   font-size: 1.25rem;
-  color: #5c1a1a;
+  color: #0f3d6e;
 }
 
 .description {
   margin: 0.35rem 0 0.5rem;
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  color: #4b3a35;
+  color: #14304f;
   font-size: 1rem;
   text-align: center;
 }
@@ -121,11 +121,11 @@
 .price {
   margin: 0;
   font-weight: bold;
-  color: #a01818;
+  color: #1d62a5;
 }
 
 .footerNote {
   margin: 0.5rem 0 0;
-  color: #5c1a1a;
+  color: #0f3d6e;
   font-weight: bold;
 }

--- a/src/NavigationGuild.module.css
+++ b/src/NavigationGuild.module.css
@@ -33,9 +33,9 @@
   align-items: center;
   justify-content: center;
   gap: 1.5rem;
-  background: #ffffff;
-  border: 3px solid #5c1a1a;
-  box-shadow: 8px 8px rgba(0, 0, 0, 0.35);
+  background: #0f1b2e;
+  border: 3px solid #ff9a3c;
+  box-shadow: 8px 8px rgba(0, 0, 0, 0.45);
   border-radius: 20px;
   padding: 1.5rem 2rem;
   max-width: 360px;
@@ -49,13 +49,13 @@
 .title {
   margin: 0;
   font-size: 2.4rem;
-  color: #5c1a1a;
+  color: #ffb35c;
 }
 
 .owner {
   margin: 0.2rem 0;
   font-size: 1.1rem;
-  color: #b94c2e;
+  color: #f2e2c7;
 }
 
 .grid {
@@ -76,7 +76,7 @@
 
   background: transparent;
   border: 0;
-  color: #2f1f1d;
+  color: #f8f1e3;
   font-family: monospace;
   font-size: 24px;
   font-weight: bolder;
@@ -89,8 +89,8 @@
   content: "";
   position: absolute;
   inset: 0;
-  background: linear-gradient(135deg, #fff5f5, #ffe7e7);
-  border: 4px solid #a01818;
+  background: linear-gradient(135deg, #111b2e, #0b101d);
+  border: 4px solid #ff9a3c;
 
   /* "bigger radius" / less aggressive cut-ins */
   clip-path: polygon(
@@ -108,13 +108,13 @@
 .cardTitle {
   margin: 0;
   font-size: 1.25rem;
-  color: #5c1a1a;
+  color: #ffb35c;
 }
 
 .description {
   margin: 0.35rem 0 0.5rem;
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  color: #4b3a35;
+  color: #e8d9c1;
   font-size: 1rem;
   text-align: center;
 }
@@ -122,11 +122,11 @@
 .price {
   margin: 0;
   font-weight: bold;
-  color: #a01818;
+  color: #ff9a3c;
 }
 
 .footerNote {
   margin: 0.5rem 0 0;
-  color: #5c1a1a;
+  color: #ffb35c;
   font-weight: bold;
 }

--- a/src/PearlsPotions.module.css
+++ b/src/PearlsPotions.module.css
@@ -33,9 +33,9 @@
   align-items: center;
   justify-content: center;
   gap: 1.5rem;
-  background: #ffffff;
-  border: 3px solid #5c1a1a;
-  box-shadow: 8px 8px rgba(0, 0, 0, 0.35);
+  background: #f0fbff;
+  border: 3px solid #2ab0c9;
+  box-shadow: 8px 8px rgba(8, 52, 70, 0.35);
   border-radius: 20px;
   padding: 1.5rem 2rem;
   max-width: 360px;
@@ -49,13 +49,13 @@
 .title {
   margin: 0;
   font-size: 2.4rem;
-  color: #5c1a1a;
+  color: #0d5c7d;
 }
 
 .owner {
   margin: 0.2rem 0;
   font-size: 1.1rem;
-  color: #b94c2e;
+  color: #2ab0c9;
 }
 
 .grid {
@@ -76,21 +76,21 @@
 
   background: transparent;
   border: 0;
-  color: #2f1f1d;
+  color: #0d3547;
   font-family: monospace;
   font-size: 24px;
   font-weight: bolder;
   text-align: center;
 
-  filter: drop-shadow(6px 6px rgba(0, 0, 0, 0.55));
+  filter: drop-shadow(6px 6px rgba(8, 50, 71, 0.45));
 }
 
 .card::before {
   content: "";
   position: absolute;
   inset: 0;
-  background: linear-gradient(135deg, #fff5f5, #ffe7e7);
-  border: 4px solid #a01818;
+  background: linear-gradient(135deg, #dff7ff, #c1e7f2);
+  border: 4px solid #2ab0c9;
 
   clip-path: polygon(
     18% 4%,  82% 4%,
@@ -106,13 +106,13 @@
 .cardTitle {
   margin: 0;
   font-size: 1.25rem;
-  color: #5c1a1a;
+  color: #0d5c7d;
 }
 
 .description {
   margin: 0.35rem 0 0.5rem;
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  color: #4b3a35;
+  color: #135c76;
   font-size: 1rem;
   text-align: center;
 }
@@ -120,11 +120,11 @@
 .price {
   margin: 0;
   font-weight: bold;
-  color: #a01818;
+  color: #e36c9d;
 }
 
 .footerNote {
   margin: 0.5rem 0 0;
-  color: #5c1a1a;
+  color: #0d5c7d;
   font-weight: bold;
 }


### PR DESCRIPTION
## Summary
- retheme Comedy Gold cards with warm gold tones to pop against the artwork
- align Dungeon Crawler, Find a Friend, Navigation Guild, and Pearl's Potions card styles with their imagery
- improve contrast on headers, borders, and text for each updated guild card

## Testing
- not run (UI-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e2073199c8329b5b4f239bf6fe2c6)