### PR TITLE
Add Hug Info destination and navigation styling

### DIFF
--- a/src/BackButton.tsx
+++ b/src/BackButton.tsx
@@ -1,6 +1,12 @@
 import React from "react";
 
-export function BackButton({ onClick }: { onClick?: () => void }) {
+export function BackButton({
+  onClick,
+  style,
+}: {
+  onClick?: () => void;
+  style?: React.CSSProperties;
+}) {
   const handleClick = () => {
     if (onClick) {
       onClick();
@@ -10,7 +16,11 @@ export function BackButton({ onClick }: { onClick?: () => void }) {
   };
 
   return (
-    <button type="button" onClick={handleClick} style={styles.backButton}>
+    <button
+      type="button"
+      onClick={handleClick}
+      style={{ ...styles.backButton, ...style }}
+    >
       ← Return to the map
     </button>
   );

--- a/src/HugInfo.module.css
+++ b/src/HugInfo.module.css
@@ -1,0 +1,129 @@
+.app {
+  text-align: center;
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
+}
+
+.backgroundImage {
+  background: url('./Hug info.webp') no-repeat center center fixed;
+  display: flex;
+  background-size: cover;
+  opacity: 0.75;
+  margin: 0;
+  z-index: -1;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 4rem 2rem 3rem;
+  align-items: center;
+  font-family: 'Times New Roman', serif;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  background: #ffffff;
+  border: 3px solid #5c1a1a;
+  box-shadow: 8px 8px rgba(0, 0, 0, 0.35);
+  border-radius: 20px;
+  padding: 1.5rem 2rem;
+  max-width: 360px;
+  width: 100%;
+}
+
+.headerText {
+  text-align: center;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.4rem;
+  color: #5c1a1a;
+}
+
+.owner {
+  margin: 0.2rem 0;
+  font-size: 1.1rem;
+  color: #b94c2e;
+}
+
+.grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: 1fr;
+  width: 100%;
+  max-width: 640px;
+}
+
+.card {
+  position: relative;
+  display: inline-block;
+  max-width: 600px;
+  padding: 2.25rem 2.75rem;
+  margin-left: auto;
+  margin-right: auto;
+
+  background: transparent;
+  border: 0;
+  color: #2f1f1d;
+  font-family: monospace;
+  font-size: 24px;
+  font-weight: bolder;
+  text-align: center;
+
+  filter: drop-shadow(6px 6px rgba(0, 0, 0, 0.55));
+}
+
+.card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, #fff5f5, #ffe7e7);
+  border: 4px solid #a01818;
+  clip-path: polygon(
+    18% 4%,  82% 4%,
+    96% 50%,
+    82% 96%, 18% 96%,
+    4% 50%
+  );
+
+  z-index: -1;
+  pointer-events: none;
+}
+
+.cardTitle {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #5c1a1a;
+}
+
+.description {
+  margin: 0.35rem 0 0.5rem;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  color: #4b3a35;
+  font-size: 1rem;
+  text-align: center;
+}
+
+.price {
+  margin: 0;
+  font-weight: bold;
+  color: #a01818;
+}
+
+.footerNote {
+  margin: 0.5rem 0 0;
+  color: #5c1a1a;
+  font-weight: bold;
+}

--- a/src/HugInfo.tsx
+++ b/src/HugInfo.tsx
@@ -1,0 +1,69 @@
+import { useMemo } from "react";
+import styles from "./HugInfo.module.css";
+import { tribeAuntiePattysPies } from "./tribeAuntiePattysPies";
+import { BackButton } from "./BackButton";
+import { Item } from "./types";
+import hugBackground from "./Hug info.webp";
+
+type DisplayItem = Item & { finalPrice: number };
+
+function calculateAdjustedPrice(item: Item, priceVariability: number): number {
+  const variability =
+    ((Math.random() * priceVariability) / 100) * item.price;
+  const upOrDown = Math.random() < 0.5 ? -1 : 1;
+  const adjusted = item.price + upOrDown * variability;
+
+  return Math.max(0, Math.round(adjusted));
+}
+
+export function HugInfo({ onBack }: { onBack?: () => void }) {
+  const displayItems: DisplayItem[] = useMemo(() => {
+    return tribeAuntiePattysPies.items
+      .map((item) => ({
+        ...item,
+        finalPrice: calculateAdjustedPrice(item, tribeAuntiePattysPies.priceVariability),
+      }))
+      .sort((a, b) => a.finalPrice - b.finalPrice);
+  }, []);
+
+  return (
+    <div className={styles.app}>
+      <BackButton
+        onClick={onBack}
+        style={{
+          right: "1.5rem",
+          left: "auto",
+          backgroundColor: "#facc15",
+        }}
+      />
+      <div
+        className={styles.backgroundImage}
+        style={{ backgroundImage: `url(${hugBackground})` }}
+      />
+      <main className={styles.content}>
+        <header className={styles.header}>
+          <div className={styles.headerText}>
+            <h1 className={styles.title}>{tribeAuntiePattysPies.name}</h1>
+            <p className={styles.owner}>Shop Owner: {tribeAuntiePattysPies.owner}</p>
+          </div>
+        </header>
+
+        <section className={styles.grid} aria-label="Available items">
+          {displayItems.map((item) => (
+            <article key={item.name} className={styles.card}>
+              <h2 className={styles.cardTitle}>{item.name}</h2>
+              <p className={styles.description}>{item.description}</p>
+              <p className={styles.price}>
+                {item.finalPrice.toLocaleString()} Gold
+              </p>
+            </article>
+          ))}
+        </section>
+
+        <p className={styles.footerNote}>
+          {tribeAuntiePattysPies.insults[0]}
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -46,6 +46,8 @@ import yeOldDonkeyImage from "./Ye Old Donkey.png";
 import provisionsParadiseImage from "./Provisions Paradise.png";
 import { ProvisionsParadise } from "./ProvisionsParadise";
 import { useEffect, useState } from "react";
+import { HugInfo } from "./HugInfo";
+import hugImage from "./Hug.webp";
 
 // Remove stray whitespace/newlines from data URIs (defensive)
 function cleanDataUrl(s?: string) {
@@ -143,6 +145,8 @@ export function Map() {
       return <ProvisionsParadise onBack={() => setNavigatedTo("")} />;
     case "YeOldDonkey":
       return <YeOldDonkey onBack={() => setNavigatedTo("")} />;
+    case "HugInfo":
+      return <HugInfo onBack={() => setNavigatedTo("")} />;
     default:
       return (
         <div style={styles.wrapper}>
@@ -316,6 +320,13 @@ export function Map() {
               delay="69s"
               backgroundColor="rgba(220, 38, 38, 0.9)"
               imageSrc={yeOldDonkeyImage}
+            />
+            <FloatingButton
+              label="Hug Info"
+              onClick={() => setNavigatedTo("HugInfo")}
+              delay="72s"
+              backgroundColor="rgba(250, 204, 21, 0.9)"
+              imageSrc={hugImage}
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add a Hug Info shop page that reuses the Auntie Patty data with the new Hug info background and right-aligned yellow return button
- allow the shared back button to accept style overrides for custom positioning/colors
- surface the Hug Info option on the hub map with the Hug.webp icon after Ye Old Donkey

## Testing
- npm test -- --watch=false

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e2484f0948329b34431992ef0ebc2)