### PR TITLE
Create Provision's Paradise shop view

### DIFF
--- a/src/ProvisionsParadise.module.css
+++ b/src/ProvisionsParadise.module.css
@@ -1,0 +1,130 @@
+.app {
+  text-align: center;
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
+  background: radial-gradient(circle at 20% 20%, #dfece2 0%, #c8d9cf 45%, #b3c9bb 90%);
+}
+
+.backgroundImage {
+  background: url("./Provisions Paradise.png") no-repeat center center fixed;
+  background-size: cover;
+  opacity: 0.7;
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  filter: saturate(0.9);
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 4rem 2rem 3rem;
+  align-items: center;
+  font-family: "Times New Roman", serif;
+  color: #1f2f28;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.25rem;
+  background: linear-gradient(135deg, rgba(138, 186, 181, 0.95), rgba(242, 231, 181, 0.9));
+  border: 3px solid #1f3329;
+  box-shadow: 8px 8px rgba(17, 46, 36, 0.35);
+  border-radius: 18px;
+  padding: 1.25rem 2rem;
+  max-width: 400px;
+  width: 100%;
+  backdrop-filter: blur(2px);
+}
+
+.headerText {
+  text-align: center;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.35rem;
+  color: #10231c;
+  letter-spacing: 0.5px;
+}
+
+.owner {
+  margin: 0.15rem 0 0;
+  font-size: 1.05rem;
+  color: #2a4a3b;
+}
+
+.grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  width: 100%;
+  max-width: 880px;
+}
+
+.card {
+  position: relative;
+  padding: 1.6rem 1.75rem;
+  margin: 0 auto;
+  background: transparent;
+  border: 0;
+  color: #10231c;
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  font-size: 1rem;
+  font-weight: 600;
+  text-align: center;
+  filter: drop-shadow(5px 7px rgba(22, 60, 45, 0.45));
+}
+
+.card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(156, 192, 184, 0.96), rgba(242, 231, 181, 0.92));
+  border: 4px solid #0f2a22;
+  clip-path: polygon(
+    14% 5%,
+    86% 5%,
+    96% 50%,
+    86% 95%,
+    14% 95%,
+    4% 50%
+  );
+  z-index: -1;
+  box-shadow: inset 0 0 12px rgba(16, 35, 28, 0.2);
+}
+
+.cardTitle {
+  margin: 0;
+  font-size: 1.3rem;
+  color: #0f2a22;
+  letter-spacing: 0.3px;
+}
+
+.description {
+  margin: 0.4rem 0 0.65rem;
+  color: #224235;
+  font-size: 0.98rem;
+}
+
+.price {
+  margin: 0;
+  font-weight: 700;
+  color: #32593f;
+  font-size: 1.05rem;
+}
+
+.footerNote {
+  margin: 0.6rem 0 0;
+  color: #1f3329;
+  font-weight: bold;
+  background: rgba(255, 255, 255, 0.6);
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(31, 51, 41, 0.35);
+  box-shadow: 0 4px 12px rgba(17, 46, 36, 0.2);
+}

--- a/src/ProvisionsParadise.tsx
+++ b/src/ProvisionsParadise.tsx
@@ -1,31 +1,15 @@
-import { BackButton } from "./BackButton";
+import { ShopTemplate } from "./ShopTemplate";
+import provisionsParadiseBackground from "./Provisions Paradise.png";
+import styles from "./ProvisionsParadise.module.css";
+import { tribeProvisionsParadise } from "./tribeProvisionsParadise";
 
 export function ProvisionsParadise({ onBack }: { onBack?: () => void }) {
   return (
-    <div
-      style={{
-        minHeight: "100vh",
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        justifyContent: "center",
-        background: "radial-gradient(circle at 30% 20%, #ffe6b3, #f3d6a0 45%, #d8b179)",
-        color: "#2f1b0c",
-        textAlign: "center",
-        padding: "2rem",
-        gap: "1.5rem",
-        fontFamily: "'Times New Roman', serif",
-      }}
-    >
-      <BackButton onClick={onBack} />
-      <h1 style={{ fontSize: "2.5rem", margin: 0 }}>Provision&apos;s Paradise</h1>
-      <p style={{ maxWidth: "46ch", fontSize: "1.25rem", lineHeight: 1.6 }}>
-        The shelves are being restocked with rare essentials, so the doors are briefly closed.
-        Check back soon to see what the merchants have in store.
-      </p>
-      <p style={{ fontStyle: "italic", fontSize: "1.1rem" }}>
-        (In the meantime, maybe pick up a pie or two.)
-      </p>
-    </div>
+    <ShopTemplate
+      tribe={tribeProvisionsParadise}
+      backgroundImage={provisionsParadiseBackground}
+      onBack={onBack}
+      styles={styles}
+    />
   );
 }

--- a/src/tribeProvisionsParadise.ts
+++ b/src/tribeProvisionsParadise.ts
@@ -1,0 +1,36 @@
+import { Tribe } from "./types";
+
+export const tribeProvisionsParadise: Tribe = {
+  name: "Provision's Paradise",
+  owner: "Parry Vr 36",
+  percentAngry: 0,
+  priceVariability: 6,
+  insults: ["Keep your hands clean — reagents don't like crumbs."],
+  items: [
+    {
+      name: "Small Components Bag",
+      price: 20,
+      description: "Stocked for 0–2 level spells.",
+    },
+    {
+      name: "Minor Bag of Holding",
+      price: 25,
+      description: "Compact space for reagents and scrolls.",
+    },
+    {
+      name: "Medium Components Bag",
+      price: 50,
+      description: "Organized for 3–5 level spells.",
+    },
+    {
+      name: "Any 3 Kits",
+      price: 75,
+      description: "Bundle any three kits you need for the road.",
+    },
+    {
+      name: "Large Components Bag",
+      price: 100,
+      description: "Ruggedly lined for 6–9 level spell components.",
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- build a Provision's Paradise shop screen using the shared shop template
- add palette-inspired styling and background to set it apart from Auntie Patty's Pies
- load the Provision's Paradise inventory and owner details with gold pricing

## Testing
- CI=true npm test -- --watch=false

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e244d65fc8329aac773a923a8af8c)