### PR TITLE
Add Iconic Dragonic shop

### DIFF
--- a/src/IconicDragonic.module.css
+++ b/src/IconicDragonic.module.css
@@ -1,0 +1,157 @@
+.app {
+  text-align: center;
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
+  background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.05), transparent 45%),
+    radial-gradient(circle at 80% 0%, rgba(190, 24, 93, 0.14), transparent 40%),
+    #0b1224;
+}
+
+.backgroundImage {
+  background: center / cover no-repeat;
+  display: flex;
+  opacity: 0.18;
+  margin: 0;
+  z-index: -2;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  filter: saturate(1.2) contrast(1.05);
+}
+
+.backgroundImage::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(14, 116, 144, 0.25), rgba(190, 24, 93, 0.24));
+  z-index: 1;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  padding: 4rem 2rem 3rem;
+  align-items: center;
+  font-family: 'Times New Roman', serif;
+  position: relative;
+  z-index: 1;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  background: linear-gradient(120deg, rgba(15, 23, 42, 0.8), rgba(251, 191, 36, 0.18));
+  border: 2px solid #fbbf24;
+  box-shadow: 0 16px 28px rgba(0, 0, 0, 0.45), inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  border-radius: 22px;
+  padding: 1.5rem 2.25rem;
+  max-width: 420px;
+  width: 100%;
+  color: #fef3c7;
+  backdrop-filter: blur(4px);
+}
+
+.headerText {
+  text-align: center;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.4rem;
+  letter-spacing: 1px;
+  color: #fde68a;
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.55);
+}
+
+.owner {
+  margin: 0.25rem 0 0;
+  font-size: 1.05rem;
+  color: #c7d2fe;
+}
+
+.grid {
+  display: grid;
+  gap: 1.35rem;
+  grid-template-columns: 1fr;
+  width: 100%;
+  max-width: 720px;
+}
+
+.card {
+  position: relative;
+  padding: 2.25rem 2.5rem;
+  border-radius: 24px;
+  color: #fefce8;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  text-align: center;
+  border: 2px solid rgba(251, 191, 36, 0.7);
+  box-shadow:
+    0 14px 26px rgba(0, 0, 0, 0.45),
+    0 0 24px rgba(251, 191, 36, 0.24),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+  backdrop-filter: blur(3px);
+}
+
+.card::before {
+  content: "";
+  position: absolute;
+  inset: -18%;
+  background: radial-gradient(circle at 20% 20%, rgba(251, 191, 36, 0.22), transparent 40%),
+    radial-gradient(circle at 80% 0%, rgba(59, 130, 246, 0.18), transparent 38%);
+  opacity: 0.45;
+  z-index: 0;
+}
+
+.cardVariant1 {
+  background: linear-gradient(135deg, rgba(13, 42, 79, 0.9), rgba(78, 0, 99, 0.85));
+}
+
+.cardVariant2 {
+  background: linear-gradient(135deg, rgba(20, 26, 59, 0.92), rgba(12, 83, 89, 0.9));
+}
+
+.cardVariant3 {
+  background: linear-gradient(135deg, rgba(37, 12, 60, 0.9), rgba(190, 24, 93, 0.8));
+}
+
+.cardTitle {
+  position: relative;
+  margin: 0 0 0.5rem;
+  font-size: 1.4rem;
+  color: #fbbf24;
+  text-shadow: 0 2px 6px rgba(0, 0, 0, 0.45);
+  z-index: 1;
+}
+
+.description {
+  position: relative;
+  margin: 0.25rem 0 0.75rem;
+  color: #e0e7ff;
+  font-size: 1rem;
+  line-height: 1.5;
+  z-index: 1;
+}
+
+.price {
+  position: relative;
+  margin: 0;
+  font-weight: 800;
+  color: #fde68a;
+  font-size: 1.05rem;
+  letter-spacing: 0.02em;
+  z-index: 1;
+}
+
+.footerNote {
+  margin: 0.5rem 0 0;
+  color: #c7d2fe;
+  font-weight: bold;
+  letter-spacing: 0.01em;
+}

--- a/src/IconicDragonic.tsx
+++ b/src/IconicDragonic.tsx
@@ -1,0 +1,75 @@
+import { useMemo } from "react";
+import styles from "./IconicDragonic.module.css";
+import { tribeIconicDragonic } from "./tribeIconicDragonic";
+import { BackButton } from "./BackButton";
+import { Item } from "./types";
+import dragonicBackground from "./Iconic Dragonic.png";
+
+type DisplayItem = Item & { finalPrice: number };
+
+function calculateAdjustedPrice(item: Item, priceVariability: number): number {
+  const variability =
+    ((Math.random() * priceVariability) / 100) * item.price;
+  const upOrDown = Math.random() < 0.5 ? -1 : 1;
+  const adjusted = item.price + upOrDown * variability;
+
+  return Math.max(0, Math.round(adjusted));
+}
+
+export function IconicDragonic({ onBack }: { onBack?: () => void }) {
+  const displayItems: DisplayItem[] = useMemo(() => {
+    return tribeIconicDragonic.items
+      .map((item) => ({
+        ...item,
+        finalPrice: calculateAdjustedPrice(item, tribeIconicDragonic.priceVariability),
+      }))
+      .sort((a, b) => a.finalPrice - b.finalPrice);
+  }, []);
+
+  return (
+    <div className={styles.app}>
+      <BackButton
+        onClick={onBack}
+        style={{
+          backgroundColor: "#facc15",
+          borderColor: "#b45309",
+          color: "#3f2a0a",
+          boxShadow: "0 4px 12px rgba(0, 0, 0, 0.35)",
+        }}
+      />
+      <div
+        className={styles.backgroundImage}
+        style={{ backgroundImage: `url(${dragonicBackground})` }}
+      />
+      <main className={styles.content}>
+        <header className={styles.header}>
+          <div className={styles.headerText}>
+            <h1 className={styles.title}>{tribeIconicDragonic.name}</h1>
+            <p className={styles.owner}>
+              Shop Owner: {tribeIconicDragonic.owner}
+            </p>
+          </div>
+        </header>
+
+        <section className={styles.grid} aria-label="Available items">
+          {displayItems.map((item, index) => (
+            <article
+              key={item.name}
+              className={`${styles.card} ${styles[`cardVariant${(index % 3) + 1}`]}`}
+            >
+              <h2 className={styles.cardTitle}>{item.name}</h2>
+              <p className={styles.description}>{item.description}</p>
+              <p className={styles.price}>
+                {item.finalPrice.toLocaleString()} Gold
+              </p>
+            </article>
+          ))}
+        </section>
+
+        <p className={styles.footerNote}>
+          {tribeIconicDragonic.insults[0]}
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -7,6 +7,7 @@ import { ApplegarthGuild } from "./ApplegarthGuild";
 import { ArchivesGuild } from "./ArchivesGuild";
 import { bookBombDataUrl } from "./bookBombImage";
 import { AuntiePattysPies } from "./AuntiePattysPies";
+import { IconicDragonic } from "./IconicDragonic";
 import { PiggyBank } from "./PiggyBank";
 import { NavigationGuild } from "./NavigationGuild";
 import { PearlsPotions } from "./PearlsPotions";
@@ -19,6 +20,7 @@ import bulletsBuffsBeyondImage from "./Bullets Buffs and Beyond.webp";
 import applegarthImage from "./Applegarth.webp";
 import archivesGuildImage from "./Archives Guild.png";
 import auntPattiePieImage from "./Aunt Pattie Pie.png";
+import iconicDragonicImage from "./Iconic Dragonic.png";
 import navigationGuildImage from "./NavigationGuild-ezgif.com-webp-to-png-converter.png";
 import pearlsPotionsImage from "./Pearls Potions.png";
 import findAFriendImage from "./Find a Friend.png";
@@ -107,6 +109,8 @@ export function Map() {
       return <BookBombs onBack={() => setNavigatedTo("")} />;
     case "AuntiePattysPies":
       return <AuntiePattysPies onBack={() => setNavigatedTo("")} />;
+    case "IconicDragonic":
+      return <IconicDragonic onBack={() => setNavigatedTo("")} />;
     case "PiggyBank":
       return <PiggyBank onBack={() => setNavigatedTo("")} />;
     case "NavigationGuild":
@@ -264,6 +268,13 @@ export function Map() {
               delay="45s"
               backgroundColor="rgba(220, 38, 38, 0.9)"
               imageSrc={auntPattiePieImage}
+            />
+            <FloatingButton
+              label="Iconic Dragonic"
+              onClick={() => setNavigatedTo("IconicDragonic")}
+              delay="46.5s"
+              backgroundColor="rgba(250, 204, 21, 0.95)"
+              imageSrc={iconicDragonicImage}
             />
             <FloatingButton
               label="Comedy Gold"

--- a/src/tribeIconicDragonic.ts
+++ b/src/tribeIconicDragonic.ts
@@ -1,0 +1,46 @@
+import { Tribe } from "./types";
+
+export const tribeIconicDragonic: Tribe = {
+  name: "Iconic Dragonic",
+  owner: "Keoki",
+  percentAngry: 0,
+  priceVariability: 5,
+  insults: [""],
+  items: [
+    {
+      name: "Lunar Dragon Wand",
+      price: 300000,
+      description:
+        "Using this wand temporarily changes the user's class level; stats, feats, race, and items stay the same.",
+    },
+    {
+      name: "Solar Dragon Hourglass Necklace",
+      price: 300000,
+      description:
+        "Reverse turn order starting with you; can only be used twice per long rest.",
+    },
+    {
+      name: "Five-Pointed Chromatic Dragonic Crown",
+      price: 300000,
+      description:
+        "Change the crown’s element to fire, ice, acid, lightning, or poison once per day. Any damage received from the chosen element is reflected back to the attacker for that day.",
+    },
+    {
+      name: "Metallic Dragon Anvil and Hammer",
+      price: 300000,
+      description: "Combine any two magical items; effects may vary.",
+    },
+    {
+      name: "Talisman of the Gemstone Dragon",
+      price: 300000,
+      description:
+        "Invert AC; now the hit has to be lower than your AC to hit.",
+    },
+    {
+      name: "Bedlam Earrings of the Floral Dragon",
+      price: 300000,
+      description:
+        "Three switchable modes, each centered on your current location. Dune Mode: a whirlwind of gravel, dirt, and sand gives everyone disadvantage on attacks and checks; as a bonus action, prevent a rock attack that would otherwise drop someone to 0 HP. Morning Born Mode: a thick fog extends 240 feet, reducing all vision except tremor sense to 5 feet; as a bonus action, you can teleport within the fog. Fablehaven Mode: plant life grows rapidly within 360 feet, reducing all movement speeds except flying and hovering to 5 feet; as a bonus action, you can entangle a creature with vines to stop its movement entirely.",
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- add an Iconic Dragonic shop screen with dragon-inspired styling, yellow back navigation, and background art
- introduce Keoki’s Iconic Dragonic inventory data with gold pricing conversions
- wire the new shop into the map with a dedicated navigation button and imagery

## Testing
- npm run build (warnings about existing invalid aria-* attributes in BookBombs.tsx and RunestoneRelay.tsx)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e25fdefbc8329afb9d324dabe0682)