### PR TITLE
Refresh Hug info display and update Provisions Paradise background

### DIFF
--- a/src/HugInfo.module.css
+++ b/src/HugInfo.module.css
@@ -1,129 +1,27 @@
 .app {
-  text-align: center;
   min-height: 100vh;
   position: relative;
-  overflow: hidden;
-}
-
-.backgroundImage {
-  background: url('./Hug info.webp') no-repeat center center fixed;
   display: flex;
-  background-size: cover;
-  opacity: 0.75;
-  margin: 0;
-  z-index: -1;
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-}
-
-.content {
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-  padding: 4rem 2rem 3rem;
-  align-items: center;
-  font-family: 'Times New Roman', serif;
-}
-
-.header {
-  display: flex;
-  align-items: center;
   justify-content: center;
-  gap: 1.5rem;
+  align-items: center;
+  padding: 3rem 1.5rem;
+  background: radial-gradient(circle at 20% 20%, #fff6dd 0%, #f5d9c4 45%, #efc9c9 90%);
+}
+
+.imageFrame {
   background: #ffffff;
-  border: 3px solid #5c1a1a;
-  box-shadow: 8px 8px rgba(0, 0, 0, 0.35);
-  border-radius: 20px;
-  padding: 1.5rem 2rem;
-  max-width: 360px;
+  border: 6px solid #5c1a1a;
+  box-shadow: 12px 12px rgba(0, 0, 0, 0.35);
+  border-radius: 24px;
+  padding: 1rem;
+  max-width: 960px;
+  width: min(92vw, 960px);
+}
+
+.image {
+  display: block;
   width: 100%;
-}
-
-.headerText {
-  text-align: center;
-}
-
-.title {
-  margin: 0;
-  font-size: 2.4rem;
-  color: #5c1a1a;
-}
-
-.owner {
-  margin: 0.2rem 0;
-  font-size: 1.1rem;
-  color: #b94c2e;
-}
-
-.grid {
-  display: grid;
-  gap: 1.25rem;
-  grid-template-columns: 1fr;
-  width: 100%;
-  max-width: 640px;
-}
-
-.card {
-  position: relative;
-  display: inline-block;
-  max-width: 600px;
-  padding: 2.25rem 2.75rem;
-  margin-left: auto;
-  margin-right: auto;
-
-  background: transparent;
-  border: 0;
-  color: #2f1f1d;
-  font-family: monospace;
-  font-size: 24px;
-  font-weight: bolder;
-  text-align: center;
-
-  filter: drop-shadow(6px 6px rgba(0, 0, 0, 0.55));
-}
-
-.card::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(135deg, #fff5f5, #ffe7e7);
-  border: 4px solid #a01818;
-  clip-path: polygon(
-    18% 4%,  82% 4%,
-    96% 50%,
-    82% 96%, 18% 96%,
-    4% 50%
-  );
-
-  z-index: -1;
-  pointer-events: none;
-}
-
-.cardTitle {
-  margin: 0;
-  font-size: 1.25rem;
-  color: #5c1a1a;
-}
-
-.description {
-  margin: 0.35rem 0 0.5rem;
-  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  color: #4b3a35;
-  font-size: 1rem;
-  text-align: center;
-}
-
-.price {
-  margin: 0;
-  font-weight: bold;
-  color: #a01818;
-}
-
-.footerNote {
-  margin: 0.5rem 0 0;
-  color: #5c1a1a;
-  font-weight: bold;
+  height: auto;
+  object-fit: contain;
+  border-radius: 16px;
 }

--- a/src/HugInfo.tsx
+++ b/src/HugInfo.tsx
@@ -1,31 +1,8 @@
-import { useMemo } from "react";
 import styles from "./HugInfo.module.css";
-import { tribeAuntiePattysPies } from "./tribeAuntiePattysPies";
 import { BackButton } from "./BackButton";
-import { Item } from "./types";
 import hugBackground from "./Hug info.webp";
 
-type DisplayItem = Item & { finalPrice: number };
-
-function calculateAdjustedPrice(item: Item, priceVariability: number): number {
-  const variability =
-    ((Math.random() * priceVariability) / 100) * item.price;
-  const upOrDown = Math.random() < 0.5 ? -1 : 1;
-  const adjusted = item.price + upOrDown * variability;
-
-  return Math.max(0, Math.round(adjusted));
-}
-
 export function HugInfo({ onBack }: { onBack?: () => void }) {
-  const displayItems: DisplayItem[] = useMemo(() => {
-    return tribeAuntiePattysPies.items
-      .map((item) => ({
-        ...item,
-        finalPrice: calculateAdjustedPrice(item, tribeAuntiePattysPies.priceVariability),
-      }))
-      .sort((a, b) => a.finalPrice - b.finalPrice);
-  }, []);
-
   return (
     <div className={styles.app}>
       <BackButton
@@ -36,34 +13,13 @@ export function HugInfo({ onBack }: { onBack?: () => void }) {
           backgroundColor: "#facc15",
         }}
       />
-      <div
-        className={styles.backgroundImage}
-        style={{ backgroundImage: `url(${hugBackground})` }}
-      />
-      <main className={styles.content}>
-        <header className={styles.header}>
-          <div className={styles.headerText}>
-            <h1 className={styles.title}>{tribeAuntiePattysPies.name}</h1>
-            <p className={styles.owner}>Shop Owner: {tribeAuntiePattysPies.owner}</p>
-          </div>
-        </header>
-
-        <section className={styles.grid} aria-label="Available items">
-          {displayItems.map((item) => (
-            <article key={item.name} className={styles.card}>
-              <h2 className={styles.cardTitle}>{item.name}</h2>
-              <p className={styles.description}>{item.description}</p>
-              <p className={styles.price}>
-                {item.finalPrice.toLocaleString()} Gold
-              </p>
-            </article>
-          ))}
-        </section>
-
-        <p className={styles.footerNote}>
-          {tribeAuntiePattysPies.insults[0]}
-        </p>
-      </main>
+      <div className={styles.imageFrame}>
+        <img
+          src={hugBackground}
+          alt="Hug information"
+          className={styles.image}
+        />
+      </div>
     </div>
   );
 }

--- a/src/ProvisionsParadise.module.css
+++ b/src/ProvisionsParadise.module.css
@@ -7,7 +7,10 @@
 }
 
 .backgroundImage {
-  background: url("./Provisions Paradise.png") no-repeat center center fixed;
+  background-image: linear-gradient(180deg, rgba(23, 46, 36, 0.28), rgba(23, 46, 36, 0.28)), url("./Provisions Paradise.png");
+  background-repeat: no-repeat;
+  background-position: center;
+  background-attachment: fixed;
   background-size: cover;
   opacity: 0.7;
   position: absolute;


### PR DESCRIPTION
## Summary
- show the Hug info artwork directly in the view without the old item list
- style the Hug info page so the image is framed and keeps its aspect ratio
- layer the Provisions Paradise background image via CSS with a subtle gradient overlay

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e26c991948329807c1726909634e8)