### PR TITLE
Add Jell Bell shop with thematic styling

### DIFF
--- a/src/JellBell.module.css
+++ b/src/JellBell.module.css
@@ -1,0 +1,163 @@
+.app {
+  text-align: center;
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
+  background: radial-gradient(circle at 18% 18%, rgba(241, 245, 249, 0.08), transparent 42%),
+    radial-gradient(circle at 82% 10%, rgba(236, 72, 153, 0.14), transparent 38%),
+    #0b1224;
+}
+
+.backgroundImage {
+  background: url('./Iconic Dragonic.png') center / cover no-repeat fixed;
+  display: flex;
+  opacity: 0.22;
+  margin: 0;
+  z-index: -2;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  filter: saturate(1.15) contrast(1.05);
+}
+
+.backgroundImage::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(14, 116, 144, 0.24), rgba(234, 179, 8, 0.2));
+  z-index: 1;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  padding: 4rem 2rem 3rem;
+  align-items: center;
+  font-family: 'Times New Roman', serif;
+  position: relative;
+  z-index: 1;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  background: linear-gradient(135deg, rgba(12, 74, 110, 0.75), rgba(244, 114, 182, 0.55));
+  border: 2px solid rgba(251, 191, 36, 0.8);
+  box-shadow: 0 16px 28px rgba(0, 0, 0, 0.45), inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  border-radius: 26px;
+  padding: 1.5rem 2.25rem;
+  max-width: 460px;
+  width: 100%;
+  color: #fef3c7;
+  backdrop-filter: blur(5px);
+}
+
+.headerText {
+  text-align: center;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.4rem;
+  letter-spacing: 1px;
+  color: #fde68a;
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.55);
+}
+
+.owner {
+  margin: 0.25rem 0 0;
+  font-size: 1.05rem;
+  color: #bae6fd;
+}
+
+.grid {
+  display: grid;
+  gap: 1.35rem;
+  grid-template-columns: 1fr;
+  width: 100%;
+  max-width: 780px;
+}
+
+.card {
+  position: relative;
+  padding: 2.2rem 2.6rem;
+  border-radius: 999px / 420px;
+  color: #fdf5e6;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  text-align: center;
+  border: 2px solid rgba(251, 191, 36, 0.65);
+  box-shadow:
+    0 16px 32px rgba(0, 0, 0, 0.42),
+    0 0 28px rgba(59, 130, 246, 0.35),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+  backdrop-filter: blur(4px);
+}
+
+.card::before {
+  content: "";
+  position: absolute;
+  inset: -14%;
+  background: radial-gradient(circle at 24% 20%, rgba(251, 191, 36, 0.2), transparent 42%),
+    radial-gradient(circle at 78% 8%, rgba(59, 130, 246, 0.18), transparent 38%);
+  opacity: 0.55;
+  z-index: 0;
+}
+
+.cardVariant1 {
+  background: linear-gradient(135deg, rgba(20, 31, 54, 0.92), rgba(96, 165, 250, 0.78));
+}
+
+.cardVariant2 {
+  background: linear-gradient(135deg, rgba(41, 26, 61, 0.9), rgba(236, 72, 153, 0.76));
+}
+
+.cardVariant3 {
+  background: linear-gradient(135deg, rgba(16, 45, 56, 0.92), rgba(251, 191, 36, 0.72));
+}
+
+.cardVariant4 {
+  background: linear-gradient(135deg, rgba(55, 29, 47, 0.92), rgba(234, 88, 12, 0.78));
+}
+
+.cardTitle {
+  position: relative;
+  margin: 0 0 0.5rem;
+  font-size: 1.4rem;
+  color: #fbbf24;
+  text-shadow: 0 2px 6px rgba(0, 0, 0, 0.45);
+  z-index: 1;
+}
+
+.description {
+  position: relative;
+  margin: 0.25rem 0 0.75rem;
+  color: #e0f2fe;
+  font-size: 1rem;
+  line-height: 1.55;
+  white-space: pre-line;
+  z-index: 1;
+}
+
+.price {
+  position: relative;
+  margin: 0;
+  font-weight: 800;
+  color: #fde68a;
+  font-size: 1.05rem;
+  letter-spacing: 0.02em;
+  text-shadow: 0 1px 6px rgba(0, 0, 0, 0.35);
+  z-index: 1;
+}
+
+.footerNote {
+  margin: 0.5rem 0 0;
+  color: #c7d2fe;
+  font-weight: bold;
+  letter-spacing: 0.01em;
+}

--- a/src/JellBell.tsx
+++ b/src/JellBell.tsx
@@ -1,0 +1,77 @@
+import { useMemo } from "react";
+import styles from "./JellBell.module.css";
+import { BackButton } from "./BackButton";
+import { Item } from "./types";
+import { JellBellItem, tribeJellBell } from "./tribeJellBell";
+import dragonicBackground from "./Iconic Dragonic.png";
+
+type DisplayItem = JellBellItem & { finalPrice: number };
+
+function calculateAdjustedPrice(item: Item, priceVariability: number): number {
+  const variability = ((Math.random() * priceVariability) / 100) * item.price;
+  const upOrDown = Math.random() < 0.5 ? -1 : 1;
+  const adjusted = item.price + upOrDown * variability;
+
+  return Math.max(0, Math.round(adjusted));
+}
+
+export function JellBell({ onBack }: { onBack?: () => void }) {
+  const displayItems: DisplayItem[] = useMemo(() => {
+    return tribeJellBell.items
+      .map((item) => ({
+        ...item,
+        finalPrice:
+          item.price > 0
+            ? calculateAdjustedPrice(item, tribeJellBell.priceVariability)
+            : 0,
+      }))
+      .sort((a, b) => a.finalPrice - b.finalPrice || a.name.localeCompare(b.name));
+  }, []);
+
+  const formatPrice = (item: DisplayItem) => {
+    if (item.priceText) return item.priceText;
+    if (item.price <= 0) return "Included";
+    return `${item.finalPrice.toLocaleString()} Gold`;
+  };
+
+  return (
+    <div className={styles.app}>
+      <BackButton
+        onClick={onBack}
+        style={{
+          backgroundColor: "#facc15",
+          borderColor: "#b45309",
+          color: "#3f2a0a",
+          boxShadow: "0 4px 12px rgba(0, 0, 0, 0.35)",
+        }}
+      />
+      <div
+        className={styles.backgroundImage}
+        style={{ backgroundImage: `url(${dragonicBackground})` }}
+      />
+      <main className={styles.content}>
+        <header className={styles.header}>
+          <div className={styles.headerText}>
+            <h1 className={styles.title}>{tribeJellBell.name}</h1>
+            <p className={styles.owner}>Shop Owner: {tribeJellBell.owner}</p>
+          </div>
+        </header>
+
+        <section className={styles.grid} aria-label="Available items">
+          {displayItems.map((item, index) => (
+            <article
+              key={item.name}
+              className={`${styles.card} ${styles[`cardVariant${(index % 4) + 1}`]}`}
+            >
+              <h2 className={styles.cardTitle}>{item.name}</h2>
+              <p className={styles.description}>{item.description}</p>
+              <p className={styles.price}>{formatPrice(item)}</p>
+            </article>
+          ))}
+        </section>
+
+        <p className={styles.footerNote}>{tribeJellBell.insults[0]}</p>
+      </main>
+    </div>
+  );
+}

--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -8,6 +8,7 @@ import { ArchivesGuild } from "./ArchivesGuild";
 import { bookBombDataUrl } from "./bookBombImage";
 import { AuntiePattysPies } from "./AuntiePattysPies";
 import { IconicDragonic } from "./IconicDragonic";
+import { JellBell } from "./JellBell";
 import { PiggyBank } from "./PiggyBank";
 import { NavigationGuild } from "./NavigationGuild";
 import { PearlsPotions } from "./PearlsPotions";
@@ -50,6 +51,7 @@ import { ProvisionsParadise } from "./ProvisionsParadise";
 import { useEffect, useState } from "react";
 import { HugInfo } from "./HugInfo";
 import hugImage from "./Hug.webp";
+import jellBellImage from "./Jell.webp";
 
 // Remove stray whitespace/newlines from data URIs (defensive)
 function cleanDataUrl(s?: string) {
@@ -111,6 +113,8 @@ export function Map() {
       return <AuntiePattysPies onBack={() => setNavigatedTo("")} />;
     case "IconicDragonic":
       return <IconicDragonic onBack={() => setNavigatedTo("")} />;
+    case "JellBell":
+      return <JellBell onBack={() => setNavigatedTo("")} />;
     case "PiggyBank":
       return <PiggyBank onBack={() => setNavigatedTo("")} />;
     case "NavigationGuild":
@@ -268,6 +272,13 @@ export function Map() {
               delay="45s"
               backgroundColor="rgba(220, 38, 38, 0.9)"
               imageSrc={auntPattiePieImage}
+            />
+            <FloatingButton
+              label="Jell Bell"
+              onClick={() => setNavigatedTo("JellBell")}
+              delay="46.25s"
+              backgroundColor="rgba(250, 204, 21, 0.9)"
+              imageSrc={jellBellImage}
             />
             <FloatingButton
               label="Iconic Dragonic"

--- a/src/tribeJellBell.ts
+++ b/src/tribeJellBell.ts
@@ -1,0 +1,65 @@
+import { Item, Tribe } from "./types";
+
+export interface JellBellItem extends Item {
+  priceText?: string;
+}
+
+export const tribeJellBell: Tribe & { items: JellBellItem[] } = {
+  name: "Jell Bell",
+  owner: "James",
+  percentAngry: 0,
+  priceVariability: 8,
+  insults: ["Ring a bell, roll the dice, and see which slime bounces your way."],
+  items: [
+    {
+      name: "3 Star Bell",
+      price: 1000,
+      description: "Roll a d4, d6, d8, d10, & a d12.",
+    },
+    {
+      name: "4 Star Bell",
+      price: 2500,
+      description: "Roll with advantage.",
+    },
+    {
+      name: "5 Star Bell",
+      price: 4000,
+      description: "Pick a category and its result, then roll for the rest.",
+    },
+    {
+      name: "Fuse two Slimes",
+      price: 500,
+      description: "Blend any two slimes together to see what fusion forms.",
+    },
+    {
+      name: "Slime Size Table",
+      price: 0,
+      priceText: "Included roll table",
+      description: `1 - Tiny, AC: 13, HP: x1\n2 & 3 - Small, AC: 15, HP: x2\n4 - Medium, AC: 17, HP: x3`,
+    },
+    {
+      name: "Slime Temperament",
+      price: 0,
+      priceText: "Included roll table",
+      description: `1 - Slappy, +1 STR\n2 - Zippy, +1 DEX\n3 - Hardy, +1 CON\n4 - Smarty, +1 INT\n5 - Jumpy, +1 WIS\n6 - Happy, +1 CHA`,
+    },
+    {
+      name: "Slime Body Type",
+      price: 0,
+      priceText: "Included roll table",
+      description: `1 - Liquidy, 5 HP, 10 ft Walk, 40 ft Swim\n2 - Bubbly, 10 HP, 40 ft Walk\n3 - Jiggly, 15 HP, 30 ft Walk\n4 - Rubbery, 15 HP, 35 ft Walk, 10 ft Climb\n5 - Sticky, 18 HP, 5 ft Walk, 5 ft Climb, 5 ft Swim\n6 - Bouncy, 20 HP, 25 ft Walk, 20 ft Climb\n7 - Slippery, 22 HP, ∞ ft Walk, but can't stop on its own\n8 - Chunky, 25 HP, 20 ft Walk`,
+    },
+    {
+      name: "Accessories",
+      price: 0,
+      priceText: "Included roll table",
+      description: `1 - Cute Bow: Can telepathically communicate\n2 - An Outfit: Adds +1 to Charisma checks\n3 - Glitter: Leaves a sparkle trail\n4 - Cozy Blanket: It's just a blanket… what a waste\n5 - Snack Pouch: Heals Slime 1d6 once per long rest\n6 - Squeaky Toy: Gives +1 to Performance checks\n7 - Tiny Hat: Advantage on Deception checks\n8 - Jingle Collar: giving +1 to CON SAV\n9 - Friendship Bracelet: BFFs 4ever!\n10 - Slime Plushie: Split into two once per long rest`,
+    },
+    {
+      name: "Elemental Flavor",
+      price: 0,
+      priceText: "Included roll table",
+      description: `1 - Pineapple Slime, Acid Resistance\n2 - Coconut Slime, Bludgeoning Resistance\n3 - Mint Slime, Cold Resistance\n4 - Cherry Slime, Fire Resistance\n5 - Vanilla Slime, Force Resistance\n6 - Lemon Slime, Lightning Resistance\n7 - Grape Slime, Necrotic Resistance\n8 - Durian Slime, Piercing Resistance\n9 - Lime Slime, Poison Resistance\n10 - Plum Slime, Psychic Resistance\n11 - Orange Slime, Radiant Resistance\n12 - Banana Slime, Thunder & Slashing Resistance`,
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- add a Jell Bell shop screen with James as owner, the provided bell and slime roll tables, and gold-formatted pricing
- style the duplicated layout with the Iconic Dragonic background, yellow back button, and oval, color-shifted item cards for contrast
- link the new shop into the world map with its icon and navigation button

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e2811fa048329be24c7aa38d844bd)