### PR TITLE
Adjust Iconic Dragonic background and map placement

### DIFF
--- a/src/IconicDragonic.module.css
+++ b/src/IconicDragonic.module.css
@@ -11,7 +11,7 @@
 .backgroundImage {
   background: center / cover no-repeat;
   display: flex;
-  opacity: 0.18;
+  opacity: 0.32;
   margin: 0;
   z-index: -2;
   position: absolute;
@@ -19,14 +19,14 @@
   left: 0;
   width: 100%;
   height: 100%;
-  filter: saturate(1.2) contrast(1.05);
+  filter: saturate(1.3) contrast(1.12) brightness(1.06);
 }
 
 .backgroundImage::after {
   content: "";
   position: absolute;
   inset: 0;
-  background: linear-gradient(135deg, rgba(14, 116, 144, 0.25), rgba(190, 24, 93, 0.24));
+  background: linear-gradient(135deg, rgba(14, 116, 144, 0.16), rgba(190, 24, 93, 0.14));
   z-index: 1;
 }
 

--- a/src/IconicDragonic.tsx
+++ b/src/IconicDragonic.tsx
@@ -35,6 +35,8 @@ export function IconicDragonic({ onBack }: { onBack?: () => void }) {
           borderColor: "#b45309",
           color: "#3f2a0a",
           boxShadow: "0 4px 12px rgba(0, 0, 0, 0.35)",
+          right: "1.5rem",
+          left: "auto",
         }}
       />
       <div

--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -270,72 +270,72 @@ export function Map() {
               imageSrc={auntPattiePieImage}
             />
             <FloatingButton
-              label="Iconic Dragonic"
-              onClick={() => setNavigatedTo("IconicDragonic")}
-              delay="46.5s"
-              backgroundColor="rgba(250, 204, 21, 0.95)"
-              imageSrc={iconicDragonicImage}
-            />
-            <FloatingButton
               label="Comedy Gold"
               onClick={() => setNavigatedTo("ComedyGold")}
-              delay="48s"
+              delay="51s"
               backgroundColor="rgba(220, 38, 38, 0.9)"
               imageSrc={comedyGoldImage}
              />
              <FloatingButton
               label="Dungeon Crawler Guild"
               onClick={() => setNavigatedTo("DungeonCrawlerGuild")}
-              delay="51s"
+              delay="54s"
               backgroundColor="rgba(220, 38, 38, 0.9)"
               imageSrc={dungeonCrawlerGuildImage}
             />
             <FloatingButton
               label="Find a Friend"
               onClick={() => setNavigatedTo("FindAFriend")}
-              delay="54s"
+              delay="57s"
               backgroundColor="rgba(220, 38, 38, 0.9)"
               imageSrc={findAFriendImage}
             />
             <FloatingButton
               label="Navigation Guild"
               onClick={() => setNavigatedTo("NavigationGuild")}
-              delay="57s"
+              delay="60s"
               backgroundColor="rgba(220, 38, 38, 0.9)"
               imageSrc={navigationGuildImage}
               />
             <FloatingButton
               label="Pearl's Potions"
               onClick={() => setNavigatedTo("PearlsPotions")}
-              delay="60s"
+              delay="63s"
               backgroundColor="rgba(220, 38, 38, 0.9)"
               imageSrc={pearlsPotionsImage}
             />
             <FloatingButton
               label="Provision's Paradise"
               onClick={() => setNavigatedTo("ProvisionsParadise")}
-              delay="63s"
+              delay="66s"
               backgroundColor="rgba(220, 38, 38, 0.9)"
               imageSrc={provisionsParadiseImage}
             />
             <FloatingButton
               label="The Piggy Bank, no hammers inside."
               onClick={() => setNavigatedTo("PiggyBank")}
-              delay="66s"
+              delay="69s"
               backgroundColor="rgba(220, 38, 38, 0.9)"
               imageSrc={piggyBankImage}
             />
             <FloatingButton
               label="Ye Old Donkey"
               onClick={() => setNavigatedTo("YeOldDonkey")}
-              delay="69s"
+              delay="72s"
               backgroundColor="rgba(220, 38, 38, 0.9)"
               imageSrc={yeOldDonkeyImage}
             />
             <FloatingButton
+              label="Iconic Dragonic"
+              onClick={() => setNavigatedTo("IconicDragonic")}
+              delay="73.5s"
+              backgroundColor="rgba(250, 204, 21, 0.95)"
+              imageSrc={iconicDragonicImage}
+            />
+            <FloatingButton
               label="Hug Info"
               onClick={() => setNavigatedTo("HugInfo")}
-              delay="72s"
+              delay="75s"
               backgroundColor="rgba(250, 204, 21, 0.9)"
               imageSrc={hugImage}
             />


### PR DESCRIPTION
## Summary
- brighten the Iconic Dragonic background artwork so the shop image stands out
- move the Iconic Dragonic back button to the top-right for consistency
- reorder the Iconic Dragonic map button to appear just before Hug Info

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e28b806ac83299a2abef24f0bbce1)