### PR TITLE
Adjust Iconic Dragonic layout

### DIFF
--- a/src/IconicDragonic.module.css
+++ b/src/IconicDragonic.module.css
@@ -80,17 +80,17 @@
   gap: 1.35rem;
   grid-template-columns: 1fr;
   width: 100%;
-  max-width: 720px;
+  max-width: 780px;
 }
 
 .card {
   position: relative;
-  padding: 2.25rem 2.5rem;
-  border-radius: 24px;
+  padding: 2.2rem 2.6rem;
+  border-radius: 999px / 420px;
   color: #fefce8;
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   text-align: center;
-  border: 2px solid rgba(251, 191, 36, 0.7);
+  border: 2px solid rgba(251, 191, 36, 0.65);
   box-shadow:
     0 14px 26px rgba(0, 0, 0, 0.45),
     0 0 24px rgba(251, 191, 36, 0.24),

--- a/src/IconicDragonic.tsx
+++ b/src/IconicDragonic.tsx
@@ -35,8 +35,6 @@ export function IconicDragonic({ onBack }: { onBack?: () => void }) {
           borderColor: "#b45309",
           color: "#3f2a0a",
           boxShadow: "0 4px 12px rgba(0, 0, 0, 0.35)",
-          right: "1.5rem",
-          left: "auto",
         }}
       />
       <div


### PR DESCRIPTION
## Summary
- align Iconic Dragonic item cards styling closer to Jell Bell layout
- keep the Iconic Dragonic return button anchored at the top-left for consistency

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ecfac671c8329b3e974243e9fe07e)