### PR TITLE
Group Monster Maker options by category

### DIFF
--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -52,6 +52,8 @@ import { useEffect, useState } from "react";
 import { HugInfo } from "./HugInfo";
 import hugImage from "./Hug.webp";
 import jellBellImage from "./Jell.webp";
+import { MonsterMaker } from "./MonsterMaker";
+import monsterImage from "./Monster.webp";
 
 // Remove stray whitespace/newlines from data URIs (defensive)
 function cleanDataUrl(s?: string) {
@@ -115,6 +117,8 @@ export function Map() {
       return <IconicDragonic onBack={() => setNavigatedTo("")} />;
     case "JellBell":
       return <JellBell onBack={() => setNavigatedTo("")} />;
+    case "MonsterMaker":
+      return <MonsterMaker onBack={() => setNavigatedTo("")} />;
     case "PiggyBank":
       return <PiggyBank onBack={() => setNavigatedTo("")} />;
     case "NavigationGuild":
@@ -349,6 +353,13 @@ export function Map() {
               delay="46.25s"
               backgroundColor="rgba(250, 204, 21, 0.9)"
               imageSrc={jellBellImage}
+            />
+            <FloatingButton
+              label="Make a Monster"
+              onClick={() => setNavigatedTo("MonsterMaker")}
+              delay="46.5s"
+              backgroundColor="rgba(250, 204, 21, 0.95)"
+              imageSrc={monsterImage}
             />
           </div>
         </div>

--- a/src/MonsterMaker.module.css
+++ b/src/MonsterMaker.module.css
@@ -1,0 +1,203 @@
+.app {
+  text-align: center;
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
+  background: radial-gradient(circle at 20% 18%, rgba(24, 24, 27, 0.2), transparent 82%),
+    radial-gradient(circle at 78% 12%, rgba(87, 83, 78, 0.22), transparent 96%),
+    #0b0f1b;
+}
+
+.backgroundImage {
+  background: url("./Monster.webp") center / cover no-repeat fixed;
+  display: flex;
+  opacity: 0.26;
+  margin: 0;
+  z-index: -2;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  filter: saturate(1.1) contrast(1.1);
+}
+
+.backgroundImage::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(234, 179, 8, 0.25), rgba(59, 130, 246, 0.22));
+  mix-blend-mode: screen;
+  z-index: 1;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  padding: 4rem 2rem 3rem;
+  align-items: center;
+  font-family: "Times New Roman", serif;
+  position: relative;
+  z-index: 1;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.65), rgba(250, 204, 21, 0.72));
+  border: 2px solid rgba(234, 179, 8, 0.9);
+  box-shadow: 0 16px 28px rgba(0, 0, 0, 0.45), inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  border-radius: 26px;
+  padding: 1.5rem 2.25rem;
+  max-width: 540px;
+  width: 100%;
+  color: #fef3c7;
+  backdrop-filter: blur(6px);
+}
+
+.headerText {
+  text-align: center;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.4rem;
+  letter-spacing: 1px;
+  color: #fde68a;
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.55);
+}
+
+.owner {
+  margin: 0.25rem 0 0;
+  font-size: 1.05rem;
+  color: #dbeafe;
+}
+
+.grid {
+  display: grid;
+  gap: 1.35rem;
+  grid-template-columns: 1fr;
+  width: 100%;
+  max-width: 860px;
+}
+
+.categories {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  width: 100%;
+}
+
+.categoryBlock {
+  width: 100%;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 22px;
+  border: 1px solid rgba(234, 179, 8, 0.45);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  padding: 1.1rem 1.25rem 1.25rem;
+}
+
+.categoryTitle {
+  margin: 0 0 1rem;
+  color: #fef9c3;
+  letter-spacing: 0.03em;
+  text-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+  font-size: 1.4rem;
+}
+
+.card {
+  position: relative;
+  padding: 2.1rem 2.5rem;
+  border-radius: 999px / 400px;
+  color: #0b0f1b;
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  text-align: center;
+  border: 2px solid rgba(234, 179, 8, 0.85);
+  box-shadow:
+    0 16px 32px rgba(0, 0, 0, 0.42),
+    0 0 26px rgba(234, 179, 8, 0.35),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.24);
+  overflow: hidden;
+  backdrop-filter: blur(4px);
+}
+
+.card::before {
+  content: "";
+  position: absolute;
+  inset: -12%;
+  background: radial-gradient(circle at 24% 20%, rgba(250, 204, 21, 0.18), transparent 42%),
+    radial-gradient(circle at 78% 8%, rgba(59, 130, 246, 0.18), transparent 38%);
+  opacity: 0.7;
+  z-index: 0;
+}
+
+.cardTitle {
+  position: relative;
+  margin: 0 0 0.45rem;
+  font-size: 1.35rem;
+  color: #713f12;
+  text-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+  z-index: 1;
+}
+
+.description {
+  position: relative;
+  margin: 0.25rem 0 0.65rem;
+  color: #111827;
+  font-size: 1rem;
+  line-height: 1.55;
+  white-space: pre-line;
+  z-index: 1;
+  font-weight: 600;
+}
+
+.price {
+  position: relative;
+  margin: 0;
+  font-weight: 800;
+  color: #1f2937;
+  font-size: 1.05rem;
+  letter-spacing: 0.02em;
+  text-shadow: 0 1px 6px rgba(255, 255, 255, 0.25);
+  z-index: 1;
+}
+
+.footerNote {
+  margin: 0.5rem 0 0;
+  color: #fef9c3;
+  font-weight: bold;
+  letter-spacing: 0.01em;
+}
+
+.palette {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+}
+
+.cardStyle0 {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.78), rgba(125, 211, 252, 0.9));
+}
+
+.cardStyle1 {
+  background: linear-gradient(135deg, rgba(255, 237, 213, 0.9), rgba(254, 226, 226, 0.92));
+}
+
+.cardStyle2 {
+  background: linear-gradient(135deg, rgba(219, 234, 254, 0.92), rgba(224, 231, 255, 0.88));
+}
+
+.cardStyle3 {
+  background: linear-gradient(135deg, rgba(254, 243, 199, 0.95), rgba(254, 249, 195, 0.9));
+}
+
+.cardStyle4 {
+  background: linear-gradient(135deg, rgba(220, 252, 231, 0.92), rgba(187, 247, 208, 0.9));
+}
+
+.cardStyle5 {
+  background: linear-gradient(135deg, rgba(233, 213, 255, 0.9), rgba(221, 214, 254, 0.92));
+}

--- a/src/MonsterMaker.tsx
+++ b/src/MonsterMaker.tsx
@@ -1,0 +1,123 @@
+import { useMemo } from "react";
+import styles from "./MonsterMaker.module.css";
+import { BackButton } from "./BackButton";
+import { Item } from "./types";
+import { MonsterMakerItem, tribeMonsterMaker } from "./tribeMonsterMaker";
+import monsterBackground from "./Monster.webp";
+
+type DisplayItem = MonsterMakerItem & { finalPrice: number };
+
+function calculateAdjustedPrice(item: Item, priceVariability: number): number {
+  const variability = ((Math.random() * priceVariability) / 100) * item.price;
+  const upOrDown = Math.random() < 0.5 ? -1 : 1;
+  const adjusted = item.price + upOrDown * variability;
+
+  return Math.max(0, Math.round(adjusted));
+}
+
+const cardPalettes = [
+  styles.cardStyle0,
+  styles.cardStyle1,
+  styles.cardStyle2,
+  styles.cardStyle3,
+  styles.cardStyle4,
+  styles.cardStyle5,
+];
+
+export function MonsterMaker({ onBack }: { onBack?: () => void }) {
+  const groupedItems = useMemo(() => {
+    const categoryOrder = [
+      "Type of Elemental",
+      "Size Options",
+      "Age Category",
+      "Personality Customization (Optional)",
+      "Additional Accessories",
+    ];
+
+    const categoryMap: Record<string, DisplayItem[]> = {};
+    const seenOrder: string[] = [];
+
+    tribeMonsterMaker.items.forEach((item) => {
+      const category = item.category || "Other";
+      if (!categoryMap[category]) {
+        categoryMap[category] = [];
+        seenOrder.push(category);
+      }
+      categoryMap[category].push({
+        ...item,
+        finalPrice:
+          item.price > 0
+            ? calculateAdjustedPrice(item, tribeMonsterMaker.priceVariability)
+            : 0,
+      });
+    });
+
+    const orderedCategories = [
+      ...categoryOrder.filter((cat) => seenOrder.includes(cat)),
+      ...seenOrder.filter((cat) => !categoryOrder.includes(cat)),
+    ];
+
+    return orderedCategories.map((category) => ({
+      category,
+      items: categoryMap[category].sort(
+        (a, b) => a.finalPrice - b.finalPrice || a.name.localeCompare(b.name)
+      ),
+    }));
+  }, []);
+
+  const formatPrice = (item: DisplayItem) => {
+    if (item.priceText) return item.priceText;
+    if (item.price <= 0) return "Included";
+    return `${item.finalPrice.toLocaleString()} Gold`;
+  };
+
+  return (
+    <div className={styles.app}>
+      <BackButton
+        onClick={onBack}
+        style={{
+          backgroundColor: "#facc15",
+          borderColor: "#854d0e",
+          color: "#422006",
+          boxShadow: "0 4px 12px rgba(0, 0, 0, 0.35)",
+        }}
+      />
+      <div
+        className={styles.backgroundImage}
+        style={{ backgroundImage: `url(${monsterBackground})` }}
+      />
+      <main className={styles.content}>
+        <header className={styles.header}>
+          <div className={styles.headerText}>
+            <h1 className={styles.title}>{tribeMonsterMaker.name}</h1>
+            <p className={styles.owner}>Shop Owner: {tribeMonsterMaker.owner}</p>
+          </div>
+        </header>
+
+        <div className={styles.categories}>
+          {groupedItems.map(({ category, items }) => (
+            <section key={category} className={styles.categoryBlock} aria-label={category}>
+              <h2 className={styles.categoryTitle}>{category}</h2>
+              <div className={styles.grid}>
+                {items.map((item, index) => (
+                  <article
+                    key={item.name}
+                    className={`${styles.card} ${
+                      cardPalettes[index % cardPalettes.length]
+                    }`}
+                  >
+                    <h3 className={styles.cardTitle}>{item.name}</h3>
+                    <p className={styles.description}>{item.description}</p>
+                    <p className={styles.price}>{formatPrice(item)}</p>
+                  </article>
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+
+        <p className={styles.footerNote}>{tribeMonsterMaker.insults[0]}</p>
+      </main>
+    </div>
+  );
+}

--- a/src/tribeMonsterMaker.ts
+++ b/src/tribeMonsterMaker.ts
@@ -1,0 +1,172 @@
+import { Item, Tribe } from "./types";
+
+export interface MonsterMakerItem extends Item {
+  priceText?: string;
+  category: string;
+}
+
+export const tribeMonsterMaker: Tribe & { items: MonsterMakerItem[] } = {
+  name: "Make a Monster",
+  owner: "Mertal",
+  percentAngry: 0,
+  priceVariability: 10,
+  insults: ["If you can dream it, we can bolt it together and make it roar."],
+  items: [
+    {
+      category: "Type of Elemental",
+      name: "Water Elemental",
+      price: 1000,
+      description: "Speed: 30 ft, Swim: 90 ft",
+    },
+    {
+      category: "Type of Elemental",
+      name: "Air Elemental",
+      price: 1200,
+      description: "Speed: 90 ft, Fly: 60 ft",
+    },
+    {
+      category: "Type of Elemental",
+      name: "Earth Elemental",
+      price: 1250,
+      description: "Speed: 30 ft, Burrow: 15 ft",
+    },
+    {
+      category: "Type of Elemental",
+      name: "Ice Elemental",
+      price: 1400,
+      description: "Speed: 30 ft, Glide: 20 ft",
+    },
+    {
+      category: "Type of Elemental",
+      name: "Fire Elemental",
+      price: 1500,
+      description: "Speed: 50 ft",
+    },
+    {
+      category: "Type of Elemental",
+      name: "Metal Elemental",
+      price: 1600,
+      description: "Speed: 25 ft",
+    },
+    {
+      category: "Type of Elemental",
+      name: "Lightning Elemental",
+      price: 1750,
+      description: "Speed: 60 ft",
+    },
+    {
+      category: "Type of Elemental",
+      name: "Cosmic (Arcane) Elemental",
+      price: 3000,
+      description: "Speed: 15 ft, Swim: 15 ft, Climb: 15 ft, Fly: 15 ft, Burrow: 15 ft",
+    },
+    {
+      category: "Size Options",
+      name: "Tiny",
+      price: 500,
+      description: "AC: 13, HP: 1 to Age HP",
+    },
+    {
+      category: "Size Options",
+      name: "Small",
+      price: 1000,
+      description: "AC: 15, HP: 2 to Age HP",
+    },
+    {
+      category: "Size Options",
+      name: "Medium",
+      price: 2000,
+      description: "AC: 17, HP: 3 to Age HP, Mountable",
+    },
+    {
+      category: "Age Category",
+      name: "Young",
+      price: 800,
+      description: "HP: 30, Susceptible, friendly",
+    },
+    {
+      category: "Age Category",
+      name: "Adult",
+      price: 1200,
+      description: "HP: 60, Willful, Obedience",
+    },
+    {
+      category: "Age Category",
+      name: "Elder",
+      price: 2500,
+      description: "HP: 90, Independent yet powerful, gains AOE attacks",
+    },
+    {
+      category: "Personality Customization (Optional)",
+      name: "Fierce",
+      price: 0,
+      priceText: "Included personality: +2 STR",
+      description: "Personality customization",
+    },
+    {
+      category: "Personality Customization (Optional)",
+      name: "Nimble",
+      price: 0,
+      priceText: "Included personality: +2 DEX",
+      description: "Personality customization",
+    },
+    {
+      category: "Personality Customization (Optional)",
+      name: "Resilient",
+      price: 0,
+      priceText: "Included personality: +2 CON",
+      description: "Personality customization",
+    },
+    {
+      category: "Personality Customization (Optional)",
+      name: "Keen",
+      price: 0,
+      priceText: "Included personality: +2 INT",
+      description: "Personality customization",
+    },
+    {
+      category: "Personality Customization (Optional)",
+      name: "Wise",
+      price: 0,
+      priceText: "Included personality: +2 WIS",
+      description: "Personality customization",
+    },
+    {
+      category: "Personality Customization (Optional)",
+      name: "Charming",
+      price: 0,
+      priceText: "Included personality: +2 CHA",
+      description: "Personality customization",
+    },
+    {
+      category: "Additional Accessories",
+      name: "Make it glow!",
+      price: 800,
+      description: "Emits a faint glow, illuminating a 30 ft radius",
+    },
+    {
+      category: "Additional Accessories",
+      name: "Friendship Bracelet",
+      price: 1500,
+      description: "Grants minor regeneration restoring heal while not in combat.",
+    },
+    {
+      category: "Additional Accessories",
+      name: "Any Color Bow",
+      price: 1800,
+      description: "Allows telepathic communication with the elemental, up to 1 mile",
+    },
+    {
+      category: "Additional Accessories",
+      name: "Power Snack",
+      price: 2000,
+      description: "Boosts elemental attacks, increasing damage dice by one level (e.g., d6 to d8, d8 to d10)",
+    },
+    {
+      category: "Additional Accessories",
+      name: "Toasts Besties Scarf",
+      price: 3000,
+      description: "Allows the elemental to take half of the damage dealt to its bonded owner, usable once per short rest.",
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- group Monster Maker options by build-a-bear style categories with headings for each batch
- keep item pricing in Gold with oval palette cards under each category section
- retain yellow navigation/back buttons and Monster-themed styling

## Testing
- npm test -- --watch=false

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ecf28b4c88329b32a7755abc71c8c)