### PR TITLE
Fix MonsterMaker category typing

### DIFF
--- a/src/MonsterMaker.tsx
+++ b/src/MonsterMaker.tsx
@@ -37,7 +37,7 @@ export function MonsterMaker({ onBack }: { onBack?: () => void }) {
     const categoryMap: Record<string, DisplayItem[]> = {};
     const seenOrder: string[] = [];
 
-    tribeMonsterMaker.items.forEach((item) => {
+    tribeMonsterMaker.items.forEach((item: MonsterMakerItem) => {
       const category = item.category || "Other";
       if (!categoryMap[category]) {
         categoryMap[category] = [];
@@ -45,6 +45,7 @@ export function MonsterMaker({ onBack }: { onBack?: () => void }) {
       }
       categoryMap[category].push({
         ...item,
+        category,
         finalPrice:
           item.price > 0
             ? calculateAdjustedPrice(item, tribeMonsterMaker.priceVariability)


### PR DESCRIPTION
## Summary
- ensure MonsterMaker items are treated as MonsterMakerItem entries with categories
- preserve category when building display items for rendering

## Testing
- CI=true npm test -- --watch=false


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ed1de4a588329a8017a5aa206a2df)