### PR TITLE
Add Paws, Claws, & Maws shop variant

### DIFF
--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -54,6 +54,8 @@ import hugImage from "./Hug.webp";
 import jellBellImage from "./Jell.webp";
 import { MonsterMaker } from "./MonsterMaker";
 import monsterImage from "./Monster.webp";
+import { PawsClawsMaws } from "./PawsClawsMaws";
+import pawsClawsMawsImage from "./Paws, Claws, & Maws.png";
 
 // Remove stray whitespace/newlines from data URIs (defensive)
 function cleanDataUrl(s?: string) {
@@ -119,6 +121,8 @@ export function Map() {
       return <JellBell onBack={() => setNavigatedTo("")} />;
     case "MonsterMaker":
       return <MonsterMaker onBack={() => setNavigatedTo("")} />;
+    case "PawsClawsMaws":
+      return <PawsClawsMaws onBack={() => setNavigatedTo("")} />;
     case "PiggyBank":
       return <PiggyBank onBack={() => setNavigatedTo("")} />;
     case "NavigationGuild":
@@ -360,6 +364,13 @@ export function Map() {
               delay="46.5s"
               backgroundColor="rgba(250, 204, 21, 0.95)"
               imageSrc={monsterImage}
+            />
+            <FloatingButton
+              label="Paws, Claws, & Maws"
+              onClick={() => setNavigatedTo("PawsClawsMaws")}
+              delay="46.75s"
+              backgroundColor="rgba(250, 204, 21, 0.95)"
+              imageSrc={pawsClawsMawsImage}
             />
           </div>
         </div>

--- a/src/PawsClawsMaws.module.css
+++ b/src/PawsClawsMaws.module.css
@@ -1,0 +1,167 @@
+.app {
+  text-align: center;
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
+  background: radial-gradient(circle at 16% 18%, rgba(255, 237, 213, 0.08), transparent 92%),
+    radial-gradient(circle at 82% 12%, rgba(190, 242, 100, 0.12), transparent 98%),
+    #0c121500;
+}
+
+.backgroundImage {
+  background: url('./Paws, Claws, & Maws.png') center / cover no-repeat fixed;
+  display: flex;
+  opacity: 0.2;
+  margin: 0;
+  z-index: -2;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  filter: saturate(1.05) contrast(1.04);
+}
+
+.backgroundImage::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(52, 101, 36, 0.26), rgba(220, 38, 38, 0.22));
+  z-index: 1;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  padding: 4rem 2rem 3rem;
+  align-items: center;
+  font-family: 'Times New Roman', serif;
+  position: relative;
+  z-index: 1;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  background: linear-gradient(135deg, rgba(52, 101, 36, 0.78), rgba(226, 120, 68, 0.62));
+  border: 2px solid rgba(234, 179, 8, 0.78);
+  box-shadow: 0 16px 28px rgba(0, 0, 0, 0.42), inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  border-radius: 26px;
+  padding: 1.5rem 2.25rem;
+  max-width: 480px;
+  width: 100%;
+  color: #fef3c7;
+  backdrop-filter: blur(5px);
+}
+
+.headerText {
+  text-align: center;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.45rem;
+  letter-spacing: 1px;
+  color: #fde68a;
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.52);
+}
+
+.owner {
+  margin: 0.25rem 0 0;
+  font-size: 1.05rem;
+  color: #dcfce7;
+}
+
+.grid {
+  display: grid;
+  gap: 1.35rem;
+  grid-template-columns: 1fr;
+  width: 100%;
+  max-width: 780px;
+}
+
+.card {
+  position: relative;
+  padding: 2.15rem 2.6rem;
+  border-radius: 999px / 420px;
+  color: #fef9e6;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  text-align: center;
+  border: 2px solid rgba(234, 179, 8, 0.7);
+  box-shadow:
+    0 16px 32px rgba(0, 0, 0, 0.4),
+    0 0 24px rgba(220, 38, 38, 0.28),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+  backdrop-filter: blur(5px);
+}
+
+.card::before {
+  content: "";
+  position: absolute;
+  inset: -16%;
+  background: radial-gradient(circle at 22% 18%, rgba(251, 191, 36, 0.2), transparent 42%),
+    radial-gradient(circle at 78% 8%, rgba(74, 222, 128, 0.16), transparent 36%);
+  opacity: 0.55;
+  z-index: 0;
+}
+
+.cardPalette0 {
+  background: linear-gradient(135deg, rgba(26, 46, 22, 0.9), rgba(74, 222, 128, 0.72));
+}
+
+.cardPalette1 {
+  background: linear-gradient(135deg, rgba(82, 32, 15, 0.88), rgba(234, 179, 8, 0.7));
+}
+
+.cardPalette2 {
+  background: linear-gradient(135deg, rgba(26, 38, 72, 0.9), rgba(251, 146, 60, 0.7));
+}
+
+.cardPalette3 {
+  background: linear-gradient(135deg, rgba(32, 64, 50, 0.92), rgba(239, 68, 68, 0.68));
+}
+
+.cardPalette4 {
+  background: linear-gradient(135deg, rgba(54, 26, 39, 0.9), rgba(74, 158, 255, 0.65));
+}
+
+.cardTitle {
+  position: relative;
+  margin: 0 0 0.5rem;
+  font-size: 1.4rem;
+  color: #fcd34d;
+  text-shadow: 0 2px 6px rgba(0, 0, 0, 0.44);
+  z-index: 1;
+}
+
+.description {
+  position: relative;
+  margin: 0.25rem 0 0.75rem;
+  color: #f1f5f9;
+  font-size: 1rem;
+  line-height: 1.55;
+  white-space: pre-line;
+  z-index: 1;
+}
+
+.price {
+  position: relative;
+  margin: 0;
+  font-weight: 800;
+  color: #fef3c7;
+  font-size: 1.05rem;
+  letter-spacing: 0.02em;
+  text-shadow: 0 1px 6px rgba(0, 0, 0, 0.33);
+  z-index: 1;
+}
+
+.footerNote {
+  margin: 0.5rem 0 0;
+  color: #f9e2af;
+  font-weight: bold;
+  letter-spacing: 0.01em;
+}

--- a/src/PawsClawsMaws.tsx
+++ b/src/PawsClawsMaws.tsx
@@ -1,0 +1,85 @@
+import { useMemo } from "react";
+import styles from "./PawsClawsMaws.module.css";
+import { BackButton } from "./BackButton";
+import { Item } from "./types";
+import { PawsClawsMawsItem, tribePawsClawsMaws } from "./tribePawsClawsMaws";
+import pawsClawsMawsBackground from "./Paws, Claws, & Maws.png";
+
+type DisplayItem = PawsClawsMawsItem & { finalPrice: number };
+
+function calculateAdjustedPrice(item: Item, priceVariability: number): number {
+  const variability = ((Math.random() * priceVariability) / 100) * item.price;
+  const upOrDown = Math.random() < 0.5 ? -1 : 1;
+  const adjusted = item.price + upOrDown * variability;
+
+  return Math.max(0, Math.round(adjusted));
+}
+
+const cardPalettes = [
+  styles.cardPalette0,
+  styles.cardPalette1,
+  styles.cardPalette2,
+  styles.cardPalette3,
+  styles.cardPalette4,
+];
+
+export function PawsClawsMaws({ onBack }: { onBack?: () => void }) {
+  const displayItems: DisplayItem[] = useMemo(() => {
+    return tribePawsClawsMaws.items
+      .map((item) => ({
+        ...item,
+        finalPrice:
+          item.price > 0
+            ? calculateAdjustedPrice(item, tribePawsClawsMaws.priceVariability)
+            : 0,
+      }))
+      .sort((a, b) => a.finalPrice - b.finalPrice || a.name.localeCompare(b.name));
+  }, []);
+
+  const formatPrice = (item: DisplayItem) => {
+    if (item.priceText) return item.priceText;
+    if (item.price <= 0) return "Included";
+    return `${item.finalPrice.toLocaleString()} Gold`;
+  };
+
+  return (
+    <div className={styles.app}>
+      <BackButton
+        onClick={onBack}
+        style={{
+          backgroundColor: "#facc15",
+          borderColor: "#a16207",
+          color: "#422006",
+          boxShadow: "0 4px 12px rgba(0, 0, 0, 0.35)",
+        }}
+      />
+      <div
+        className={styles.backgroundImage}
+        style={{ backgroundImage: `url(${pawsClawsMawsBackground})` }}
+      />
+      <main className={styles.content}>
+        <header className={styles.header}>
+          <div className={styles.headerText}>
+            <h1 className={styles.title}>{tribePawsClawsMaws.name}</h1>
+            <p className={styles.owner}>Shop Owner: {tribePawsClawsMaws.owner}</p>
+          </div>
+        </header>
+
+        <section className={styles.grid} aria-label="Available items">
+          {displayItems.map((item, index) => (
+            <article
+              key={item.name}
+              className={`${styles.card} ${cardPalettes[index % cardPalettes.length]}`}
+            >
+              <h2 className={styles.cardTitle}>{item.name}</h2>
+              <p className={styles.description}>{item.description}</p>
+              <p className={styles.price}>{formatPrice(item)}</p>
+            </article>
+          ))}
+        </section>
+
+        <p className={styles.footerNote}>{tribePawsClawsMaws.insults[0]}</p>
+      </main>
+    </div>
+  );
+}

--- a/src/tribePawsClawsMaws.ts
+++ b/src/tribePawsClawsMaws.ts
@@ -1,0 +1,37 @@
+import { Item, Tribe } from "./types";
+
+export interface PawsClawsMawsItem extends Item {
+  priceText?: string;
+}
+
+export const tribePawsClawsMaws: Tribe & { items: PawsClawsMawsItem[] } = {
+  name: "Paws, Claws, & Maws",
+  owner: "Wah",
+  percentAngry: 0,
+  priceVariability: 6,
+  insults: [
+    "Each critter is hand-raised—watch your fingers when you give them a boop.",
+  ],
+  items: [
+    {
+      name: "Baby Basilisk",
+      price: 100,
+      description: "A sleepy hatchling with curious eyes and a fondness for sunny rocks.",
+    },
+    {
+      name: "Chimera Chick",
+      price: 100,
+      description: "A tiny trio-in-one with a purr, a bleat, and a chirp in one breath.",
+    },
+    {
+      name: "Displacer Kitten",
+      price: 100,
+      description: "Two tails, eight lives, and a talent for vanishing at snack time.",
+    },
+    {
+      name: "Faerie Chest Weasel",
+      price: 100,
+      description: "Guardian of small treasures with a glitter-dusted giggle.",
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- add a new Paws, Claws, & Maws shop modeled after Jell Bell with its own yellow back button and contrasting oval card palettes
- create dedicated tribe data for the new shop and use the Paws, Claws, & Maws artwork as the background
- wire the shop into the map with a floating button alongside the other pet-focused locations

## Testing
- npm test -- --watch=false

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ed3dd0e1483299e61f38ed6555c73)