### PR TITLE
Add Valhalla Mart shop with distinct styling

### DIFF
--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -58,6 +58,8 @@ import { PawsClawsMaws } from "./PawsClawsMaws";
 import pawsClawsMawsImage from "./Paws, Claws, & Maws.png";
 import { MichaelsMount } from "./MichaelsMount";
 import mountsImage from "./Mounts.webp";
+import { ValhallaMart } from "./ValhallaMart";
+import valhallaMartImage from "./Valhalla Mart.png";
 
 // Remove stray whitespace/newlines from data URIs (defensive)
 function cleanDataUrl(s?: string) {
@@ -127,6 +129,8 @@ export function Map() {
       return <PawsClawsMaws onBack={() => setNavigatedTo("")} />;
     case "MichaelsMount":
       return <MichaelsMount onBack={() => setNavigatedTo("")} />;
+    case "ValhallaMart":
+      return <ValhallaMart onBack={() => setNavigatedTo("")} />;
     case "PiggyBank":
       return <PiggyBank onBack={() => setNavigatedTo("")} />;
     case "NavigationGuild":
@@ -376,12 +380,19 @@ export function Map() {
               backgroundColor="rgba(250, 204, 21, 0.95)"
               imageSrc={pawsClawsMawsImage}
              />
-             <FloatingButton
+            <FloatingButton
               label="Michael's Mount"
               onClick={() => setNavigatedTo("MichaelsMount")}
               delay="46.75s"
               backgroundColor="rgba(250, 204, 21, 0.95)"
               imageSrc={mountsImage}
+            />
+            <FloatingButton
+              label="Valhalla Mart"
+              onClick={() => setNavigatedTo("ValhallaMart")}
+              delay="47s"
+              backgroundColor="rgba(250, 204, 21, 0.95)"
+              imageSrc={valhallaMartImage}
             />
           </div>
         </div>

--- a/src/ValhallaMart.module.css
+++ b/src/ValhallaMart.module.css
@@ -1,0 +1,169 @@
+.app {
+  text-align: center;
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
+  background: radial-gradient(circle at 12% 20%, rgba(255, 225, 176, 0.1), transparent 80%),
+    radial-gradient(circle at 88% 18%, rgba(125, 210, 255, 0.12), transparent 85%),
+    radial-gradient(circle at 50% 70%, rgba(255, 255, 255, 0.08), transparent 72%),
+    #0b122400;
+}
+
+.backgroundImage {
+  background: url('./Valhalla Mart.png') center / cover no-repeat fixed;
+  display: flex;
+  opacity: 0.24;
+  margin: 0;
+  z-index: -2;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  filter: saturate(1.15) contrast(1.05);
+}
+
+.backgroundImage::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(255, 200, 124, 0.22), rgba(111, 139, 255, 0.22));
+  z-index: 1;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  padding: 4rem 2rem 3rem;
+  align-items: center;
+  font-family: 'Times New Roman', serif;
+  position: relative;
+  z-index: 1;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  background: linear-gradient(135deg, rgba(255, 214, 153, 0.8), rgba(137, 189, 255, 0.7));
+  border: 2px solid rgba(250, 204, 21, 0.85);
+  box-shadow: 0 16px 28px rgba(0, 0, 0, 0.45), inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  border-radius: 26px;
+  padding: 1.5rem 2.25rem;
+  max-width: 460px;
+  width: 100%;
+  color: #0b0a0a;
+  backdrop-filter: blur(5px);
+}
+
+.headerText {
+  text-align: center;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.4rem;
+  letter-spacing: 1px;
+  color: #1d1a10;
+  text-shadow: 0 2px 8px rgba(255, 255, 255, 0.25);
+}
+
+.owner {
+  margin: 0.25rem 0 0;
+  font-size: 1.05rem;
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.grid {
+  display: grid;
+  gap: 1.35rem;
+  grid-template-columns: 1fr;
+  width: 100%;
+  max-width: 780px;
+}
+
+.card {
+  position: relative;
+  padding: 2.2rem 2.6rem;
+  border-radius: 999px / 420px;
+  color: #0f172a;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  text-align: center;
+  border: 2px solid rgba(255, 255, 255, 0.7);
+  box-shadow:
+    0 16px 32px rgba(0, 0, 0, 0.32),
+    0 0 24px rgba(15, 23, 42, 0.22),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.14);
+  overflow: hidden;
+  backdrop-filter: blur(6px);
+}
+
+.card::before {
+  content: "";
+  position: absolute;
+  inset: -14%;
+  background: radial-gradient(circle at 24% 20%, rgba(255, 255, 255, 0.18), transparent 42%),
+    radial-gradient(circle at 78% 8%, rgba(0, 0, 0, 0.12), transparent 38%);
+  opacity: 0.45;
+  z-index: 0;
+}
+
+.cardVariant1 {
+  background: linear-gradient(135deg, rgba(38, 70, 83, 0.9), rgba(233, 196, 106, 0.78));
+  color: #0b1b2a;
+}
+
+.cardVariant2 {
+  background: linear-gradient(135deg, rgba(231, 111, 81, 0.9), rgba(244, 162, 97, 0.8));
+  color: #2f0a05;
+}
+
+.cardVariant3 {
+  background: linear-gradient(135deg, rgba(42, 157, 143, 0.9), rgba(233, 196, 106, 0.82));
+  color: #0a1f1c;
+}
+
+.cardVariant4 {
+  background: linear-gradient(135deg, rgba(94, 129, 172, 0.9), rgba(244, 162, 97, 0.82));
+  color: #0b1224;
+}
+
+.cardTitle {
+  position: relative;
+  margin: 0 0 0.5rem;
+  font-size: 1.4rem;
+  color: #faf089;
+  text-shadow: 0 2px 6px rgba(0, 0, 0, 0.35);
+  z-index: 1;
+}
+
+.description {
+  position: relative;
+  margin: 0.25rem 0 0.75rem;
+  color: #f8fafc;
+  font-size: 1rem;
+  line-height: 1.55;
+  white-space: pre-line;
+  z-index: 1;
+}
+
+.price {
+  position: relative;
+  margin: 0;
+  font-weight: 800;
+  color: #fefce8;
+  font-size: 1.05rem;
+  letter-spacing: 0.02em;
+  text-shadow: 0 1px 6px rgba(0, 0, 0, 0.25);
+  z-index: 1;
+}
+
+.footerNote {
+  margin: 0.5rem 0 0;
+  color: #0f172a;
+  font-weight: bold;
+  letter-spacing: 0.01em;
+}

--- a/src/ValhallaMart.tsx
+++ b/src/ValhallaMart.tsx
@@ -1,0 +1,77 @@
+import { useMemo } from "react";
+import styles from "./ValhallaMart.module.css";
+import { BackButton } from "./BackButton";
+import { Item } from "./types";
+import { ValhallaMartItem, tribeValhallaMart } from "./tribeValhallaMart";
+import valhallaBackground from "./Valhalla Mart.png";
+
+type DisplayItem = ValhallaMartItem & { finalPrice: number };
+
+function calculateAdjustedPrice(item: Item, priceVariability: number): number {
+  const variability = ((Math.random() * priceVariability) / 100) * item.price;
+  const upOrDown = Math.random() < 0.5 ? -1 : 1;
+  const adjusted = item.price + upOrDown * variability;
+
+  return Math.max(0, Math.round(adjusted));
+}
+
+export function ValhallaMart({ onBack }: { onBack?: () => void }) {
+  const displayItems: DisplayItem[] = useMemo(() => {
+    return tribeValhallaMart.items
+      .map((item) => ({
+        ...item,
+        finalPrice:
+          item.price > 0
+            ? calculateAdjustedPrice(item, tribeValhallaMart.priceVariability)
+            : 0,
+      }))
+      .sort((a, b) => a.finalPrice - b.finalPrice || a.name.localeCompare(b.name));
+  }, []);
+
+  const formatPrice = (item: DisplayItem) => {
+    if (item.priceText) return item.priceText;
+    if (item.price <= 0) return "Included";
+    return `${item.finalPrice.toLocaleString()} Gold`;
+  };
+
+  return (
+    <div className={styles.app}>
+      <BackButton
+        onClick={onBack}
+        style={{
+          backgroundColor: "#facc15",
+          borderColor: "#b45309",
+          color: "#3f2a0a",
+          boxShadow: "0 4px 12px rgba(0, 0, 0, 0.35)",
+        }}
+      />
+      <div
+        className={styles.backgroundImage}
+        style={{ backgroundImage: `url(${valhallaBackground})` }}
+      />
+      <main className={styles.content}>
+        <header className={styles.header}>
+          <div className={styles.headerText}>
+            <h1 className={styles.title}>{tribeValhallaMart.name}</h1>
+            <p className={styles.owner}>Shop Owner: {tribeValhallaMart.owner}</p>
+          </div>
+        </header>
+
+        <section className={styles.grid} aria-label="Available items">
+          {displayItems.map((item, index) => (
+            <article
+              key={item.name}
+              className={`${styles.card} ${styles[`cardVariant${(index % 4) + 1}`]}`}
+            >
+              <h2 className={styles.cardTitle}>{item.name}</h2>
+              <p className={styles.description}>{item.description}</p>
+              <p className={styles.price}>{formatPrice(item)}</p>
+            </article>
+          ))}
+        </section>
+
+        <p className={styles.footerNote}>{tribeValhallaMart.insults[0]}</p>
+      </main>
+    </div>
+  );
+}

--- a/src/tribeValhallaMart.ts
+++ b/src/tribeValhallaMart.ts
@@ -1,0 +1,43 @@
+import { Item, Tribe } from "./types";
+
+export interface ValhallaMartItem extends Item {
+  priceText?: string;
+}
+
+export const tribeValhallaMart: Tribe & { items: ValhallaMartItem[] } = {
+  name: "Valhalla Mart",
+  owner: "Victor",
+  percentAngry: 0,
+  priceVariability: 8,
+  insults: ["Heroes never fall empty-handed—equip yourself for the next saga."],
+  items: [
+    {
+      name: "Blast from the Past",
+      price: 10000,
+      description: "Take an item from a previous character and add it to your current one.",
+    },
+    {
+      name: "Gjallarhorn Replica",
+      price: 10000,
+      description:
+        "A small horn that, when blown, can intimidate enemies or rally NPCs, signaling a call to bravery or retreat.",
+    },
+    {
+      name: "Langskip Whistle",
+      price: 10000,
+      description:
+        "A magical whistle that summons a spectral langskip that moves faster with each character you've lost.",
+    },
+    {
+      name: "Soul-bound Compass",
+      price: 10000,
+      description: "This compass points towards the location of significant or unfinished quests of fallen heroes.",
+    },
+    {
+      name: "Harald Pendant",
+      price: 10000,
+      description:
+        "Allows the wearer to briefly become a spectral version of a fallen hero for 10 minutes once per long rest.",
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- add a Valhalla Mart shop that mirrors the Jell Bell layout with Valhalla-themed colors and oval cards
- wire the new shop into the map navigation after Michael's Mount and reuse the Valhalla Mart artwork

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ed772def0832986f419ea82ed7325)