### PR TITLE
Tighten shop card layouts and swap monster button

### DIFF
--- a/src/IconicDragonic.module.css
+++ b/src/IconicDragonic.module.css
@@ -78,15 +78,16 @@
 .grid {
   display: grid;
   gap: 1.35rem;
-  grid-template-columns: 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   width: 100%;
-  max-width: 780px;
+  max-width: 920px;
+  justify-items: center;
 }
 
 .card {
   position: relative;
-  padding: 2.2rem 2.6rem;
-  border-radius: 999px / 420px;
+  padding: 1.35rem 1.6rem;
+  border-radius: 26px;
   color: #fefce8;
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   text-align: center;
@@ -97,6 +98,8 @@
     inset 0 0 0 1px rgba(255, 255, 255, 0.08);
   overflow: hidden;
   backdrop-filter: blur(3px);
+  width: 100%;
+  max-width: 560px;
 }
 
 .card::before {

--- a/src/JellBell.module.css
+++ b/src/JellBell.module.css
@@ -78,15 +78,16 @@
 .grid {
   display: grid;
   gap: 1.35rem;
-  grid-template-columns: 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   width: 100%;
-  max-width: 780px;
+  max-width: 920px;
+  justify-items: center;
 }
 
 .card {
   position: relative;
-  padding: 2.2rem 2.6rem;
-  border-radius: 999px / 420px;
+  padding: 1.4rem 1.65rem;
+  border-radius: 26px;
   color: #fdf5e6;
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   text-align: center;
@@ -97,6 +98,8 @@
     inset 0 0 0 1px rgba(255, 255, 255, 0.08);
   overflow: hidden;
   backdrop-filter: blur(4px);
+  width: 100%;
+  max-width: 560px;
 }
 
 .card::before {

--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -363,19 +363,19 @@ export function Map() {
               imageSrc={jellBellImage}
             />
             <FloatingButton
-              label="Make a Monster"
-              onClick={() => setNavigatedTo("MonsterMaker")}
-              delay="46.5s"
-              backgroundColor="rgba(250, 204, 21, 0.95)"
-              imageSrc={monsterImage}
-            />
-            <FloatingButton
               label="Paws, Claws, & Maws"
               onClick={() => setNavigatedTo("PawsClawsMaws")}
-              delay="46.75s"
+              delay="46.5s"
               backgroundColor="rgba(250, 204, 21, 0.95)"
               imageSrc={pawsClawsMawsImage}
              />
+            <FloatingButton
+              label="Make a Monster"
+              onClick={() => setNavigatedTo("MonsterMaker")}
+              delay="46.75s"
+              backgroundColor="rgba(250, 204, 21, 0.95)"
+              imageSrc={monsterImage}
+            />
              <FloatingButton
               label="Michael's Mount"
               onClick={() => setNavigatedTo("MichaelsMount")}

--- a/src/MichaelsMount.module.css
+++ b/src/MichaelsMount.module.css
@@ -78,15 +78,16 @@
 .grid {
   display: grid;
   gap: 1.35rem;
-  grid-template-columns: 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   width: 100%;
-  max-width: 820px;
+  max-width: 920px;
+  justify-items: center;
 }
 
 .card {
   position: relative;
-  padding: 2.25rem 2.8rem;
-  border-radius: 1100px / 420px;
+  padding: 1.45rem 1.7rem;
+  border-radius: 28px;
   color: #fdf5e6;
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   text-align: center;
@@ -97,6 +98,8 @@
     inset 0 0 0 1px rgba(255, 255, 255, 0.08);
   overflow: hidden;
   backdrop-filter: blur(4px);
+  width: 100%;
+  max-width: 580px;
 }
 
 .card::before {

--- a/src/MonsterMaker.module.css
+++ b/src/MonsterMaker.module.css
@@ -79,20 +79,23 @@
 .grid {
   display: grid;
   gap: 1.35rem;
-  grid-template-columns: 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   width: 100%;
-  max-width: 860px;
+  max-width: 960px;
+  justify-items: center;
 }
 
 .categories {
-  display: grid center;
-  flex-direction: column center;
+  display: flex;
+  flex-direction: column;
   gap: 1.75rem;
   width: 100%;
+  align-items: center;
 }
 
 .categoryBlock {
   width: 100%;
+  max-width: 1024px;
   padding: 1.1rem 1.25rem 1.25rem;
 }
 
@@ -102,12 +105,13 @@
   letter-spacing: 0.03em;
   text-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
   font-size: 1.4rem;
+  text-align: center;
 }
 
 .card {
   position: relative;
-  padding: 2.1rem 2.5rem;
-  border-radius: 999px / 400px;
+  padding: 1.35rem 1.7rem;
+  border-radius: 26px;
   color: #0b0f1b;
   font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
   text-align: center;
@@ -118,6 +122,8 @@
     inset 0 0 0 1px rgba(255, 255, 255, 0.24);
   overflow: hidden;
   backdrop-filter: blur(4px);
+  width: 100%;
+  max-width: 580px;
 }
 
 .card::before {

--- a/src/PawsClawsMaws.module.css
+++ b/src/PawsClawsMaws.module.css
@@ -78,15 +78,16 @@
 .grid {
   display: grid;
   gap: 1.35rem;
-  grid-template-columns: 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   width: 100%;
-  max-width: 780px;
+  max-width: 920px;
+  justify-items: center;
 }
 
 .card {
   position: relative;
-  padding: 2.15rem 2.6rem;
-  border-radius: 999px / 420px;
+  padding: 1.35rem 1.6rem;
+  border-radius: 26px;
   color: #fef9e6;
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   text-align: center;
@@ -97,6 +98,8 @@
     inset 0 0 0 1px rgba(255, 255, 255, 0.08);
   overflow: hidden;
   backdrop-filter: blur(5px);
+  width: 100%;
+  max-width: 560px;
 }
 
 .card::before {


### PR DESCRIPTION
## Summary
- reduce padding and width of multiple shop cards so text wraps more snugly while grids stay centered
- center Make a Monster categories and cards with constrained widths for tighter presentation
- swap the map button ordering for Paws, Claws, & Maws with Make a Monster

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ed860d98c8329a36b09734d9b432f)