### PR TITLE
Add Blossom Hotel shop

### DIFF
--- a/src/BlossomHotel.module.css
+++ b/src/BlossomHotel.module.css
@@ -1,0 +1,127 @@
+.app {
+  text-align: center;
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
+}
+
+.backgroundImage {
+  background: url('./Blossom Hotel.png') no-repeat center center fixed;
+  display: flex;
+  background-size: cover;
+  opacity: 0.78;
+  margin: 0;
+  z-index: -1;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  padding: 4rem 2rem 3rem;
+  align-items: center;
+  font-family: 'Times New Roman', serif;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.25rem;
+  background: rgba(255, 255, 255, 0.9);
+  border: 3px solid #8c5bb8;
+  box-shadow: 8px 10px rgba(0, 0, 0, 0.25);
+  border-radius: 20px;
+  padding: 1.4rem 2rem;
+  max-width: 420px;
+  width: 100%;
+}
+
+.headerText {
+  text-align: center;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.4rem;
+  color: #3d2a5c;
+}
+
+.owner {
+  margin: 0.2rem 0;
+  font-size: 1.05rem;
+  color: #5e3e7c;
+}
+
+.grid {
+  display: grid;
+  gap: 1.1rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  width: 100%;
+  max-width: 820px;
+}
+
+.card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.75rem 1.5rem;
+  background: linear-gradient(135deg, rgba(231, 243, 255, 0.95), rgba(255, 232, 247, 0.95));
+  border: 3px solid #5f7bb8;
+  border-radius: 18px;
+  color: #1d2a44;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  font-size: 1rem;
+  box-shadow: 0 14px 28px rgba(93, 77, 141, 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  aspect-ratio: 1 / 1;
+  min-height: 260px;
+}
+
+.card::after {
+  content: "";
+  position: absolute;
+  inset: 8px;
+  border-radius: 14px;
+  border: 1px solid rgba(61, 42, 92, 0.15);
+  pointer-events: none;
+}
+
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 18px 30px rgba(93, 77, 141, 0.3);
+}
+
+.cardTitle {
+  margin: 0;
+  font-size: 1.2rem;
+  color: #3d2a5c;
+  text-align: center;
+}
+
+.description {
+  margin: 0.4rem 0 0.6rem;
+  color: #24334f;
+  font-size: 0.98rem;
+  text-align: center;
+}
+
+.price {
+  margin: 0;
+  font-weight: bold;
+  color: #8c2b7a;
+  font-size: 1.05rem;
+}
+
+.footerNote {
+  margin: 0.25rem 0 0;
+  color: #3d2a5c;
+  font-weight: bold;
+}

--- a/src/BlossomHotel.tsx
+++ b/src/BlossomHotel.tsx
@@ -1,0 +1,80 @@
+import { useMemo } from "react";
+import styles from "./BlossomHotel.module.css";
+import { BackButton } from "./BackButton";
+import { Item } from "./types";
+import { BlossomHotelItem, tribeBlossomHotel } from "./tribeBlossomHotel";
+import blossomHotelBackground from "./Blossom Hotel.png";
+
+type DisplayItem = BlossomHotelItem & { finalPrice: number };
+
+function calculateAdjustedPrice(item: Item, priceVariability: number): number {
+  const variability = ((Math.random() * priceVariability) / 100) * item.price;
+  const upOrDown = Math.random() < 0.5 ? -1 : 1;
+  const adjusted = item.price + upOrDown * variability;
+
+  return Math.max(0, Math.round(adjusted));
+}
+
+function formatPrice(item: DisplayItem): string {
+  if (item.priceText) return item.priceText;
+  return `${item.finalPrice.toLocaleString()} Gold`;
+}
+
+export function BlossomHotel({ onBack }: { onBack?: () => void }) {
+  const displayItems: DisplayItem[] = useMemo(
+    () =>
+      tribeBlossomHotel.items.map((item) => ({
+        ...item,
+        finalPrice:
+          item.price > 0
+            ? calculateAdjustedPrice(item, tribeBlossomHotel.priceVariability)
+            : 0,
+      })),
+    []
+  );
+
+  return (
+    <div className={styles.app}>
+      <BackButton
+        onClick={onBack}
+        style={{
+          backgroundColor: "#22c55e",
+          borderColor: "#166534",
+          color: "#0f172a",
+          boxShadow: "0 6px 14px rgba(0, 0, 0, 0.35)",
+        }}
+      />
+      <div
+        className={styles.backgroundImage}
+        style={{ backgroundImage: `url(${blossomHotelBackground})` }}
+      />
+      <main className={styles.content}>
+        <header className={styles.header}>
+          <div className={styles.headerText}>
+            <h1 className={styles.title}>{tribeBlossomHotel.name}</h1>
+            <p className={styles.owner}>
+              Shop Owner: {tribeBlossomHotel.owner}
+            </p>
+          </div>
+        </header>
+
+        <section className={styles.grid} aria-label="Available items">
+          {displayItems.map((item, index) => (
+            <article
+              key={`${item.name}-${index}`}
+              className={styles.card}
+            >
+              <h2 className={styles.cardTitle}>{item.name}</h2>
+              {item.description && (
+                <p className={styles.description}>{item.description}</p>
+              )}
+              <p className={styles.price}>{formatPrice(item)}</p>
+            </article>
+          ))}
+        </section>
+
+        <p className={styles.footerNote}>{tribeBlossomHotel.insults[0]}</p>
+      </main>
+    </div>
+  );
+}

--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -60,6 +60,8 @@ import { MichaelsMount } from "./MichaelsMount";
 import mountsImage from "./Mounts.webp";
 import { ValhallaMart } from "./ValhallaMart";
 import valhallaMartImage from "./Valhalla Mart.png";
+import { BlossomHotel } from "./BlossomHotel";
+import blossomHotelImage from "./Blossom Hotel.png";
 
 // Remove stray whitespace/newlines from data URIs (defensive)
 function cleanDataUrl(s?: string) {
@@ -131,6 +133,8 @@ export function Map() {
       return <MichaelsMount onBack={() => setNavigatedTo("")} />;
     case "ValhallaMart":
       return <ValhallaMart onBack={() => setNavigatedTo("")} />;
+    case "BlossomHotel":
+      return <BlossomHotel onBack={() => setNavigatedTo("")} />;
     case "PiggyBank":
       return <PiggyBank onBack={() => setNavigatedTo("")} />;
     case "NavigationGuild":
@@ -393,6 +397,14 @@ export function Map() {
               delay="47s"
               backgroundColor="rgba(250, 204, 21, 0.95)"
               imageSrc={valhallaMartImage}
+            />
+            <FloatingButton
+              label="Blossom Hotel"
+              onClick={() => setNavigatedTo("BlossomHotel")}
+              delay="47.25s"
+              backgroundColor="rgba(34, 197, 94, 0.9)"
+              color="#0a2f14"
+              imageSrc={blossomHotelImage}
             />
           </div>
         </div>

--- a/src/tribeBlossomHotel.ts
+++ b/src/tribeBlossomHotel.ts
@@ -1,0 +1,69 @@
+import { Item, Tribe } from "./types";
+
+export interface BlossomHotelItem extends Item {
+  priceText?: string;
+}
+
+export const tribeBlossomHotel: Tribe & { items: BlossomHotelItem[] } = {
+  name: "Blossom Hotel",
+  owner: "Perma for Winter Blossom, Marlee For Spring Blossom, Solin For Summon Blossom, & Adel Autumn Blossom",
+  percentAngry: 0,
+  priceVariability: 6,
+  insults: ["Hospitality blooms year-round—choose your season and settle in."],
+  items: [
+    {
+      name: "Room, Board, & Repair Gear",
+      price: 50,
+      description: "Overnight stay with hearty meals and gear repairs included.",
+    },
+    {
+      name: "Room, Board, Repair Gear, & Spa",
+      price: 60,
+      description: "Adds a calming spa visit to the standard lodging bundle.",
+    },
+    {
+      name: "Room, Board, Repair Gear, Spa, & Time Dilation Chamber",
+      price: 70,
+      description: "Stretch recovery time while your gear is restored and you relax.",
+    },
+    {
+      name: "Room, Board, Repair Gear, Spa, Time Dilation Chamber, & Pick of Temp Buff",
+      price: 80,
+      description: "Premium stay with temporal perks and your choice of temporary buff.",
+    },
+    {
+      name: "Blossom Hotel Season Pass",
+      price: 30000,
+      description: "Season-long access to every seasonal host and amenity.",
+    },
+    {
+      name: "Mini Game: Riddles for Rewards",
+      price: 0,
+      priceText: "Price may vary",
+      description: "Test your wit for rotating prizes and hints.",
+    },
+    {
+      name: "Mini Game: Monster Trivia Night",
+      price: 0,
+      priceText: "Price may vary",
+      description: "Lore-heavy trivia where correct answers earn lounge perks.",
+    },
+    {
+      name: "Mini Game: Guess the Guest",
+      price: 0,
+      priceText: "Price may vary",
+      description: "Match silhouettes and rumors to the right seasonal visitor.",
+    },
+    {
+      name: "Mini Game: The Bard's Tale",
+      price: 0,
+      priceText: "Price may vary",
+      description: "Storytelling contest judged by the seasonal hosts.",
+    },
+    {
+      name: "Black Candle Training",
+      price: 1000,
+      description: "Hands-on focus training with the Black Candle tradition.",
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- add the Blossom Hotel shop with seasonal hosts and updated pricing labels
- style the new storefront with a blossom-inspired palette, rounded-square cards, and a green back button
- link the Blossom Hotel into the map with a green navigation button and gold-formatted pricing

## Testing
- CI=true npm test -- --watch=false

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694eda0a9fd08329ae0cbade281f33c0)