### PR TITLE
Adjust card spacing for Blossom Hotel and Monster Maker

### DIFF
--- a/src/BlossomHotel.module.css
+++ b/src/BlossomHotel.module.css
@@ -60,8 +60,8 @@
 
 .grid {
   display: grid;
-  gap: 1.1rem;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.6rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   width: 100%;
   max-width: 820px;
 }
@@ -70,8 +70,9 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  justify-content: flex-start;
   align-items: center;
+  gap: 0.65rem;
   padding: 1.75rem 1.5rem;
   background: linear-gradient(135deg, rgba(231, 243, 255, 0.95), rgba(255, 232, 247, 0.95));
   border: 3px solid #5f7bb8;
@@ -81,8 +82,8 @@
   font-size: 1rem;
   box-shadow: 0 14px 28px rgba(93, 77, 141, 0.25);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
-  aspect-ratio: 1 / 1;
-  min-height: 260px;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .card::after {

--- a/src/MonsterMaker.module.css
+++ b/src/MonsterMaker.module.css
@@ -75,18 +75,47 @@
   color: #dcfce7;
 }
 
+.categories {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  width: 100%;
+  align-items: center;
+}
+
+.categoryBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 100%;
+  max-width: 1040px;
+}
+
+.categoryTitle {
+  margin: 0;
+  color: #fef3c7;
+  font-size: 1.5rem;
+  letter-spacing: 0.02em;
+  text-align: center;
+}
+
 .grid {
   display: grid;
-  gap: 1.35rem;
+  gap: 1.6rem;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   width: 100%;
-  max-width: 920px;
+  max-width: 960px;
   justify-items: center;
 }
 
 .card {
   position: relative;
-  padding: 1.35rem 1.6rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 0.55rem;
+  padding: 1.25rem 1.5rem;
   border-radius: 26px;
   color: #ffffff;
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
@@ -100,6 +129,7 @@
   backdrop-filter: blur(5px);
   width: 100%;
   max-width: 560px;
+  box-sizing: border-box;
 }
 
 .card::before {


### PR DESCRIPTION
## Summary
- increase grid spacing and let Blossom Hotel cards size to their content
- add layout styling for Monster Maker categories and space cards so they do not touch

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694edd6350bc83298278d59ede6d83b6)