### PR TITLE
Add Evan's Enchanting Emporium shop

### DIFF
--- a/src/EvansEnchantingEmporium.module.css
+++ b/src/EvansEnchantingEmporium.module.css
@@ -1,0 +1,125 @@
+.app {
+  text-align: center;
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
+}
+
+.backgroundImage {
+  background: url("./Evan's Enchanting Emporium.png") no-repeat center center fixed;
+  display: flex;
+  background-size: cover;
+  opacity: 0.75;
+  margin: 0;
+  z-index: -1;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  padding: 4rem 2rem 3rem;
+  align-items: center;
+  font-family: "Times New Roman", serif;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.25rem;
+  background: rgba(18, 16, 38, 0.85);
+  border: 3px solid #8df0ff;
+  box-shadow: 10px 14px rgba(0, 0, 0, 0.35);
+  border-radius: 18px;
+  padding: 1.4rem 2rem;
+  max-width: 440px;
+  width: 100%;
+  color: #e8f5ff;
+}
+
+.headerText {
+  text-align: center;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.4rem;
+  color: #a7f3d0;
+  letter-spacing: 0.5px;
+}
+
+.owner {
+  margin: 0.2rem 0;
+  font-size: 1.05rem;
+  color: #c7d2fe;
+}
+
+.grid {
+  display: grid;
+  gap: 1.6rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  width: 100%;
+  max-width: 860px;
+}
+
+.card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: stretch;
+  gap: 0.75rem;
+  padding: 1.6rem 1.5rem;
+  background: radial-gradient(circle at 20% 20%, rgba(93, 59, 146, 0.9), rgba(30, 26, 62, 0.92));
+  border: 3px solid rgba(141, 240, 255, 0.8);
+  border-radius: 18px;
+  color: #ecf1ff;
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  font-size: 1rem;
+  box-shadow: 0 18px 32px rgba(19, 19, 33, 0.6);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  width: 100%;
+  box-sizing: border-box;
+  aspect-ratio: 1 / 1;
+}
+
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 24px 38px rgba(19, 19, 33, 0.65);
+  border-color: #a7f3d0;
+}
+
+.cardTitle {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #a7f3d0;
+  text-align: center;
+}
+
+.description {
+  margin: 0.35rem 0 0.45rem;
+  color: #d9e8ff;
+  font-size: 0.98rem;
+  text-align: center;
+}
+
+.price {
+  margin: 0;
+  font-weight: 700;
+  color: #8df0ff;
+  font-size: 1.08rem;
+  text-align: center;
+}
+
+.footerNote {
+  margin: 0.25rem 0 0;
+  color: #d9e8ff;
+  font-weight: 600;
+  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.45);
+}

--- a/src/EvansEnchantingEmporium.tsx
+++ b/src/EvansEnchantingEmporium.tsx
@@ -1,0 +1,89 @@
+import { useMemo } from "react";
+import styles from "./EvansEnchantingEmporium.module.css";
+import { BackButton } from "./BackButton";
+import { Item } from "./types";
+import {
+  EvansEnchantingItem,
+  tribeEvansEnchantingEmporium,
+} from "./tribeEvansEnchantingEmporium";
+import evansEnchantingBackground from "./Evan's Enchanting Emporium.png";
+
+type DisplayItem = EvansEnchantingItem & { finalPrice: number };
+
+function calculateAdjustedPrice(item: Item, priceVariability: number): number {
+  const variability = ((Math.random() * priceVariability) / 100) * item.price;
+  const upOrDown = Math.random() < 0.5 ? -1 : 1;
+  const adjusted = item.price + upOrDown * variability;
+
+  return Math.max(0, Math.round(adjusted));
+}
+
+function formatPrice(item: DisplayItem): string {
+  if (item.priceText) return item.priceText;
+  return `${item.finalPrice.toLocaleString()} Gold`;
+}
+
+export function EvansEnchantingEmporium({ onBack }: { onBack?: () => void }) {
+  const displayItems: DisplayItem[] = useMemo(
+    () =>
+      tribeEvansEnchantingEmporium.items.map((item) => ({
+        ...item,
+        finalPrice:
+          item.price > 0
+            ? calculateAdjustedPrice(
+                item,
+                tribeEvansEnchantingEmporium.priceVariability
+              )
+            : 0,
+      })),
+    []
+  );
+
+  return (
+    <div className={styles.app}>
+      <BackButton
+        onClick={onBack}
+        style={{
+          backgroundColor: "#22c55e",
+          borderColor: "#166534",
+          color: "#0f172a",
+          boxShadow: "0 6px 14px rgba(0, 0, 0, 0.35)",
+        }}
+      />
+      <div
+        className={styles.backgroundImage}
+        style={{ backgroundImage: `url(${evansEnchantingBackground})` }}
+      />
+      <main className={styles.content}>
+        <header className={styles.header}>
+          <div className={styles.headerText}>
+            <h1 className={styles.title}>
+              {tribeEvansEnchantingEmporium.name}
+            </h1>
+            <p className={styles.owner}>
+              Shop Owner: {tribeEvansEnchantingEmporium.owner}
+            </p>
+          </div>
+        </header>
+
+        <section className={styles.grid} aria-label="Available items">
+          {displayItems.map((item, index) => (
+            <article key={`${item.name}-${index}`} className={styles.card}>
+              <div>
+                <h2 className={styles.cardTitle}>{item.name}</h2>
+                {item.description && (
+                  <p className={styles.description}>{item.description}</p>
+                )}
+              </div>
+              <p className={styles.price}>{formatPrice(item)}</p>
+            </article>
+          ))}
+        </section>
+
+        <p className={styles.footerNote}>
+          {tribeEvansEnchantingEmporium.insults[0]}
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -62,6 +62,8 @@ import { ValhallaMart } from "./ValhallaMart";
 import valhallaMartImage from "./Valhalla Mart.png";
 import { BlossomHotel } from "./BlossomHotel";
 import blossomHotelImage from "./Blossom Hotel.png";
+import { EvansEnchantingEmporium } from "./EvansEnchantingEmporium";
+import evansEnchantingEmporiumImage from "./Evan's Enchanting Emporium.png";
 
 // Remove stray whitespace/newlines from data URIs (defensive)
 function cleanDataUrl(s?: string) {
@@ -135,6 +137,8 @@ export function Map() {
       return <ValhallaMart onBack={() => setNavigatedTo("")} />;
     case "BlossomHotel":
       return <BlossomHotel onBack={() => setNavigatedTo("")} />;
+    case "EvansEnchantingEmporium":
+      return <EvansEnchantingEmporium onBack={() => setNavigatedTo("")} />;
     case "PiggyBank":
       return <PiggyBank onBack={() => setNavigatedTo("")} />;
     case "NavigationGuild":
@@ -405,6 +409,14 @@ export function Map() {
               backgroundColor="rgba(34, 197, 94, 0.9)"
               color="#0a2f14"
               imageSrc={blossomHotelImage}
+            />
+            <FloatingButton
+              label="Evan's Enchanting Emporium"
+              onClick={() => setNavigatedTo("EvansEnchantingEmporium")}
+              delay="47.5s"
+              backgroundColor="rgba(34, 197, 94, 0.9)"
+              color="#0a2f14"
+              imageSrc={evansEnchantingEmporiumImage}
             />
           </div>
         </div>

--- a/src/tribeEvansEnchantingEmporium.ts
+++ b/src/tribeEvansEnchantingEmporium.ts
@@ -1,0 +1,70 @@
+import { Item, Tribe } from "./types";
+
+export interface EvansEnchantingItem extends Item {
+  priceText?: string;
+}
+
+export const tribeEvansEnchantingEmporium: Tribe & {
+  items: EvansEnchantingItem[];
+} = {
+  name: "Evan's Enchanting Emporium",
+  owner: "Evan",
+  percentAngry: 0,
+  priceVariability: 8,
+  insults: ["Every enchantment is crafted to fit your story."],
+  items: [
+    {
+      name: "Try Enchanting Yourself",
+      price: 0,
+      priceText: "????",
+      description: "A risky, dazzling experiment—attempt your own enchantment.",
+    },
+    {
+      name: "Inspect Item",
+      price: 1,
+      description: "Quick appraisal to gauge an item's enchantment potential.",
+    },
+    {
+      name: "Spell Scroll",
+      price: 100,
+      priceText: "100 Gold per level of Spell",
+      description: "Scrolls scribed to match the level of the spell you seek.",
+    },
+    {
+      name: "Arcane Consultation",
+      price: 500,
+      priceText: "5-500 Gold",
+      description: "Strategize the perfect enchantment with Evan's guidance.",
+    },
+    {
+      name: "Remove Enchantment",
+      price: 1000,
+      description: "Safely lift a lingering enchantment without harming the item.",
+    },
+    {
+      name: "Common Enchantment",
+      price: 10,
+      description: "Practical, reliable magic for everyday heroes.",
+    },
+    {
+      name: "Uncommon Enchantment",
+      price: 100,
+      description: "Tailored upgrades with a spark of rare arcana.",
+    },
+    {
+      name: "Rare Enchantment",
+      price: 1000,
+      description: "Potent effects for prized gear and ambitious goals.",
+    },
+    {
+      name: "Very Rare Enchantment",
+      price: 10000,
+      description: "High-tier magic with meticulous craftsmanship.",
+    },
+    {
+      name: "Legendary Enchantment",
+      price: 100000,
+      description: "Mythic-level work reserved for destiny-shaping relics.",
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- add Evan's Enchanting Emporium shop based on Blossom Hotel with green navigation/back buttons
- define the emporium's inventory data with gold-formatted prices and descriptive text
- update the map to include the new shop and button using the emporium artwork

## Testing
- CI=true npm test -- --watch=false


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ee0eb6698832994cb002f926db5bb)