### PR TITLE
Add Fairies of Flora shop

### DIFF
--- a/src/FairiesOfFlora.module.css
+++ b/src/FairiesOfFlora.module.css
@@ -1,0 +1,130 @@
+.app {
+  text-align: center;
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
+}
+
+.backgroundImage {
+  background: url('./Floral.webp') no-repeat center center fixed;
+  display: flex;
+  background-size: cover;
+  opacity: 0.8;
+  margin: 0;
+  z-index: -1;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  padding: 4rem 2rem 3rem;
+  align-items: center;
+  font-family: 'Times New Roman', serif;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.25rem;
+  background: rgba(244, 252, 248, 0.92);
+  border: 3px solid #3e7f63;
+  box-shadow: 10px 12px rgba(0, 0, 0, 0.2);
+  border-radius: 22px;
+  padding: 1.4rem 2rem;
+  max-width: 460px;
+  width: 100%;
+}
+
+.headerText {
+  text-align: center;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.4rem;
+  color: #1d4734;
+}
+
+.owner {
+  margin: 0.2rem 0;
+  font-size: 1.05rem;
+  color: #2d5c45;
+}
+
+.grid {
+  display: grid;
+  gap: 1.6rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  width: 100%;
+  max-width: 880px;
+}
+
+.card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1.5rem 1.25rem;
+  background: linear-gradient(135deg, rgba(244, 232, 247, 0.96), rgba(219, 242, 229, 0.96));
+  border: 3px solid #5ea28a;
+  border-radius: 18px;
+  color: #193328;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  font-size: 1rem;
+  box-shadow: 0 16px 32px rgba(34, 90, 62, 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  width: 100%;
+  box-sizing: border-box;
+  aspect-ratio: 1 / 1;
+}
+
+.card::after {
+  content: "";
+  position: absolute;
+  inset: 10px;
+  border-radius: 12px;
+  border: 1px solid rgba(25, 51, 40, 0.18);
+  pointer-events: none;
+}
+
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 20px 34px rgba(34, 90, 62, 0.32);
+  border-color: #3e7f63;
+}
+
+.cardTitle {
+  margin: 0;
+  font-size: 1.2rem;
+  color: #1f5b44;
+  text-align: center;
+}
+
+.description {
+  margin: 0.4rem 0 0.6rem;
+  color: #234235;
+  font-size: 0.98rem;
+  text-align: center;
+}
+
+.price {
+  margin: 0;
+  font-weight: bold;
+  color: #3b8b6b;
+  font-size: 1.05rem;
+}
+
+.footerNote {
+  margin: 0.25rem 0 0;
+  color: #1f5b44;
+  font-weight: bold;
+}

--- a/src/FairiesOfFlora.tsx
+++ b/src/FairiesOfFlora.tsx
@@ -1,0 +1,73 @@
+import { useMemo } from "react";
+import styles from "./FairiesOfFlora.module.css";
+import { BackButton } from "./BackButton";
+import { Item } from "./types";
+import { FairiesOfFloraItem, tribeFairiesOfFlora } from "./tribeFairiesOfFlora";
+import floralBackground from "./Floral.webp";
+
+type DisplayItem = FairiesOfFloraItem & { finalPrice: number };
+
+function calculateAdjustedPrice(item: Item, priceVariability: number): number {
+  const variability = ((Math.random() * priceVariability) / 100) * item.price;
+  const upOrDown = Math.random() < 0.5 ? -1 : 1;
+  const adjusted = item.price + upOrDown * variability;
+
+  return Math.max(0, Math.round(adjusted));
+}
+
+function formatPrice(item: DisplayItem): string {
+  if (item.priceText) return item.priceText;
+  return `${item.finalPrice.toLocaleString()} Gold`;
+}
+
+export function FairiesOfFlora({ onBack }: { onBack?: () => void }) {
+  const displayItems: DisplayItem[] = useMemo(
+    () =>
+      tribeFairiesOfFlora.items.map((item) => ({
+        ...item,
+        finalPrice:
+          item.price > 0
+            ? calculateAdjustedPrice(item, tribeFairiesOfFlora.priceVariability)
+            : 0,
+      })),
+    []
+  );
+
+  return (
+    <div className={styles.app}>
+      <BackButton
+        onClick={onBack}
+        style={{
+          backgroundColor: "#22c55e",
+          borderColor: "#14532d",
+          color: "#0f172a",
+          boxShadow: "0 6px 14px rgba(0, 0, 0, 0.35)",
+        }}
+      />
+      <div
+        className={styles.backgroundImage}
+        style={{ backgroundImage: `url(${floralBackground})` }}
+      />
+      <main className={styles.content}>
+        <header className={styles.header}>
+          <div className={styles.headerText}>
+            <h1 className={styles.title}>{tribeFairiesOfFlora.name}</h1>
+            <p className={styles.owner}>Shop Owner: {tribeFairiesOfFlora.owner}</p>
+          </div>
+        </header>
+
+        <section className={styles.grid} aria-label="Available items">
+          {displayItems.map((item, index) => (
+            <article key={`${item.name}-${index}`} className={styles.card}>
+              <h2 className={styles.cardTitle}>{item.name}</h2>
+              {item.description && <p className={styles.description}>{item.description}</p>}
+              <p className={styles.price}>{formatPrice(item)}</p>
+            </article>
+          ))}
+        </section>
+
+        <p className={styles.footerNote}>{tribeFairiesOfFlora.insults[0]}</p>
+      </main>
+    </div>
+  );
+}

--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -64,6 +64,8 @@ import { BlossomHotel } from "./BlossomHotel";
 import blossomHotelImage from "./Blossom Hotel.png";
 import { EvansEnchantingEmporium } from "./EvansEnchantingEmporium";
 import evansEnchantingEmporiumImage from "./Evan's Enchanting Emporium.png";
+import { FairiesOfFlora } from "./FairiesOfFlora";
+import floralImage from "./Floral.webp";
 
 // Remove stray whitespace/newlines from data URIs (defensive)
 function cleanDataUrl(s?: string) {
@@ -139,6 +141,8 @@ export function Map() {
       return <BlossomHotel onBack={() => setNavigatedTo("")} />;
     case "EvansEnchantingEmporium":
       return <EvansEnchantingEmporium onBack={() => setNavigatedTo("")} />;
+    case "FairiesOfFlora":
+      return <FairiesOfFlora onBack={() => setNavigatedTo("")} />;
     case "PiggyBank":
       return <PiggyBank onBack={() => setNavigatedTo("")} />;
     case "NavigationGuild":
@@ -417,6 +421,14 @@ export function Map() {
               backgroundColor="rgba(34, 197, 94, 0.9)"
               color="#0a2f14"
               imageSrc={evansEnchantingEmporiumImage}
+            />
+            <FloatingButton
+              label="Fairies of Flora"
+              onClick={() => setNavigatedTo("FairiesOfFlora")}
+              delay="47.75s"
+              backgroundColor="rgba(34, 197, 94, 0.95)"
+              color="#0a2f14"
+              imageSrc={floralImage}
             />
           </div>
         </div>

--- a/src/tribeFairiesOfFlora.ts
+++ b/src/tribeFairiesOfFlora.ts
@@ -1,0 +1,47 @@
+import { Item, Tribe } from "./types";
+
+export interface FairiesOfFloraItem extends Item {
+  priceText?: string;
+}
+
+export const tribeFairiesOfFlora: Tribe & { items: FairiesOfFloraItem[] } = {
+  name: "Fairies of Flora",
+  owner: "Poppy",
+  percentAngry: 0,
+  priceVariability: 0,
+  insults: ["Whispers among the petals guide the bold buyer."],
+  items: [
+    {
+      name: "Buy a Shambling Mound / Chi Chi Chia Automaton / Walking Mushroom",
+      price: 0,
+      priceText: "???",
+      description: "Seedlings ???, Saplings ???, or Fully Grown ???",
+    },
+    {
+      name: "I need a plumber who can work around the clock.",
+      price: 0,
+      priceText: "???",
+      description: "Request any plant-based power-up from Nintendo",
+    },
+    {
+      name: "I want a new house for my other spouse.",
+      price: 0,
+      priceText: "???",
+      description:
+        "I've requested any fruit or vegetable seeds from a cloud giant that will grow big enough to carve a house out of.",
+    },
+    {
+      name: "Hire a any color Hydrangeas / Treant / Wood Elf",
+      price: 0,
+      priceText: "???",
+      description: "Seedlings ???, Saplings ???, or Fully Grown ???",
+    },
+    {
+      name: "I know a guy who needs to take a break and smell a flower",
+      price: 0,
+      priceText: "???",
+      description:
+        "Soul Seizer chrysanthemum- This deceptive flower will bloom if an organic creature gets within 5 feet of it and tries to drain that creature's soul, killing it immediately.",
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- add a Fairies of Flora shop variant modeled after Blossom Hotel with floral theming and green navigation
- apply a cohesive floral-inspired palette with square, rounded-edge cards and updated background image
- register the new shop in the hub map with a button placed after Evan's Enchanting Emporium

## Testing
- npm test -- --watch=false


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ee1ea5cb883298b4ee39e63235ce0)