### PR TITLE
Use loading screen background for map

### DIFF
--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -66,6 +66,7 @@ import { EvansEnchantingEmporium } from "./EvansEnchantingEmporium";
 import evansEnchantingEmporiumImage from "./Evan's Enchanting Emporium.png";
 import { FairiesOfFlora } from "./FairiesOfFlora";
 import floralImage from "./Floral.webp";
+import loadingScreenBackground from "./Loading screen.gif";
 
 // Remove stray whitespace/newlines from data URIs (defensive)
 function cleanDataUrl(s?: string) {
@@ -481,7 +482,11 @@ const styles: Record<string, React.CSSProperties> = {
     alignItems: "center",
     justifyContent: "center",
     height: "100vh",
-    backgroundColor: "#f1e0c9",
+    backgroundImage: `url(${loadingScreenBackground})`,
+    backgroundSize: "cover",
+    backgroundPosition: "center",
+    backgroundRepeat: "no-repeat",
+    backgroundColor: "#0b0b0b",
     gap: "2rem",
     fontFamily: "'Times New Roman', serif",
   },
@@ -500,7 +505,7 @@ const styles: Record<string, React.CSSProperties> = {
     overflowY: "auto",
     padding: "1rem",
     width: "98%",
-    backgroundColor: "#f1e0c9",
+    backgroundColor: "rgba(255, 255, 255, 0.85)",
     borderRadius: "18px",
     border: "2px solid rgba(0, 0, 0, 0.15)",
     boxShadow: "inset 0 2px 6px rgba(0, 0, 0, 0.08)",


### PR DESCRIPTION
## Summary
- set the map view background to the existing Loading screen.gif asset
- add background sizing and positioning so the image covers the viewport
- adjust the button container overlay to keep content readable atop the new background

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ee40d50c48329a87560181927b5a3)