### PR TITLE
Add Golem Workshop shop variant

### DIFF
--- a/src/GolemWorkshop.module.css
+++ b/src/GolemWorkshop.module.css
@@ -1,0 +1,131 @@
+.app {
+  text-align: center;
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
+}
+
+.backgroundImage {
+  background: url('./Golem Work Shop.png') no-repeat center center fixed;
+  display: flex;
+  background-size: cover;
+  opacity: 0.82;
+  margin: 0;
+  z-index: -1;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  padding: 4rem 2rem 3rem;
+  align-items: center;
+  font-family: 'Times New Roman', serif;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.25rem;
+  background: rgba(18, 23, 30, 0.9);
+  border: 3px solid #9fc5c1;
+  box-shadow: 10px 12px rgba(0, 0, 0, 0.28);
+  border-radius: 18px;
+  padding: 1.4rem 2rem;
+  max-width: 460px;
+  width: 100%;
+}
+
+.headerText {
+  text-align: center;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.4rem;
+  color: #e7f2ee;
+}
+
+.owner {
+  margin: 0.2rem 0;
+  font-size: 1.05rem;
+  color: #c0e2da;
+}
+
+.grid {
+  display: grid;
+  gap: 1.2rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  width: 100%;
+  max-width: 860px;
+}
+
+.card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: stretch;
+  gap: 0.65rem;
+  padding: 1.4rem 1.25rem;
+  background: linear-gradient(135deg, rgba(18, 32, 44, 0.92), rgba(37, 51, 62, 0.9));
+  border: 3px solid rgba(223, 165, 72, 0.85);
+  border-radius: 16px;
+  color: #e8f3ef;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  font-size: 1rem;
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.35), 0 0 0 1px rgba(159, 197, 193, 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  width: 100%;
+  box-sizing: border-box;
+  aspect-ratio: 1 / 1;
+}
+
+.card::after {
+  content: "";
+  position: absolute;
+  inset: 10px;
+  border-radius: 12px;
+  border: 1px solid rgba(223, 165, 72, 0.45);
+  pointer-events: none;
+}
+
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(159, 197, 193, 0.35);
+}
+
+.cardTitle {
+  margin: 0;
+  font-size: 1.15rem;
+  color: #f2d19f;
+  text-align: center;
+}
+
+.description {
+  margin: 0.4rem 0 0.6rem;
+  color: #dbe9e4;
+  font-size: 0.98rem;
+  text-align: center;
+}
+
+.price {
+  margin: 0;
+  font-weight: 700;
+  color: #fff6e1;
+  font-size: 1.08rem;
+  text-align: center;
+}
+
+.footerNote {
+  margin: 0.25rem 0 0;
+  color: #e7f2ee;
+  font-weight: bold;
+  text-shadow: 0 1px 6px rgba(0, 0, 0, 0.3);
+}

--- a/src/GolemWorkshop.tsx
+++ b/src/GolemWorkshop.tsx
@@ -1,0 +1,77 @@
+import { useMemo } from "react";
+import styles from "./GolemWorkshop.module.css";
+import { BackButton } from "./BackButton";
+import { Item } from "./types";
+import { GolemWorkshopItem, tribeGolemWorkshop } from "./tribeGolemWorkshop";
+import golemWorkshopBackground from "./Golem Work Shop.png";
+
+type DisplayItem = GolemWorkshopItem & { finalPrice: number };
+
+function calculateAdjustedPrice(item: Item, priceVariability: number): number {
+  const variability = ((Math.random() * priceVariability) / 100) * item.price;
+  const upOrDown = Math.random() < 0.5 ? -1 : 1;
+  const adjusted = item.price + upOrDown * variability;
+
+  return Math.max(0, Math.round(adjusted));
+}
+
+function formatPrice(item: DisplayItem): string {
+  if (item.priceText) return item.priceText;
+  return `${item.finalPrice.toLocaleString()} Gold`;
+}
+
+export function GolemWorkshop({ onBack }: { onBack?: () => void }) {
+  const displayItems: DisplayItem[] = useMemo(
+    () =>
+      tribeGolemWorkshop.items.map((item) => ({
+        ...item,
+        finalPrice:
+          item.price > 0
+            ? calculateAdjustedPrice(item, tribeGolemWorkshop.priceVariability)
+            : 0,
+      })),
+    []
+  );
+
+  return (
+    <div className={styles.app}>
+      <BackButton
+        onClick={onBack}
+        style={{
+          backgroundColor: "#22c55e",
+          borderColor: "#0f3b24",
+          color: "#0b1a12",
+          boxShadow: "0 6px 14px rgba(0, 0, 0, 0.35)",
+        }}
+      />
+      <div
+        className={styles.backgroundImage}
+        style={{ backgroundImage: `url(${golemWorkshopBackground})` }}
+      />
+      <main className={styles.content}>
+        <header className={styles.header}>
+          <div className={styles.headerText}>
+            <h1 className={styles.title}>{tribeGolemWorkshop.name}</h1>
+            <p className={styles.owner}>
+              Shop Owner: {tribeGolemWorkshop.owner}
+            </p>
+          </div>
+        </header>
+
+        <section className={styles.grid} aria-label="Available items">
+          {displayItems.map((item, index) => (
+            <article key={`${item.name}-${index}`} className={styles.card}>
+              <h2 className={styles.cardTitle}>{item.name}</h2>
+              {item.description && (
+                <p className={styles.description}>{item.description}</p>
+              )}
+              <p className={styles.price}>{formatPrice(item)}</p>
+            </article>
+          ))}
+        </section>
+
+        <p className={styles.footerNote}>{tribeGolemWorkshop.insults[0]}</p>
+      </main>
+    </div>
+  );
+}

--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -66,6 +66,8 @@ import { EvansEnchantingEmporium } from "./EvansEnchantingEmporium";
 import evansEnchantingEmporiumImage from "./Evan's Enchanting Emporium.png";
 import { FairiesOfFlora } from "./FairiesOfFlora";
 import floralImage from "./Floral.webp";
+import { GolemWorkshop } from "./GolemWorkshop";
+import golemWorkshopImage from "./Golem Work Shop.png";
 
 // Remove stray whitespace/newlines from data URIs (defensive)
 function cleanDataUrl(s?: string) {
@@ -143,6 +145,10 @@ export function Map() {
       return <EvansEnchantingEmporium onBack={() => setNavigatedTo("")} />;
     case "FairiesOfFlora":
       return <FairiesOfFlora onBack={() => setNavigatedTo("")} />;
+    case "GolemWorkshop":
+      return <GolemWorkshop onBack={() => setNavigatedTo("")} />;
+    case "GolemWorkshop":
+      return <GolemWorkshop onBack={() => setNavigatedTo("")} />;
     case "PiggyBank":
       return <PiggyBank onBack={() => setNavigatedTo("")} />;
     case "NavigationGuild":
@@ -429,6 +435,14 @@ export function Map() {
               backgroundColor="rgba(34, 197, 94, 0.95)"
               color="#0a2f14"
               imageSrc={floralImage}
+            />
+            <FloatingButton
+              label="Golem Workshop"
+              onClick={() => setNavigatedTo("GolemWorkshop")}
+              delay="48s"
+              backgroundColor="rgba(34, 197, 94, 0.95)"
+              color="#0a2f14"
+              imageSrc={golemWorkshopImage}
             />
           </div>
         </div>

--- a/src/tribeGolemWorkshop.ts
+++ b/src/tribeGolemWorkshop.ts
@@ -1,0 +1,68 @@
+import { Item, Tribe } from "./types";
+
+export interface GolemWorkshopItem extends Item {
+  priceText?: string;
+}
+
+export const tribeGolemWorkshop: Tribe & { items: GolemWorkshopItem[] } = {
+  name: "Golem Workshop",
+  owner: "Goldhand Redrockson",
+  percentAngry: 0,
+  priceVariability: 5,
+  insults: ["Every construct is forged to order—talk terms or pay in gold."],
+  items: [
+    {
+      name: "Clay or Landscaping Golem",
+      price: 300,
+      description: "Gentle shapers perfect for gardens, terraces, and tidy grounds.",
+    },
+    {
+      name: "Crystal or Vehicle Operator Golem",
+      price: 400,
+      description: "Precision-driven cores to pilot carts, caravans, or fragile rigs.",
+    },
+    {
+      name: "Wood or Carpenter Golem",
+      price: 500,
+      description: "Reliable joiners that frame, sand, and finish on tireless cycles.",
+    },
+    {
+      name: "Stone or Mason Golem",
+      price: 600,
+      description: "Foundation specialists that lift, stack, and set quarried slabs.",
+    },
+    {
+      name: "Iron or Smith Golem",
+      price: 700,
+      description: "Forge-floor assistants to hammer billets and mind the bellows.",
+    },
+    {
+      name: "Steel or Builder Golem",
+      price: 800,
+      description: "Architectural muscle that braces beams and locks plates in place.",
+    },
+    {
+      name: "Siege Golem",
+      price: 900,
+      description: "Armored rams and throwers ready for fortified obstacles.",
+    },
+    {
+      name: "Build a Base",
+      price: 0,
+      priceText: "Negotiable",
+      description: "Full-site planning, from anchor stones to final battlements.",
+    },
+    {
+      name: "Unprocessed Supplies",
+      price: 0,
+      priceText: "Negotiable",
+      description: "Raw ore, timber, and crystal lots priced to current markets.",
+    },
+    {
+      name: "Custom Golem Construction",
+      price: 0,
+      priceText: "Negotiable",
+      description: "Tailored chassis, enchantments, and control runes on request.",
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- add the Golem Workshop shop variant mirroring Blossom Hotel with its own data and styling
- introduce custom theming and square card layout with gold-accent palette based on the new background
- link the new shop from the map after Fairies of Flora with its green navigation button

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ee3c426f8832988f9b1d39a8a3faa)