### PR TITLE
Add Jazz Portable Potions experience

### DIFF
--- a/src/JazzPortablePotions.module.css
+++ b/src/JazzPortablePotions.module.css
@@ -1,0 +1,32 @@
+.app {
+  min-height: 100vh;
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 3rem 1.5rem;
+  background: radial-gradient(circle at 20% 25%, #0f1d2b 0%, #1e3a4c 45%, #1f5142 90%);
+}
+
+.imageFrame {
+  background: linear-gradient(135deg, rgba(31, 81, 66, 0.85), rgba(15, 29, 43, 0.92));
+  border: 6px solid #0ea5e9;
+  box-shadow: 16px 16px 0 rgba(0, 0, 0, 0.35);
+  border-radius: 28px;
+  padding: 1rem;
+  max-width: 880px;
+  width: min(92vw, 880px);
+  aspect-ratio: 1 / 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.image {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.08);
+}

--- a/src/JazzPortablePotions.tsx
+++ b/src/JazzPortablePotions.tsx
@@ -1,0 +1,27 @@
+import styles from "./JazzPortablePotions.module.css";
+import { BackButton } from "./BackButton";
+import objectiveSurvive from "./Objective survive.webp";
+
+export function JazzPortablePotions({ onBack }: { onBack?: () => void }) {
+  return (
+    <div className={styles.app}>
+      <BackButton
+        onClick={onBack}
+        style={{
+          right: "1.5rem",
+          left: "auto",
+          backgroundColor: "#16a34a",
+          color: "#0b1f16",
+          borderColor: "#0f5132",
+        }}
+      />
+      <div className={styles.imageFrame}>
+        <img
+          src={objectiveSurvive}
+          alt="Objective Survive information"
+          className={styles.image}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -69,6 +69,8 @@ import floralImage from "./Floral.webp";
 import loadingScreenBackground from "./Loading screen.gif";
 import { GolemWorkshop } from "./GolemWorkshop";
 import golemWorkshopImage from "./Golem Work Shop.png";
+import { JazzPortablePotions } from "./JazzPortablePotions";
+import jazzPortablePotionsImage from "./Jazz's Portable Potions.png";
 
 // Remove stray whitespace/newlines from data URIs (defensive)
 function cleanDataUrl(s?: string) {
@@ -190,6 +192,8 @@ export function Map() {
       return <YeOldDonkey onBack={() => setNavigatedTo("")} />;
     case "HugInfo":
       return <HugInfo onBack={() => setNavigatedTo("")} />;
+    case "JazzPortablePotions":
+      return <JazzPortablePotions onBack={() => setNavigatedTo("")} />;
     default:
       return (
         <div style={styles.wrapper}>
@@ -371,6 +375,14 @@ export function Map() {
               backgroundColor="rgba(250, 204, 21, 0.9)"
               imageSrc={hugImage}
             />  
+            <FloatingButton
+              label="Jazz's Portable Potions"
+              onClick={() => setNavigatedTo("JazzPortablePotions")}
+              delay="76s"
+              backgroundColor="rgba(34, 197, 94, 0.95)"
+              color="#0a2f14"
+              imageSrc={jazzPortablePotionsImage}
+            />
             <FloatingButton
               label="Iconic Dragonic"
               onClick={() => setNavigatedTo("IconicDragonic")}


### PR DESCRIPTION
## Summary
- add a Jazz's Portable Potions experience modeled after Hug Info with new assets
- style the new view with a square, rounded frame and palette inspired by the Objective survive artwork
- surface the new destination on the map with a green button and updated thumbnail

## Testing
- CI=true npm test -- --watch=false

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ee64c9e188329be88646b0f7455e5)