### PR TITLE
Add Jewelry Guild shop

### DIFF
--- a/src/JewelryGuild.module.css
+++ b/src/JewelryGuild.module.css
@@ -1,0 +1,138 @@
+.app {
+  text-align: center;
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
+  background-color: #0b1118;
+}
+
+.backgroundImage {
+  background: url('./Jewelry Guild.png') no-repeat center center fixed;
+  display: flex;
+  background-size: cover;
+  opacity: 0.74;
+  margin: 0;
+  z-index: -1;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.8rem;
+  padding: 4rem 2rem 3rem;
+  align-items: center;
+  font-family: 'Times New Roman', serif;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.25rem;
+  background: linear-gradient(135deg, rgba(15, 42, 61, 0.92), rgba(30, 111, 120, 0.9));
+  border: 3px solid rgba(220, 189, 114, 0.9);
+  box-shadow: 8px 10px rgba(0, 0, 0, 0.32);
+  border-radius: 22px;
+  padding: 1.4rem 2.2rem;
+  max-width: 460px;
+  width: 100%;
+  color: #f5edd9;
+}
+
+.headerText {
+  text-align: center;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.45rem;
+  color: #f8e9c3;
+  letter-spacing: 0.5px;
+}
+
+.owner {
+  margin: 0.2rem 0;
+  font-size: 1.08rem;
+  color: #d5c08b;
+}
+
+.grid {
+  display: grid;
+  gap: 1.4rem;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  width: 100%;
+  max-width: 880px;
+}
+
+.card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 0.7rem;
+  padding: 1.5rem;
+  background: linear-gradient(135deg, rgba(13, 34, 46, 0.9), rgba(32, 89, 104, 0.9));
+  border: 3px solid rgba(221, 191, 116, 0.85);
+  border-radius: 18px;
+  color: #e8f3ff;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  font-size: 1rem;
+  box-shadow: 0 16px 32px rgba(15, 42, 61, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  width: 100%;
+  box-sizing: border-box;
+  aspect-ratio: 1 / 1;
+}
+
+.card::after {
+  content: "";
+  position: absolute;
+  inset: 9px;
+  border-radius: 14px;
+  border: 1px solid rgba(243, 223, 156, 0.28);
+  pointer-events: none;
+  box-shadow: inset 0 0 22px rgba(221, 191, 116, 0.25);
+}
+
+.card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 20px 36px rgba(15, 42, 61, 0.45);
+}
+
+.cardTitle {
+  margin: 0;
+  font-size: 1.22rem;
+  color: #f8e9c3;
+  text-align: center;
+}
+
+.description {
+  margin: 0.45rem 0 0.55rem;
+  color: #d3e8f8;
+  font-size: 0.98rem;
+  text-align: center;
+}
+
+.price {
+  margin: 0;
+  font-weight: bold;
+  color: #f1d27b;
+  font-size: 1.08rem;
+}
+
+.footerNote {
+  margin: 0.25rem 0 0;
+  color: #f8e9c3;
+  font-weight: bold;
+  background: rgba(13, 34, 46, 0.7);
+  padding: 0.7rem 1.1rem;
+  border: 2px solid rgba(221, 191, 116, 0.65);
+  border-radius: 14px;
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.25);
+}

--- a/src/JewelryGuild.tsx
+++ b/src/JewelryGuild.tsx
@@ -1,0 +1,75 @@
+import { useMemo } from "react";
+import styles from "./JewelryGuild.module.css";
+import { BackButton } from "./BackButton";
+import { Item } from "./types";
+import { JewelryGuildItem, tribeJewelryGuild } from "./tribeJewelryGuild";
+import jewelryGuildBackground from "./Jewelry Guild.png";
+
+type DisplayItem = JewelryGuildItem & { finalPrice: number };
+
+function calculateAdjustedPrice(item: Item, priceVariability: number): number {
+  const variability = ((Math.random() * priceVariability) / 100) * item.price;
+  const upOrDown = Math.random() < 0.5 ? -1 : 1;
+  const adjusted = item.price + upOrDown * variability;
+
+  return Math.max(0, Math.round(adjusted));
+}
+
+function formatPrice(item: DisplayItem): string {
+  if (item.priceText) return item.priceText;
+  return `${item.finalPrice.toLocaleString()} Gold`;
+}
+
+export function JewelryGuild({ onBack }: { onBack?: () => void }) {
+  const displayItems: DisplayItem[] = useMemo(
+    () =>
+      tribeJewelryGuild.items.map((item) => ({
+        ...item,
+        finalPrice:
+          item.price > 0
+            ? calculateAdjustedPrice(item, tribeJewelryGuild.priceVariability)
+            : 0,
+      })),
+    []
+  );
+
+  return (
+    <div className={styles.app}>
+      <BackButton
+        onClick={onBack}
+        style={{
+          backgroundColor: "#22c55e",
+          borderColor: "#14532d",
+          color: "#0b1f16",
+          boxShadow: "0 6px 14px rgba(0, 0, 0, 0.38)",
+        }}
+      />
+      <div
+        className={styles.backgroundImage}
+        style={{ backgroundImage: `url(${jewelryGuildBackground})` }}
+      />
+      <main className={styles.content}>
+        <header className={styles.header}>
+          <div className={styles.headerText}>
+            <h1 className={styles.title}>{tribeJewelryGuild.name}</h1>
+            <p className={styles.owner}>Shop Owner: {tribeJewelryGuild.owner}</p>
+          </div>
+        </header>
+
+        <section className={styles.grid} aria-label="Available items">
+          {displayItems.map((item, index) => (
+            <article key={`${item.name}-${index}`} className={styles.card}>
+              <h2 className={styles.cardTitle}>{item.name}</h2>
+              {item.description && (
+                <p className={styles.description}>{item.description}</p>
+              )}
+              <p className={styles.price}>{formatPrice(item)}</p>
+            </article>
+          ))}
+        </section>
+
+        <p className={styles.footerNote}>{tribeJewelryGuild.insults[0]}</p>
+      </main>
+    </div>
+  );
+}

--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -71,6 +71,8 @@ import { GolemWorkshop } from "./GolemWorkshop";
 import golemWorkshopImage from "./Golem Work Shop.png";
 import { JazzPortablePotions } from "./JazzPortablePotions";
 import jazzPortablePotionsImage from "./Jazz's Portable Potions.png";
+import { JewelryGuild } from "./JewelryGuild";
+import jewelryGuildImage from "./Jewelry Guild.png";
 
 // Remove stray whitespace/newlines from data URIs (defensive)
 function cleanDataUrl(s?: string) {
@@ -194,6 +196,8 @@ export function Map() {
       return <HugInfo onBack={() => setNavigatedTo("")} />;
     case "JazzPortablePotions":
       return <JazzPortablePotions onBack={() => setNavigatedTo("")} />;
+    case "JewelryGuild":
+      return <JewelryGuild onBack={() => setNavigatedTo("")} />;
     default:
       return (
         <div style={styles.wrapper}>
@@ -382,6 +386,14 @@ export function Map() {
               backgroundColor="rgba(34, 197, 94, 0.95)"
               color="#0a2f14"
               imageSrc={jazzPortablePotionsImage}
+            />
+            <FloatingButton
+              label="Jewelry Guild"
+              onClick={() => setNavigatedTo("JewelryGuild")}
+              delay="76.25s"
+              backgroundColor="rgba(34, 197, 94, 0.92)"
+              color="#0b1f16"
+              imageSrc={jewelryGuildImage}
             />
             <FloatingButton
               label="Iconic Dragonic"

--- a/src/tribeJewelryGuild.ts
+++ b/src/tribeJewelryGuild.ts
@@ -1,0 +1,65 @@
+import { Item, Tribe } from "./types";
+
+export interface JewelryGuildItem extends Item {
+  priceText?: string;
+}
+
+export const tribeJewelryGuild: Tribe & { items: JewelryGuildItem[] } = {
+  name: "Jewelry Guild",
+  owner: "Garry",
+  percentAngry: 0,
+  priceVariability: 12,
+  insults: ["Trade a gem for a grin—Garry appraises with a spark in his eye."],
+  items: [
+    {
+      name: "Trinket Trade",
+      price: 0,
+      priceText: "???",
+    },
+    {
+      name: "Regular Ring, Neckless, or Earrings",
+      price: 10,
+      description: "Simple adornments forged for everyday shine.",
+    },
+    {
+      name: "Degrading Diamond Dust",
+      price: 500,
+      description: "Sparkling grit that weakens enchantments over time.",
+    },
+    {
+      name: "Emerald Entrancement",
+      price: 500,
+      description: "Green-hued charm that entices attention your way.",
+    },
+    {
+      name: "Obsidian Oath",
+      price: 500,
+      description: "A dark pledge sealed in volcanic glass.",
+    },
+    {
+      name: "Petrifying Pyrite Pebbles",
+      price: 500,
+      description: "Fool's gold stones that stiffen the will and limbs.",
+    },
+    {
+      name: "Phantom Pearl Powder",
+      price: 500,
+      description: "Iridescent dust that shimmers between realities.",
+    },
+    {
+      name: "Reaper Ruby",
+      price: 500,
+      description: "Crimson gem that whispers of mortality.",
+    },
+    {
+      name: "Soul Swapping Sapphire",
+      price: 500,
+      description: "Azure crystal rumored to mirror another's essence.",
+    },
+    {
+      name: "Empty Memory Stone",
+      price: 1000,
+      description: "A blank gem waiting to be etched with new recollections.",
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- create a Jewelry Guild shop based on the Blossom Hotel layout with a green return button and jewel-toned styling
- add square, rounded cards using a palette that contrasts the Jewelry Guild background
- register the new shop data and navigation button after Jazz's Portable Potions

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ee7ba44d08329b44391e7108b2077)