### PR TITLE
Add Labyrinthine Library shop variant

### DIFF
--- a/src/LabyrinthineLibrary.module.css
+++ b/src/LabyrinthineLibrary.module.css
@@ -1,0 +1,129 @@
+.app {
+  text-align: center;
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
+}
+
+.backgroundImage {
+  background: url('./Labyrinthine Labrary.png') no-repeat center center fixed;
+  display: flex;
+  background-size: cover;
+  opacity: 0.82;
+  margin: 0;
+  z-index: -1;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  padding: 4rem 2rem 3rem;
+  align-items: center;
+  font-family: 'Times New Roman', serif;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.25rem;
+  background: rgba(13, 16, 38, 0.85);
+  border: 3px solid #9fa8ff;
+  box-shadow: 8px 12px rgba(0, 0, 0, 0.28);
+  border-radius: 20px;
+  padding: 1.4rem 2rem;
+  max-width: 520px;
+  width: 100%;
+}
+
+.headerText {
+  text-align: center;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.4rem;
+  color: #eaf0ff;
+}
+
+.owner {
+  margin: 0.2rem 0;
+  font-size: 1.05rem;
+  color: #c4cbff;
+}
+
+.grid {
+  display: grid;
+  gap: 1.6rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  width: 100%;
+  max-width: 900px;
+}
+
+.card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 1.75rem 1.5rem;
+  background: linear-gradient(145deg, rgba(17, 23, 49, 0.95), rgba(35, 41, 82, 0.92));
+  border: 3px solid rgba(159, 168, 255, 0.55);
+  border-radius: 18px;
+  color: #eef2ff;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  font-size: 1rem;
+  box-shadow: 0 18px 32px rgba(11, 16, 38, 0.45);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  width: 100%;
+  box-sizing: border-box;
+  aspect-ratio: 1 / 1;
+}
+
+.card::after {
+  content: "";
+  position: absolute;
+  inset: 10px;
+  border-radius: 14px;
+  border: 1px solid rgba(228, 233, 255, 0.18);
+  pointer-events: none;
+}
+
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 22px 36px rgba(11, 16, 38, 0.55);
+}
+
+.cardTitle {
+  margin: 0;
+  font-size: 1.2rem;
+  color: #f3f6ff;
+  text-align: center;
+}
+
+.description {
+  margin: 0.4rem 0 0.6rem;
+  color: #cbd5ff;
+  font-size: 0.98rem;
+  text-align: center;
+}
+
+.price {
+  margin: 0;
+  font-weight: bold;
+  color: #7ce7b7;
+  font-size: 1.05rem;
+}
+
+.footerNote {
+  margin: 0.25rem 0 0;
+  color: #eaf0ff;
+  font-weight: bold;
+}

--- a/src/LabyrinthineLibrary.tsx
+++ b/src/LabyrinthineLibrary.tsx
@@ -1,0 +1,83 @@
+import { useMemo } from "react";
+import styles from "./LabyrinthineLibrary.module.css";
+import { BackButton } from "./BackButton";
+import { Item } from "./types";
+import {
+  LabyrinthineLibraryItem,
+  tribeLabyrinthineLibrary,
+} from "./tribeLabyrinthineLibrary";
+import labyrinthineLibraryBackground from "./Labyrinthine Labrary.png";
+
+type DisplayItem = LabyrinthineLibraryItem & { finalPrice: number };
+
+function calculateAdjustedPrice(item: Item, priceVariability: number): number {
+  const variability = ((Math.random() * priceVariability) / 100) * item.price;
+  const upOrDown = Math.random() < 0.5 ? -1 : 1;
+  const adjusted = item.price + upOrDown * variability;
+
+  return Math.max(0, Math.round(adjusted));
+}
+
+function formatPrice(item: DisplayItem): string {
+  if (item.priceText) return item.priceText;
+  return `${item.finalPrice.toLocaleString()} Gold`;
+}
+
+export function LabyrinthineLibrary({ onBack }: { onBack?: () => void }) {
+  const displayItems: DisplayItem[] = useMemo(
+    () =>
+      tribeLabyrinthineLibrary.items.map((item) => ({
+        ...item,
+        finalPrice:
+          item.price > 0
+            ? calculateAdjustedPrice(
+                item,
+                tribeLabyrinthineLibrary.priceVariability
+              )
+            : 0,
+      })),
+    []
+  );
+
+  return (
+    <div className={styles.app}>
+      <BackButton
+        onClick={onBack}
+        style={{
+          backgroundColor: "#22c55e",
+          borderColor: "#14532d",
+          color: "#0b1f16",
+          boxShadow: "0 6px 14px rgba(0, 0, 0, 0.38)",
+        }}
+      />
+      <div
+        className={styles.backgroundImage}
+        style={{ backgroundImage: `url(${labyrinthineLibraryBackground})` }}
+      />
+      <main className={styles.content}>
+        <header className={styles.header}>
+          <div className={styles.headerText}>
+            <h1 className={styles.title}>{tribeLabyrinthineLibrary.name}</h1>
+            <p className={styles.owner}>
+              Shop Owner: {tribeLabyrinthineLibrary.owner}
+            </p>
+          </div>
+        </header>
+
+        <section className={styles.grid} aria-label="Available items">
+          {displayItems.map((item, index) => (
+            <article key={`${item.name}-${index}`} className={styles.card}>
+              <h2 className={styles.cardTitle}>{item.name}</h2>
+              {item.description && (
+                <p className={styles.description}>{item.description}</p>
+              )}
+              <p className={styles.price}>{formatPrice(item)}</p>
+            </article>
+          ))}
+        </section>
+
+        <p className={styles.footerNote}>{tribeLabyrinthineLibrary.insults[0]}</p>
+      </main>
+    </div>
+  );
+}

--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -73,6 +73,8 @@ import { JazzPortablePotions } from "./JazzPortablePotions";
 import jazzPortablePotionsImage from "./Jazz's Portable Potions.png";
 import { JewelryGuild } from "./JewelryGuild";
 import jewelryGuildImage from "./Jewelry Guild.png";
+import { LabyrinthineLibrary } from "./LabyrinthineLibrary";
+import labyrinthineLibraryImage from "./Labyrinthine Labrary.png";
 
 // Remove stray whitespace/newlines from data URIs (defensive)
 function cleanDataUrl(s?: string) {
@@ -152,8 +154,8 @@ export function Map() {
       return <FairiesOfFlora onBack={() => setNavigatedTo("")} />;
     case "GolemWorkshop":
       return <GolemWorkshop onBack={() => setNavigatedTo("")} />;
-    case "GolemWorkshop":
-      return <GolemWorkshop onBack={() => setNavigatedTo("")} />;
+    case "LabyrinthineLibrary":
+      return <LabyrinthineLibrary onBack={() => setNavigatedTo("")} />;
     case "PiggyBank":
       return <PiggyBank onBack={() => setNavigatedTo("")} />;
     case "NavigationGuild":
@@ -380,22 +382,6 @@ export function Map() {
               imageSrc={hugImage}
             />  
             <FloatingButton
-              label="Jazz's Portable Potions"
-              onClick={() => setNavigatedTo("JazzPortablePotions")}
-              delay="76s"
-              backgroundColor="rgba(34, 197, 94, 0.95)"
-              color="#0a2f14"
-              imageSrc={jazzPortablePotionsImage}
-            />
-            <FloatingButton
-              label="Jewelry Guild"
-              onClick={() => setNavigatedTo("JewelryGuild")}
-              delay="76.25s"
-              backgroundColor="rgba(34, 197, 94, 0.92)"
-              color="#0b1f16"
-              imageSrc={jewelryGuildImage}
-            />
-            <FloatingButton
               label="Iconic Dragonic"
               onClick={() => setNavigatedTo("IconicDragonic")}
               delay="73.5s"
@@ -468,6 +454,30 @@ export function Map() {
               backgroundColor="rgba(34, 197, 94, 0.95)"
               color="#0a2f14"
               imageSrc={golemWorkshopImage}
+            />
+            <FloatingButton
+              label="Jazz's Portable Potions"
+              onClick={() => setNavigatedTo("JazzPortablePotions")}
+              delay="48.25s"
+              backgroundColor="rgba(34, 197, 94, 0.95)"
+              color="#0a2f14"
+              imageSrc={jazzPortablePotionsImage}
+            />
+            <FloatingButton
+              label="Jewelry Guild"
+              onClick={() => setNavigatedTo("JewelryGuild")}
+              delay="48.5s"
+              backgroundColor="rgba(34, 197, 94, 0.92)"
+              color="#0b1f16"
+              imageSrc={jewelryGuildImage}
+            />
+            <FloatingButton
+              label="Labyrinthine Library"
+              onClick={() => setNavigatedTo("LabyrinthineLibrary")}
+              delay="48.75s"
+              backgroundColor="rgba(34, 197, 94, 0.95)"
+              color="#0a2f14"
+              imageSrc={labyrinthineLibraryImage}
             />
           </div>
         </div>

--- a/src/tribeLabyrinthineLibrary.ts
+++ b/src/tribeLabyrinthineLibrary.ts
@@ -1,0 +1,73 @@
+import { Item, Tribe } from "./types";
+
+export interface LabyrinthineLibraryItem extends Item {
+  priceText?: string;
+}
+
+export const tribeLabyrinthineLibrary: Tribe & {
+  items: LabyrinthineLibraryItem[];
+} = {
+  name: "Labyrinthine Library",
+  owner: "Larry",
+  percentAngry: 0,
+  priceVariability: 6,
+  insults: [
+    "Are you looking for knowledge? The Labyrinth Library might be just the thing for you. It's not your typical dungeon, it's a mobile pocket dimension. It's not run by the Dungeon Crawlers Guild, which likes brawn over brains. When you're ready to explore, let me know what interests you. You can choose a specific topic or go for a general overview. But be warned - each level you explore will require a greater toll. You might lose health, spell slots, or even unique abilities. However, the deeper you go, the more knowledge you'll gain.The Labyrinth Library is definitely worth the risk. You'll uncover a wealth of information about your chosen topic. So, if you're ready for the challenge, prepare for an adventure full of rewards!",
+  ],
+  items: [
+    {
+      name: "Room, Board, & Repair Gear",
+      price: 50,
+      description: "Overnight stay with hearty meals and gear repairs included.",
+    },
+    {
+      name: "Room, Board, Repair Gear, & Spa",
+      price: 60,
+      description: "Adds a calming spa visit to the standard lodging bundle.",
+    },
+    {
+      name: "Room, Board, Repair Gear, Spa, & Time Dilation Chamber",
+      price: 70,
+      description: "Stretch recovery time while your gear is restored and you relax.",
+    },
+    {
+      name: "Room, Board, Repair Gear, Spa, Time Dilation Chamber, & Pick of Temp Buff",
+      price: 80,
+      description: "Premium stay with temporal perks and your choice of temporary buff.",
+    },
+    {
+      name: "Blossom Hotel Season Pass",
+      price: 30000,
+      description: "Season-long access to every seasonal host and amenity.",
+    },
+    {
+      name: "Mini Game: Riddles for Rewards",
+      price: 0,
+      priceText: "Price may vary",
+      description: "Test your wit for rotating prizes and hints.",
+    },
+    {
+      name: "Mini Game: Monster Trivia Night",
+      price: 0,
+      priceText: "Price may vary",
+      description: "Lore-heavy trivia where correct answers earn lounge perks.",
+    },
+    {
+      name: "Mini Game: Guess the Guest",
+      price: 0,
+      priceText: "Price may vary",
+      description: "Match silhouettes and rumors to the right seasonal visitor.",
+    },
+    {
+      name: "Mini Game: The Bard's Tale",
+      price: 0,
+      priceText: "Price may vary",
+      description: "Storytelling contest judged by the seasonal hosts.",
+    },
+    {
+      name: "Black Candle Training",
+      price: 1000,
+      description: "Hands-on focus training with the Black Candle tradition.",
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- add a Labyrinthine Library shop variant that mirrors Blossom Hotel with new branding, owner details, and styling that matches the new background
- introduce a dedicated tribe data file and component for the Labyrinthine Library with squared, rounded cards and a green back button
- reorder the map buttons so Jazz's Portable Potions, Jewelry Guild, and the new Labyrinthine Library follow Golem Workshop with the updated green styling

## Testing
- npm test -- --runInBand --watch=false

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694eea2286588329a9655613a59630f8)