### PR TITLE
Add NME shop variant

### DIFF
--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -75,6 +75,8 @@ import { JewelryGuild } from "./JewelryGuild";
 import jewelryGuildImage from "./Jewelry Guild.png";
 import { LabyrinthineLibrary } from "./LabyrinthineLibrary";
 import labyrinthineLibraryImage from "./Labyrinthine Labrary.png";
+import { NME } from "./NME";
+import nmeImage from "./N.M.E.png";
 
 // Remove stray whitespace/newlines from data URIs (defensive)
 function cleanDataUrl(s?: string) {
@@ -156,6 +158,8 @@ export function Map() {
       return <GolemWorkshop onBack={() => setNavigatedTo("")} />;
     case "LabyrinthineLibrary":
       return <LabyrinthineLibrary onBack={() => setNavigatedTo("")} />;
+    case "NME":
+      return <NME onBack={() => setNavigatedTo("")} />;
     case "PiggyBank":
       return <PiggyBank onBack={() => setNavigatedTo("")} />;
     case "NavigationGuild":
@@ -478,6 +482,14 @@ export function Map() {
               backgroundColor="rgba(34, 197, 94, 0.95)"
               color="#0a2f14"
               imageSrc={labyrinthineLibraryImage}
+            />
+            <FloatingButton
+              label="N.M.E."
+              onClick={() => setNavigatedTo("NME")}
+              delay="49s"
+              backgroundColor="rgba(22, 163, 74, 0.95)"
+              color="#04260f"
+              imageSrc={nmeImage}
             />
           </div>
         </div>

--- a/src/NME.module.css
+++ b/src/NME.module.css
@@ -1,0 +1,137 @@
+.app {
+  text-align: center;
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
+  color: #f5eaf7;
+}
+
+.backgroundImage {
+  background: url('./N.M.E.png') no-repeat center center fixed;
+  display: flex;
+  background-size: cover;
+  opacity: 0.75;
+  margin: 0;
+  z-index: -1;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  filter: saturate(1.05) brightness(0.95);
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  padding: 4rem 2rem 3rem;
+  align-items: center;
+  font-family: 'Times New Roman', serif;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.25rem;
+  background: rgba(16, 10, 23, 0.9);
+  border: 3px solid #c12f4a;
+  box-shadow: 10px 14px rgba(0, 0, 0, 0.35);
+  border-radius: 22px;
+  padding: 1.4rem 2.2rem;
+  max-width: 460px;
+  width: 100%;
+  backdrop-filter: blur(2px);
+}
+
+.headerText {
+  text-align: center;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.4rem;
+  color: #f6e5fb;
+  letter-spacing: 0.04em;
+}
+
+.owner {
+  margin: 0.2rem 0;
+  font-size: 1.05rem;
+  color: #e3c8d5;
+}
+
+.grid {
+  display: grid;
+  gap: 1.4rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  width: 100%;
+  max-width: 900px;
+}
+
+.card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 1.5rem;
+  background: linear-gradient(145deg, rgba(20, 14, 32, 0.92), rgba(52, 20, 34, 0.9));
+  border: 3px solid #c12f4a;
+  border-radius: 18px;
+  color: #f5eaf7;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  font-size: 1rem;
+  box-shadow: 0 16px 30px rgba(0, 0, 0, 0.45), 0 0 0 6px rgba(193, 47, 74, 0.08);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  width: 100%;
+  box-sizing: border-box;
+  aspect-ratio: 1 / 1;
+}
+
+.card::after {
+  content: "";
+  position: absolute;
+  inset: 10px;
+  border-radius: 14px;
+  border: 1px solid rgba(245, 234, 247, 0.2);
+  pointer-events: none;
+  box-shadow: inset 0 0 0 8px rgba(6, 10, 20, 0.35);
+}
+
+.card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 20px 34px rgba(0, 0, 0, 0.5), 0 0 0 8px rgba(193, 47, 74, 0.12);
+  border-color: #d54c63;
+}
+
+.cardTitle {
+  margin: 0;
+  font-size: 1.18rem;
+  color: #f8d2dc;
+  text-align: center;
+}
+
+.description {
+  margin: 0.35rem 0 0.55rem;
+  color: #e6d5e2;
+  font-size: 0.97rem;
+  text-align: center;
+  line-height: 1.45;
+}
+
+.price {
+  margin: 0;
+  font-weight: bold;
+  color: #a1f7c4;
+  font-size: 1.05rem;
+}
+
+.footerNote {
+  margin: 0.25rem 0 0;
+  color: #f3d2df;
+  font-weight: bold;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
+}

--- a/src/NME.tsx
+++ b/src/NME.tsx
@@ -1,0 +1,75 @@
+import { useMemo } from "react";
+import styles from "./NME.module.css";
+import { BackButton } from "./BackButton";
+import { Item } from "./types";
+import { NMEItem, tribeNME } from "./tribeNME";
+import nmeBackground from "./N.M.E.png";
+
+type DisplayItem = NMEItem & { finalPrice: number };
+
+function calculateAdjustedPrice(item: Item, priceVariability: number): number {
+  const variability = ((Math.random() * priceVariability) / 100) * item.price;
+  const upOrDown = Math.random() < 0.5 ? -1 : 1;
+  const adjusted = item.price + upOrDown * variability;
+
+  return Math.max(0, Math.round(adjusted));
+}
+
+function formatPrice(item: DisplayItem): string {
+  if (item.priceText) return item.priceText;
+  return `${item.finalPrice.toLocaleString()} Gold`;
+}
+
+export function NME({ onBack }: { onBack?: () => void }) {
+  const displayItems: DisplayItem[] = useMemo(
+    () =>
+      tribeNME.items.map((item) => ({
+        ...item,
+        finalPrice:
+          item.price > 0
+            ? calculateAdjustedPrice(item, tribeNME.priceVariability)
+            : 0,
+      })),
+    []
+  );
+
+  return (
+    <div className={styles.app}>
+      <BackButton
+        onClick={onBack}
+        style={{
+          backgroundColor: "#16a34a",
+          borderColor: "#0f5132",
+          color: "#03130a",
+          boxShadow: "0 6px 14px rgba(0, 0, 0, 0.4)",
+        }}
+      />
+      <div
+        className={styles.backgroundImage}
+        style={{ backgroundImage: `url(${nmeBackground})` }}
+      />
+      <main className={styles.content}>
+        <header className={styles.header}>
+          <div className={styles.headerText}>
+            <h1 className={styles.title}>{tribeNME.name}</h1>
+            <p className={styles.owner}>Shop Owner: {tribeNME.owner}</p>
+          </div>
+        </header>
+
+        <section className={styles.grid} aria-label="Available items">
+          {displayItems.map((item, index) => (
+            <article key={`${item.name}-${index}`} className={styles.card}>
+              <h2 className={styles.cardTitle}>{item.name}</h2>
+              {item.description && (
+                <p className={styles.description}>{item.description}</p>
+              )}
+              <p className={styles.price}>{formatPrice(item)}</p>
+            </article>
+          ))}
+        </section>
+
+        <p className={styles.footerNote}>{tribeNME.insults[0]}</p>
+      </main>
+    </div>
+  );
+}

--- a/src/tribeNME.ts
+++ b/src/tribeNME.ts
@@ -1,0 +1,72 @@
+import { Item, Tribe } from "./types";
+
+export interface NMEItem extends Item {
+  priceText?: string;
+}
+
+export const tribeNME: Tribe & { items: NMEItem[] } = {
+  name: "N.M.E.",
+  owner: "Fred the Vampire",
+  percentAngry: 0,
+  priceVariability: 0,
+  insults: ["Power and secrets come at a cost—blood or coin will do."],
+  items: [
+    {
+      name: "Blood for Knowledge",
+      price: 0,
+      priceText: "10-50 Permanent HPs",
+      description: "Trade lasting vitality for forbidden lore from Fred's archives.",
+    },
+    {
+      name: "Blood for Power",
+      price: 0,
+      priceText: "Loss of 5-25 Permanent HPs",
+      description: "Sacrifice strength to gain raw, volatile power.",
+    },
+    {
+      name: "Blood for Blackmail",
+      price: 0,
+      priceText: "Loss of 5-25 Permanent HPs",
+      description: "Offer your essence to secure leverage over rivals.",
+    },
+    {
+      name: "Blood for An Endless Elixir",
+      price: 0,
+      priceText: "Loss of 5-25 Permanent HPs",
+      description: "Bleed into a vial that never runs dry—at a price to your lifeforce.",
+    },
+    {
+      name: "Blood for Spectral Servant",
+      price: 0,
+      priceText: "Loss of 5-25 Permanent HPs",
+      description: "Summon a bound spirit to serve, fueled by your own blood.",
+    },
+    {
+      name: "Blood for Legendary Artifact",
+      price: 0,
+      priceText: "Loss of 15-35 Permanent HPs",
+      description: "Secure an artifact of legend by pledging a deeper sacrifice.",
+    },
+    {
+      name: "Random Illegal Blueprint",
+      price: 50,
+      description: "Schematics too risky for open markets, offered discreetly.",
+    },
+    {
+      name: "Random Illegal Weapons",
+      price: 100,
+      description: "A surprise weapon smuggled from forbidden caches.",
+    },
+    {
+      name: "Scroll of True Resurrection",
+      price: 150,
+      description: "A rare scroll capable of restoring the fallen—if you dare pay.",
+    },
+    {
+      name: "Random Illegal Contraptions",
+      price: 0,
+      priceText: "150-2,000 Gold",
+      description: "Unpredictable devices with prices to match their volatility.",
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- create a new N.M.E. shop view mirroring Blossom Hotel functionality with Fred the Vampire’s offerings and gold price text
- style the N.M.E. cards with a dark, contrasting palette inspired by the background image, square layout, and a green back button
- wire the map to the N.M.E. shop and add a green navigation button after Labyrinthine Library using the N.M.E. asset

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69508af6f5388329a951357600da5551)