### PR TITLE
Add Sleuth University storefront

### DIFF
--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -62,6 +62,8 @@ import { ValhallaMart } from "./ValhallaMart";
 import valhallaMartImage from "./Valhalla Mart.png";
 import { BlossomHotel } from "./BlossomHotel";
 import blossomHotelImage from "./Blossom Hotel.png";
+import { SleuthUniversity } from "./SleuthUniversity";
+import sleuthUniversityImage from "./Sleuth.webp";
 import { EvansEnchantingEmporium } from "./EvansEnchantingEmporium";
 import evansEnchantingEmporiumImage from "./Evan's Enchanting Emporium.png";
 import { FairiesOfFlora } from "./FairiesOfFlora";
@@ -150,6 +152,8 @@ export function Map() {
       return <ValhallaMart onBack={() => setNavigatedTo("")} />;
     case "BlossomHotel":
       return <BlossomHotel onBack={() => setNavigatedTo("")} />;
+    case "SleuthUniversity":
+      return <SleuthUniversity onBack={() => setNavigatedTo("")} />;
     case "EvansEnchantingEmporium":
       return <EvansEnchantingEmporium onBack={() => setNavigatedTo("")} />;
     case "FairiesOfFlora":
@@ -490,6 +494,14 @@ export function Map() {
               backgroundColor="rgba(22, 163, 74, 0.95)"
               color="#04260f"
               imageSrc={nmeImage}
+            />
+            <FloatingButton
+              label="Sleuth University"
+              onClick={() => setNavigatedTo("SleuthUniversity")}
+              delay="49.25s"
+              backgroundColor="rgba(34, 197, 94, 0.95)"
+              color="#0a2f14"
+              imageSrc={sleuthUniversityImage}
             />
           </div>
         </div>

--- a/src/SleuthUniversity.module.css
+++ b/src/SleuthUniversity.module.css
@@ -1,0 +1,132 @@
+.app {
+  text-align: center;
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
+}
+
+.backgroundImage {
+  background: url('./Sleuth.webp') no-repeat center center fixed;
+  display: flex;
+  background-size: cover;
+  opacity: 0.78;
+  margin: 0;
+  z-index: -1;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  padding: 4rem 2rem 3rem;
+  align-items: center;
+  font-family: 'Times New Roman', serif;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.25rem;
+  background: rgba(12, 33, 50, 0.85);
+  border: 2px solid #d7c07a;
+  box-shadow: 8px 10px rgba(0, 0, 0, 0.35);
+  border-radius: 18px;
+  padding: 1.4rem 2rem;
+  max-width: 520px;
+  width: 100%;
+  color: #f3e7c0;
+}
+
+.headerText {
+  text-align: center;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.3rem;
+  color: #f7d774;
+  letter-spacing: 0.5px;
+}
+
+.owner {
+  margin: 0.2rem 0;
+  font-size: 1.05rem;
+  color: #d9e6f2;
+}
+
+.grid {
+  display: grid;
+  gap: 1.4rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  width: 100%;
+  max-width: 880px;
+}
+
+.card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1.5rem 1.4rem;
+  background: linear-gradient(145deg, rgba(20, 47, 66, 0.92), rgba(34, 78, 96, 0.92));
+  border: 2px solid #d7c07a;
+  border-radius: 18px;
+  color: #f3e7c0;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  font-size: 1rem;
+  box-shadow: 0 18px 28px rgba(0, 0, 0, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  width: 100%;
+  box-sizing: border-box;
+  aspect-ratio: 1 / 1;
+  overflow: hidden;
+}
+
+.card::after {
+  content: "";
+  position: absolute;
+  inset: 10px;
+  border-radius: 14px;
+  border: 1px solid rgba(215, 192, 122, 0.25);
+  pointer-events: none;
+}
+
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 22px 36px rgba(0, 0, 0, 0.4);
+}
+
+.cardTitle {
+  margin: 0;
+  font-size: 1.2rem;
+  color: #f7d774;
+  text-align: center;
+}
+
+.description {
+  margin: 0.4rem 0 0.6rem;
+  color: #d8e3ed;
+  font-size: 0.98rem;
+  text-align: center;
+}
+
+.price {
+  margin: 0;
+  font-weight: bold;
+  color: #9ed2ff;
+  font-size: 1.05rem;
+}
+
+.footerNote {
+  margin: 0.25rem 0 0;
+  color: #f3e7c0;
+  font-weight: bold;
+}

--- a/src/SleuthUniversity.tsx
+++ b/src/SleuthUniversity.tsx
@@ -1,0 +1,80 @@
+import { useMemo } from "react";
+import styles from "./SleuthUniversity.module.css";
+import { BackButton } from "./BackButton";
+import { Item } from "./types";
+import {
+  SleuthUniversityItem,
+  tribeSleuthUniversity,
+} from "./tribeSleuthUniversity";
+import sleuthBackground from "./Sleuth.webp";
+
+type DisplayItem = SleuthUniversityItem & { finalPrice: number };
+
+function calculateAdjustedPrice(item: Item, priceVariability: number): number {
+  const variability = ((Math.random() * priceVariability) / 100) * item.price;
+  const upOrDown = Math.random() < 0.5 ? -1 : 1;
+  const adjusted = item.price + upOrDown * variability;
+
+  return Math.max(0, Math.round(adjusted));
+}
+
+function formatPrice(item: DisplayItem): string {
+  if (item.priceText) return item.priceText;
+  return `${item.finalPrice.toLocaleString()} Gold`;
+}
+
+export function SleuthUniversity({ onBack }: { onBack?: () => void }) {
+  const displayItems: DisplayItem[] = useMemo(
+    () =>
+      tribeSleuthUniversity.items.map((item) => ({
+        ...item,
+        finalPrice:
+          item.price > 0
+            ? calculateAdjustedPrice(item, tribeSleuthUniversity.priceVariability)
+            : 0,
+      })),
+    []
+  );
+
+  return (
+    <div className={styles.app}>
+      <BackButton
+        onClick={onBack}
+        style={{
+          backgroundColor: "#22c55e",
+          borderColor: "#166534",
+          color: "#0f172a",
+          boxShadow: "0 6px 14px rgba(0, 0, 0, 0.35)",
+        }}
+      />
+      <div
+        className={styles.backgroundImage}
+        style={{ backgroundImage: `url(${sleuthBackground})` }}
+      />
+      <main className={styles.content}>
+        <header className={styles.header}>
+          <div className={styles.headerText}>
+            <h1 className={styles.title}>{tribeSleuthUniversity.name}</h1>
+            <p className={styles.owner}>
+              Shop Owner: {tribeSleuthUniversity.owner}
+            </p>
+          </div>
+        </header>
+
+        <section className={styles.grid} aria-label="Available items">
+          {displayItems.map((item, index) => (
+            <article key={`${item.name}-${index}`} className={styles.card}>
+              <h2 className={styles.cardTitle}>{item.name}</h2>
+              {item.description && (
+                <p className={styles.description}>{item.description}</p>
+              )}
+              <p className={styles.price}>{formatPrice(item)}</p>
+            </article>
+          ))}
+        </section>
+
+        <p className={styles.footerNote}>{tribeSleuthUniversity.insults[0]}</p>
+      </main>
+    </div>
+  );
+}

--- a/src/tribeSleuthUniversity.ts
+++ b/src/tribeSleuthUniversity.ts
@@ -1,0 +1,41 @@
+import { Item, Tribe } from "./types";
+
+export interface SleuthUniversityItem extends Item {
+  priceText?: string;
+}
+
+export const tribeSleuthUniversity: Tribe & { items: SleuthUniversityItem[] } = {
+  name: "Sleuth University",
+  owner: "Professor Layton",
+  percentAngry: 0,
+  priceVariability: 8,
+  insults: ["Every puzzle has an answer—follow the clues you can afford."],
+  items: [
+    {
+      name: "Lost & Found",
+      price: 5,
+      description: "Track misplaced belongings through the campus network.",
+    },
+    {
+      name: "Hire a Private Investigator / Spy / Ninja",
+      price: 10,
+      priceText: "Novice 10 Gold, Appreciate 25 Gold, or Master 50 Gold",
+      description: "Pick the level of stealth support that fits your mystery.",
+    },
+    {
+      name: "Rent Experimental Spell / Magic item",
+      price: 20,
+      description: "Borrow cutting-edge arcana for field tests and capers.",
+    },
+    {
+      name: "High-Quality Architecture blueprints",
+      price: 30,
+      description: "Detailed, trustworthy plans for infiltration or restoration.",
+    },
+    {
+      name: "Artisans Tomes of Learning (Fill in an empty skill with anything from the artisan's tool/kit list plus Enchanting, Engineering, & Magic-tech. You can have three different Artisans' skills, but only ten are between all three)",
+      price: 75,
+      description: "Structured study to master specialized artisan disciplines.",
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- add a Sleuth University shop that mirrors the Blossom Hotel experience with a detective-inspired palette and Sleuth.webp background
- populate the new offerings with updated gold pricing and square card styling for contrast
- link the storefront from the map with a green button placed after N.M.E.

## Testing
- npm run build (warnings in existing BookBombs.tsx and RunestoneRelay.tsx about invalid aria-* attribute names)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69508cec95a08329bac8fba025c323fd)