### PR TITLE
Add Fizzy Tales shop based on Blossom Hotel layout

### DIFF
--- a/src/FizzyTales.module.css
+++ b/src/FizzyTales.module.css
@@ -1,0 +1,135 @@
+.app {
+  text-align: center;
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
+}
+
+.backgroundImage {
+  background: url('./Sleuth.webp') no-repeat center center fixed;
+  display: flex;
+  background-size: cover;
+  opacity: 0.8;
+  margin: 0;
+  z-index: -1;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  filter: saturate(1.05);
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  padding: 4rem 2rem 3rem;
+  align-items: center;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  background: rgba(11, 30, 47, 0.82);
+  border: 3px solid rgba(125, 211, 252, 0.8);
+  box-shadow: 0 14px 30px rgba(6, 24, 38, 0.45);
+  border-radius: 18px;
+  padding: 1.4rem 2rem;
+  max-width: 440px;
+  width: 100%;
+  backdrop-filter: blur(4px);
+}
+
+.headerText {
+  text-align: center;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.35rem;
+  color: #e0f2fe;
+  letter-spacing: 0.5px;
+}
+
+.owner {
+  margin: 0.2rem 0;
+  font-size: 1.05rem;
+  color: #a5f3fc;
+}
+
+.grid {
+  display: grid;
+  gap: 1.6rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  width: 100%;
+  max-width: 900px;
+  justify-items: center;
+}
+
+.card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  padding: 1.4rem 1.6rem;
+  background: radial-gradient(circle at 30% 30%, rgba(125, 211, 252, 0.9), rgba(14, 34, 54, 0.95));
+  border: 4px solid rgba(56, 189, 248, 0.85);
+  border-radius: 50%;
+  color: #e2f3ff;
+  font-size: 1rem;
+  box-shadow: 0 18px 36px rgba(6, 24, 38, 0.5);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+  width: 260px;
+  aspect-ratio: 1 / 1;
+  box-sizing: border-box;
+  overflow: hidden;
+}
+
+.card::after {
+  content: "";
+  position: absolute;
+  inset: 10px;
+  border-radius: 50%;
+  border: 1px solid rgba(226, 243, 255, 0.35);
+  pointer-events: none;
+}
+
+.card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 22px 40px rgba(6, 24, 38, 0.65);
+}
+
+.cardTitle {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #f1f5f9;
+  text-align: center;
+}
+
+.description {
+  margin: 0.35rem 0 0.5rem;
+  color: #c7e8ff;
+  font-size: 0.97rem;
+  text-align: center;
+  line-height: 1.35;
+}
+
+.price {
+  margin: 0;
+  font-weight: 700;
+  color: #fcd34d;
+  font-size: 1.05rem;
+}
+
+.footerNote {
+  margin: 0.25rem 0 0;
+  color: #e0f2fe;
+  font-weight: bold;
+  text-shadow: 0 2px 6px rgba(6, 24, 38, 0.5);
+}

--- a/src/FizzyTales.tsx
+++ b/src/FizzyTales.tsx
@@ -1,0 +1,71 @@
+import { useMemo } from "react";
+import styles from "./FizzyTales.module.css";
+import { BackButton } from "./BackButton";
+import { Item } from "./types";
+import { FizzyTalesItem, tribeFizzyTales } from "./tribeFizzyTales";
+import fizzyTalesBackground from "./Sleuth.webp";
+
+type DisplayItem = FizzyTalesItem & { finalPrice: number };
+
+function calculateAdjustedPrice(item: Item, priceVariability: number): number {
+  const variability = ((Math.random() * priceVariability) / 100) * item.price;
+  const upOrDown = Math.random() < 0.5 ? -1 : 1;
+  const adjusted = item.price + upOrDown * variability;
+
+  return Math.max(0, Math.round(adjusted));
+}
+
+function formatPrice(item: DisplayItem): string {
+  if (item.priceText) return item.priceText;
+  return `${item.finalPrice.toLocaleString()} Gold`;
+}
+
+export function FizzyTales({ onBack }: { onBack?: () => void }) {
+  const displayItems: DisplayItem[] = useMemo(
+    () =>
+      tribeFizzyTales.items.map((item) => ({
+        ...item,
+        finalPrice:
+          item.price > 0 ? calculateAdjustedPrice(item, tribeFizzyTales.priceVariability) : 0,
+      })),
+    []
+  );
+
+  return (
+    <div className={styles.app}>
+      <BackButton
+        onClick={onBack}
+        style={{
+          backgroundColor: "#2563eb",
+          borderColor: "#1d4ed8",
+          color: "#e2e8f0",
+          boxShadow: "0 8px 18px rgba(37, 99, 235, 0.35)",
+        }}
+      />
+      <div
+        className={styles.backgroundImage}
+        style={{ backgroundImage: `url(${fizzyTalesBackground})` }}
+      />
+      <main className={styles.content}>
+        <header className={styles.header}>
+          <div className={styles.headerText}>
+            <h1 className={styles.title}>{tribeFizzyTales.name}</h1>
+            <p className={styles.owner}>Shop Owner: {tribeFizzyTales.owner}</p>
+          </div>
+        </header>
+
+        <section className={styles.grid} aria-label="Available items">
+          {displayItems.map((item, index) => (
+            <article key={`${item.name}-${index}`} className={styles.card}>
+              <h2 className={styles.cardTitle}>{item.name}</h2>
+              {item.description && <p className={styles.description}>{item.description}</p>}
+              <p className={styles.price}>{formatPrice(item)}</p>
+            </article>
+          ))}
+        </section>
+
+        <p className={styles.footerNote}>{tribeFizzyTales.insults[0]}</p>
+      </main>
+    </div>
+  );
+}

--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -79,6 +79,7 @@ import { LabyrinthineLibrary } from "./LabyrinthineLibrary";
 import labyrinthineLibraryImage from "./Labyrinthine Labrary.png";
 import { NME } from "./NME";
 import nmeImage from "./N.M.E.png";
+import { FizzyTales } from "./FizzyTales";
 
 // Remove stray whitespace/newlines from data URIs (defensive)
 function cleanDataUrl(s?: string) {
@@ -164,6 +165,8 @@ export function Map() {
       return <LabyrinthineLibrary onBack={() => setNavigatedTo("")} />;
     case "NME":
       return <NME onBack={() => setNavigatedTo("")} />;
+    case "FizzyTales":
+      return <FizzyTales onBack={() => setNavigatedTo("")} />;
     case "PiggyBank":
       return <PiggyBank onBack={() => setNavigatedTo("")} />;
     case "NavigationGuild":
@@ -501,6 +504,14 @@ export function Map() {
               delay="49.25s"
               backgroundColor="rgba(34, 197, 94, 0.95)"
               color="#0a2f14"
+              imageSrc={sleuthUniversityImage}
+            />
+            <FloatingButton
+              label="Fizzy Tales"
+              onClick={() => setNavigatedTo("FizzyTales")}
+              delay="49.5s"
+              backgroundColor="rgba(59, 130, 246, 0.92)"
+              color="#e2e8f0"
               imageSrc={sleuthUniversityImage}
             />
           </div>

--- a/src/tribeFizzyTales.ts
+++ b/src/tribeFizzyTales.ts
@@ -1,0 +1,46 @@
+import { Item, Tribe } from "./types";
+
+export interface FizzyTalesItem extends Item {
+  priceText?: string;
+}
+
+export const tribeFizzyTales: Tribe & { items: FizzyTalesItem[] } = {
+  name: "Fizzy Tales",
+  owner: "Candy Cane Princess",
+  percentAngry: 0,
+  priceVariability: 0,
+  insults: ["Sweet secrets fizz to the surface—pick your treat and enjoy the story."],
+  items: [
+    {
+      name: "Moon Rocks",
+      price: 5,
+      description: "The eater becomes nearly weightless, floating gently for 10 min.",
+    },
+    {
+      name: "Bubble Barrier",
+      price: 5,
+      description:
+        "A stick of bubble gum that, once blown, creates a semi-durable barrier with 2d12+5 HP and an AC of 13, lasting up to 10 minutes.",
+    },
+    {
+      name: "Mirror Mints",
+      price: 10,
+      description: "Allows the user to pass through mirrors into a mirror realm for up to 1 hour.",
+    },
+    {
+      name: "Proxy Dust",
+      price: 10,
+      description: "Enables control over a small doll as if inhabiting it, lasting for 1 hour.",
+    },
+    {
+      name: "Gerald-d dry",
+      price: 200,
+      description: "A carbonated drink that heals half of the drinker's HP.",
+    },
+    {
+      name: "Winter Wafers",
+      price: 200,
+      description: "Increase a stat point by 1, stat points can not pass 18.",
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- add Fizzy Tales shop modeled on the Blossom Hotel layout with Sleuth-inspired backdrop and blue navigation button
- introduce circular, teal-to-navy card styling that contrasts the background while keeping prices in Gold
- link the new shop from the map directly after Sleuth University using the Sleuth artwork

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69508f9584a08329a2c7483b244e6773)