### PR TITLE
Add Sandbox destinations menu and refresh main menu spacing

### DIFF
--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -82,6 +82,22 @@ import nmeImage from "./N.M.E.png";
 import { FizzyTales } from "./FizzyTales";
 import { YeOldHomeDepot } from "./YeOldHomeDepot";
 import yeOldHomeDepotImage from "./Ye Old Home Depot.webp";
+import sandboxWorldMapImage from "./SandboxWorldMap.webp";
+import sandboxAnalepticHoltImage from "./SandboxAnalepticHolt.webp";
+import sandboxBallisticBellowsImage from "./SandboxBallisticBellows.webp";
+import sandboxBigHomeImage from "./SandboxBigHome.webp";
+import sandboxButtingRamsImage from "./SandboxButtingRams.webp";
+import sandboxByfordDolphinImage from "./SandboxByfordDolphin.webp";
+import sandboxCalidrisImage from "./SandboxCalidris.webp";
+import sandboxGraveBornImage from "./SandboxGraveBorn.webp";
+import sandboxHebronImage from "./SandboxHebron.webp";
+import sandboxJellyCityImage from "./SandboxJellyCity.webp";
+import sandboxMeanderImage from "./SandboxMeander.webp";
+import sandboxMerricksGroveImage from "./SandboxMerricksGrove.webp";
+import sandboxOrbitingCityImage from "./SandboxOrbitingCity.webp";
+import sandboxPopNFaithImage from "./SandboxPop-nFaith.webp";
+import sandboxSeymoursDriftImage from "./SandboxSeymoursDrift.webp";
+import sandboxWytheholdeImage from "./SandboxWytheholde.webp";
 
 // Remove stray whitespace/newlines from data URIs (defensive)
 function cleanDataUrl(s?: string) {
@@ -121,6 +137,121 @@ function useTextImage(text?: string) {
   }, [text]);
   return dataUrl;
 }
+
+type SandboxTown = {
+  key: string;
+  name: string;
+  description: string;
+  image: string;
+};
+
+const sandboxTowns: SandboxTown[] = [
+  {
+    key: "withhold",
+    name: "Withhold (Parker)",
+    image: sandboxWytheholdeImage,
+    description:
+      "Nestled between warm rolling hills and jagged, freezing mountains, Withhold grows famous home-grown food but struggles for medicine once winter comes. As they live in Wandering Titan territory, nearly everyone knows how to flee into the tight valley caves when danger looms, preserving the town's dwindling stories.",
+  },
+  {
+    key: "butting-rams",
+    name: "Butting Rams",
+    image: sandboxButtingRamsImage,
+    description:
+      "Barbarians here love fighting, feasting, and boasting about both. Their town is literally split between two enormous rams that butt heads, catapulting residents back and forth—thankfully the rams are fluffy enough to make the landings survivable before the traditional 15-minute free-for-all.",
+  },
+  {
+    key: "meander",
+    name: "Meander (Michael)",
+    image: sandboxMeanderImage,
+    description:
+      "A cowboy's dream that never settles, Meander roams Wandering Titan territory after draining every Magitek Oil spot. Constant desert travel keeps crops from thriving, so the townsfolk trade for food while clinging to a strong moral compass they defend fiercely.",
+  },
+  {
+    key: "calidris",
+    name: "Calidris (Fisk)",
+    image: sandboxCalidrisImage,
+    description:
+      "Created as an artisans' paradise with no creative limits, Calidris thrived—until every living resident vanished overnight. Only the golems and robots remain, tirelessly working while ignoring their missing masters.",
+  },
+  {
+    key: "merricks-meadow",
+    name: "Merrick's Meadow (Howard)",
+    image: sandboxMerricksGroveImage,
+    description:
+      "This humble village boomed after discovering rare herbs. Newcomers flock to Merrick's Meadow for its newfound fame, while longtime residents grumble about the crowds disturbing their once-tranquil home.",
+  },
+  {
+    key: "ballistic-bellows",
+    name: "Ballistic Bellows (Caleb)",
+    image: sandboxBallisticBellowsImage,
+    description:
+      "Punctual and industrious, every citizen can run a forge or clockwork device. Their advanced weapons self-destruct if reverse engineered, protecting the secrets behind their booming craft.",
+  },
+  {
+    key: "byford-dolphin",
+    name: "Byford Dolphin (Robertson)",
+    image: sandboxByfordDolphinImage,
+    description:
+      "Wealth dictates status in Byford Dolphin. Legendary metals pulled from the sea fund the Clockwork King's construction projects, while the richest citizen holds the House of Blades contract—and the bill that comes with it.",
+  },
+  {
+    key: "hebron",
+    name: "Hebron (Joshua)",
+    image: sandboxHebronImage,
+    description:
+      "After the Missing Millennium, Hebron secured a monopoly on Thunder Cores by salvaging and purchasing every relic they could find. Now it's a hub for minds devoted to unlocking the power behind these remnants.",
+  },
+  {
+    key: "jelly-city",
+    name: "Jelly City",
+    image: sandboxJellyCityImage,
+    description:
+      "Built vertically inside a Wandering Titan jellyfish, this flexible city produces medicine that keeps the Disciples of Mother battle-ready. Its secrets are hard to see, but unforgettable once witnessed.",
+  },
+  {
+    key: "pop-n-faith",
+    name: "Pop-n Faith (Eli)",
+    image: sandboxPopNFaithImage,
+    description:
+      "Deities literally walk among the people here, balancing each other so none gains dominance. Their collective aura keeps their Wandering Titan host cowering, while mortals navigate divine politics daily.",
+  },
+  {
+    key: "analeptic-holt",
+    name: "Analeptic Holt (Teag)",
+    image: sandboxAnalepticHoltImage,
+    description:
+      "Hidden beneath an ancient jungle canopy, Hadozee gliders live among massive roots and high branches. They cherish harmony with their environment but stay guarded with outsiders to protect their traditions.",
+  },
+  {
+    key: "seymours-drift",
+    name: "Seymour's Drift (Melanie)",
+    image: sandboxSeymoursDriftImage,
+    description:
+      "A sprawling city on a giant drifting lily pad, Seymour's Drift follows the tides while serving its enigmatic leader, Audrey the Second. Residents bond over devotion, firearms, and an unyielding love of meat.",
+  },
+  {
+    key: "graveborn",
+    name: "Graveborn",
+    image: sandboxGraveBornImage,
+    description:
+      "A sanctuary for the undead, founded before the 75-year war so vampires, zombies, skeletons, and even dream visages could live free. Left alone, the undead eventually wander toward this vibrant necropolis.",
+  },
+  {
+    key: "orbiting-city",
+    name: "Orbiting City",
+    image: sandboxOrbitingCityImage,
+    description:
+      "Humanity pushed the impossible to reality, building a city that sails the sky thanks to alliances and generosity toward the Clockwork King. Its flight marks a new era of exploration and diplomacy.",
+  },
+  {
+    key: "big-home",
+    name: "Big Home",
+    image: sandboxBigHomeImage,
+    description:
+      "Orcs value family, honesty, and loyalty. After 'Mother' guided them to shun technology and guard the secrets of the Missing Millennium, their strength in numbers and conviction makes them formidable when provoked.",
+  },
+];
 
 export function Map() {
   const [navigatedTo, setNavigatedTo] = useState<string>("");
@@ -215,11 +346,21 @@ export function Map() {
       return <JazzPortablePotions onBack={() => setNavigatedTo("")} />;
     case "JewelryGuild":
       return <JewelryGuild onBack={() => setNavigatedTo("")} />;
+    case "Sandbox":
+      return <SandboxMenu onBack={() => setNavigatedTo("")} />;
     default:
       return (
         <div style={styles.wrapper}>
           <h1 style={styles.title}>Which world would you like to go to?</h1>
           <div style={styles.buttonContainer}>
+            <FloatingButton
+              label="Sandbox"
+              onClick={() => setNavigatedTo("Sandbox")}
+              delay="1.5s"
+              backgroundColor="rgba(15, 23, 42, 0.85)"
+              color="#e2e8f0"
+              imageSrc={sandboxWorldMapImage}
+            />
             <FloatingButton
               label="Goblin Market"
               onClick={() => setNavigatedTo("goblins")}
@@ -533,6 +674,44 @@ export function Map() {
   }
 }
 
+function SandboxMenu({ onBack }: { onBack: () => void }) {
+  return (
+    <div style={styles.wrapper}>
+      <button type="button" onClick={onBack} style={styles.backButton}>
+        ← Back to main menu
+      </button>
+      <div style={styles.sandboxIntro}>
+        <img
+          src={sandboxWorldMapImage}
+          alt="Sandbox world map"
+          style={styles.sandboxIntroImage}
+        />
+        <div style={styles.sandboxIntroText}>
+          <h1 style={styles.title}>Sandbox Destinations</h1>
+          <p>
+            Explore every corner of the Sandbox realm. Each town is wrapped in its own
+            legend—tap a destination to learn the vibe before you dive in.
+          </p>
+        </div>
+      </div>
+      <div style={styles.sandboxGrid}>
+        {sandboxTowns.map((town) => (
+          <FloatingButton
+            key={town.key}
+            label={town.name}
+            description={town.description}
+            imageSrc={town.image}
+            backgroundColor="rgba(30, 41, 59, 0.88)"
+            color="#e2e8f0"
+            delay="0s"
+            onClick={() => {}}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
 function FloatingButton({
   label,
   onClick,
@@ -540,6 +719,7 @@ function FloatingButton({
   backgroundColor,
   color = "#000",
   imageSrc,
+  description,
 }: {
   label: string;
   onClick: () => void;
@@ -547,6 +727,7 @@ function FloatingButton({
   backgroundColor: string;
   color?: string;
   imageSrc?: string;
+  description?: string;
 }) {
   return (
     <button
@@ -563,6 +744,7 @@ function FloatingButton({
         <div style={styles.buttonContent}>
           <img src={imageSrc} alt={`${label} logo`} style={styles.buttonImage} />
           <span style={styles.buttonLabel}>{label}</span>
+          {description ? <p style={styles.buttonDescription}>{description}</p> : null}
         </div>
       ) : (
         label
@@ -584,7 +766,7 @@ const styles: Record<string, React.CSSProperties> = {
     backgroundPosition: "center",
     backgroundAttachment: "fixed",
     width: "100%",
-    height: "100%"
+    height: "100%",
   },
   title: {
     fontSize: "2.5rem",
@@ -596,14 +778,14 @@ const styles: Record<string, React.CSSProperties> = {
     display: "flex",
     flexDirection: "column",
     alignItems: "center",
-    gap: "auto",
-    padding: "auto",
-    width: "auto",
+    gap: "1.25rem",
+    padding: "2rem 1rem 3rem",
+    width: "min(1100px, 95vw)",
   },
   button: {
     fontSize: "1.5rem",
-    padding: "auto",
-    borderRadius: "auto",
+    padding: "1.25rem 1.5rem",
+    borderRadius: "18px",
     border: "2px solid #ffffffff",
     boxShadow: "0 7px 12px rgba(0, 0, 0, 0.5)",
     cursor: "pointer",
@@ -613,16 +795,18 @@ const styles: Record<string, React.CSSProperties> = {
     display: "flex",
     flexDirection: "column",
     alignItems: "center",
-    gap: "0.75rem",
+    gap: "0.85rem",
+    width: "100%",
+    maxWidth: "100%",
   },
   backButton: {
     position: "fixed",
     top: "1.5rem",
     left: "1.5rem",
     zIndex: 1000,
-    padding: "auto",
+    padding: "0.75rem 1rem",
     fontSize: "1rem",
-    borderRadius: "auto",
+    borderRadius: "14px",
     border: "2px solid #ffffffff",
     backgroundColor: "rgba(255, 255, 255, 1)",
     boxShadow: "4 4px 10px rgba(0, 0, 0, 0.25)",
@@ -633,19 +817,58 @@ const styles: Record<string, React.CSSProperties> = {
     display: "flex",
     flexDirection: "column",
     alignItems: "center",
-    gap: "0.35rem",
+    gap: "0.5rem",
+    width: "100%",
   },
   buttonImage: {
-    width: "140px",
+    width: "160px",
     height: "auto",
     objectFit: "contain",
-    borderRadius: "auto",
+    borderRadius: "14px",
     border: "2px solid rgba(255, 255, 255, 0.6)",
     backgroundColor: "rgba(255,255,255,0.85)",
     boxShadow: "4 4px 8px rgba(0,0,0,0.35)",
   },
   buttonLabel: {
     display: "block",
+    fontWeight: 700,
+    textAlign: "center",
+  },
+  buttonDescription: {
+    margin: 0,
+    fontSize: "0.95rem",
+    lineHeight: 1.45,
+    textAlign: "center",
+    maxWidth: "720px",
+  },
+  sandboxIntro: {
+    marginTop: "4.5rem",
+    display: "flex",
+    alignItems: "center",
+    gap: "1.5rem",
+    backgroundColor: "rgba(0, 0, 0, 0.65)",
+    padding: "1.5rem",
+    borderRadius: "18px",
+    width: "min(1100px, 95vw)",
+  },
+  sandboxIntroImage: {
+    width: "220px",
+    height: "auto",
+    borderRadius: "16px",
+    border: "2px solid rgba(255, 255, 255, 0.7)",
+    boxShadow: "4px 6px 12px rgba(0,0,0,0.4)",
+  },
+  sandboxIntroText: {
+    color: "#ffffff",
+    lineHeight: 1.5,
+  },
+  sandboxGrid: {
+    marginTop: "1.25rem",
+    display: "grid",
+    gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
+    gap: "1.25rem",
+    width: "min(1100px, 95vw)",
+    paddingBottom: "3rem",
   },
 };
 


### PR DESCRIPTION
## Summary
- add a Sandbox entry to the main menu with a submenu that presents every Sandbox town using its dedicated artwork and description
- refresh menu button spacing, padding, and rounding to give items more breathing room and clarity
- introduce a Sandbox destinations header with map artwork and a back control to return to the main menu

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950b19ccc908329812b771325fe1159)