### PR TITLE
Refine Sandbox menu with dedicated layout and shop listings

### DIFF
--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -82,6 +82,8 @@ import nmeImage from "./N.M.E.png";
 import { FizzyTales } from "./FizzyTales";
 import { YeOldHomeDepot } from "./YeOldHomeDepot";
 import yeOldHomeDepotImage from "./Ye Old Home Depot.webp";
+import sandboxWorldMapImage from "./SandboxWorldMap.webp";
+import { SandboxMenu } from "./SandboxMenu";
 
 // Remove stray whitespace/newlines from data URIs (defensive)
 function cleanDataUrl(s?: string) {
@@ -215,11 +217,21 @@ export function Map() {
       return <JazzPortablePotions onBack={() => setNavigatedTo("")} />;
     case "JewelryGuild":
       return <JewelryGuild onBack={() => setNavigatedTo("")} />;
+    case "Sandbox":
+      return <SandboxMenu onBack={() => setNavigatedTo("")} />;
     default:
       return (
         <div style={styles.wrapper}>
           <h1 style={styles.title}>Which world would you like to go to?</h1>
           <div style={styles.buttonContainer}>
+            <FloatingButton
+              label="Sandbox"
+              onClick={() => setNavigatedTo("Sandbox")}
+              delay="1.5s"
+              backgroundColor="rgba(15, 23, 42, 0.85)"
+              color="#e2e8f0"
+              imageSrc={sandboxWorldMapImage}
+            />
             <FloatingButton
               label="Goblin Market"
               onClick={() => setNavigatedTo("goblins")}
@@ -584,7 +596,7 @@ const styles: Record<string, React.CSSProperties> = {
     backgroundPosition: "center",
     backgroundAttachment: "fixed",
     width: "100%",
-    height: "100%"
+    height: "100%",
   },
   title: {
     fontSize: "2.5rem",
@@ -596,14 +608,14 @@ const styles: Record<string, React.CSSProperties> = {
     display: "flex",
     flexDirection: "column",
     alignItems: "center",
-    gap: "auto",
-    padding: "auto",
-    width: "auto",
+    gap: "1.25rem",
+    padding: "2rem 1rem 3rem",
+    width: "min(1100px, 95vw)",
   },
   button: {
     fontSize: "1.5rem",
-    padding: "auto",
-    borderRadius: "auto",
+    padding: "1.25rem 1.5rem",
+    borderRadius: "18px",
     border: "2px solid #ffffffff",
     boxShadow: "0 7px 12px rgba(0, 0, 0, 0.5)",
     cursor: "pointer",
@@ -613,16 +625,18 @@ const styles: Record<string, React.CSSProperties> = {
     display: "flex",
     flexDirection: "column",
     alignItems: "center",
-    gap: "0.75rem",
+    gap: "0.85rem",
+    width: "100%",
+    maxWidth: "100%",
   },
   backButton: {
     position: "fixed",
     top: "1.5rem",
     left: "1.5rem",
     zIndex: 1000,
-    padding: "auto",
+    padding: "0.75rem 1rem",
     fontSize: "1rem",
-    borderRadius: "auto",
+    borderRadius: "14px",
     border: "2px solid #ffffffff",
     backgroundColor: "rgba(255, 255, 255, 1)",
     boxShadow: "4 4px 10px rgba(0, 0, 0, 0.25)",
@@ -633,19 +647,22 @@ const styles: Record<string, React.CSSProperties> = {
     display: "flex",
     flexDirection: "column",
     alignItems: "center",
-    gap: "0.35rem",
+    gap: "0.5rem",
+    width: "100%",
   },
   buttonImage: {
-    width: "140px",
+    width: "160px",
     height: "auto",
     objectFit: "contain",
-    borderRadius: "auto",
+    borderRadius: "14px",
     border: "2px solid rgba(255, 255, 255, 0.6)",
     backgroundColor: "rgba(255,255,255,0.85)",
     boxShadow: "4 4px 8px rgba(0,0,0,0.35)",
   },
   buttonLabel: {
     display: "block",
+    fontWeight: 700,
+    textAlign: "center",
   },
 };
 

--- a/src/SandboxMenu.module.css
+++ b/src/SandboxMenu.module.css
@@ -1,0 +1,180 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  min-height: 100vh;
+  padding: 2rem 1.25rem 3rem;
+  background: radial-gradient(circle at 25% 20%, rgba(94, 234, 212, 0.08), transparent 32%),
+    radial-gradient(circle at 80% 10%, rgba(129, 140, 248, 0.12), transparent 35%),
+    radial-gradient(circle at 50% 60%, rgba(248, 113, 113, 0.08), transparent 40%),
+    #0b1220;
+  color: #e2e8f0;
+}
+
+.backButton {
+  align-self: flex-start;
+  margin-bottom: 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  border: 2px solid rgba(255, 255, 255, 0.85);
+  background-color: rgba(255, 255, 255, 0.95);
+  color: #0f172a;
+  cursor: pointer;
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.35);
+  font-family: "Times New Roman", serif;
+  font-weight: 700;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.backButton:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 18px rgba(0, 0, 0, 0.45);
+}
+
+.header {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  gap: 1.5rem;
+  align-items: center;
+  padding: 1.5rem;
+  border-radius: 18px;
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.35);
+  width: min(1100px, 100%);
+}
+
+.heroImage {
+  width: 100%;
+  height: auto;
+  border-radius: 16px;
+  border: 2px solid rgba(255, 255, 255, 0.7);
+  box-shadow: 0 14px 24px rgba(0, 0, 0, 0.35);
+}
+
+.kicker {
+  margin: 0 0 0.25rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 700;
+  color: #a5b4fc;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.5rem;
+  color: #f8fafc;
+}
+
+.subtitle {
+  margin: 0.5rem 0 0;
+  line-height: 1.55;
+  color: #cbd5e1;
+}
+
+.grid {
+  margin-top: 1.5rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.25rem;
+  width: min(1100px, 100%);
+}
+
+.card {
+  position: relative;
+  padding: 1.25rem 1.25rem 1.5rem;
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  color: #e2e8f0;
+  text-align: left;
+  cursor: pointer;
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.35);
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+}
+
+.card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 20px 38px rgba(0, 0, 0, 0.45);
+  border-color: rgba(255, 255, 255, 0.5);
+}
+
+.cardOpen {
+  border-color: rgba(59, 130, 246, 0.6);
+  box-shadow: 0 22px 42px rgba(37, 99, 235, 0.25);
+}
+
+.cardTop {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.cardTitle {
+  font-size: 1.3rem;
+  font-weight: 800;
+  color: #f8fafc;
+}
+
+.chevron {
+  font-weight: 800;
+  color: #cbd5e1;
+}
+
+.preview {
+  margin: 0.65rem 0 0;
+  color: #cbd5e1;
+  font-size: 0.95rem;
+}
+
+.cardBody {
+  margin-top: 0.85rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.description {
+  margin: 0;
+  line-height: 1.5;
+  color: #e2e8f0;
+}
+
+.shopList {
+  background: rgba(15, 23, 42, 0.65);
+  border-radius: 14px;
+  padding: 0.85rem 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.shopList h3 {
+  margin: 0 0 0.45rem;
+  font-size: 1rem;
+  color: #c7d2fe;
+}
+
+.shopList ul {
+  margin: 0.25rem 0 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.shopList li {
+  line-height: 1.45;
+}
+
+.emptyState {
+  margin: 0;
+  color: #cbd5e1;
+}
+
+@media (max-width: 768px) {
+  .header {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/SandboxMenu.tsx
+++ b/src/SandboxMenu.tsx
@@ -1,0 +1,327 @@
+import { useState } from "react";
+import styles from "./SandboxMenu.module.css";
+import sandboxWorldMapImage from "./SandboxWorldMap.webp";
+import sandboxAnalepticHoltImage from "./SandboxAnalepticHolt.webp";
+import sandboxBallisticBellowsImage from "./SandboxBallisticBellows.webp";
+import sandboxBigHomeImage from "./SandboxBigHome.webp";
+import sandboxButtingRamsImage from "./SandboxButtingRams.webp";
+import sandboxByfordDolphinImage from "./SandboxByfordDolphin.webp";
+import sandboxCalidrisImage from "./SandboxCalidris.webp";
+import sandboxGraveBornImage from "./SandboxGraveBorn.webp";
+import sandboxHebronImage from "./SandboxHebron.webp";
+import sandboxJellyCityImage from "./SandboxJellyCity.webp";
+import sandboxMeanderImage from "./SandboxMeander.webp";
+import sandboxMerricksGroveImage from "./SandboxMerricksGrove.webp";
+import sandboxOrbitingCityImage from "./SandboxOrbitingCity.webp";
+import sandboxPopNFaithImage from "./SandboxPop-nFaith.webp";
+import sandboxSeymoursDriftImage from "./SandboxSeymoursDrift.webp";
+import sandboxWytheholdeImage from "./SandboxWytheholde.webp";
+
+type SandboxTown = {
+  key: string;
+  name: string;
+  description: string;
+  image: string;
+  shops: string[];
+};
+
+const sandboxTowns: SandboxTown[] = [
+  {
+    key: "withhold",
+    name: "Withhold (Parker)",
+    image: sandboxWytheholdeImage,
+    description:
+      "Nestled between warm rolling hills and jagged, freezing mountains, Withhold grows famous home-grown food but struggles for medicine once winter comes. As they live in Wandering Titan territory, nearly everyone knows how to flee into the tight valley caves when danger looms, preserving the town's dwindling stories.",
+    shops: [
+      "Applegarth Guild",
+      "Robin's Ropes",
+      "O-Papies Oracle Readings",
+      "Supreme Smithy",
+      "Fairies of Flora",
+      "Silent Oath",
+    ],
+  },
+  {
+    key: "butting-rams",
+    name: "Butting Rams",
+    image: sandboxButtingRamsImage,
+    description:
+      "Barbarians here love fighting, feasting, and boasting about both. Their town is literally split between two enormous rams that butt heads, catapulting residents back and forth—thankfully the rams are fluffy enough to make the landings survivable before the traditional 15-minute free-for-all.",
+    shops: ["Goblin Market"],
+  },
+  {
+    key: "meander",
+    name: "Meander (Michael)",
+    image: sandboxMeanderImage,
+    description:
+      "A cowboy's dream that never settles, Meander roams Wandering Titan territory after draining every Magitek Oil spot. Constant desert travel keeps crops from thriving, so the townsfolk trade for food while clinging to a strong moral compass they defend fiercely.",
+    shops: [
+      "Make a Monster",
+      "Michael's Mount",
+      "Iconic Dragonic",
+      "Paws, Claws, & Maws",
+      "Valhalla Mart",
+      "Bullets, Buffs, & Beyond",
+    ],
+  },
+  {
+    key: "calidris",
+    name: "Calidris; The Ghost Town that Kept Running (Fisk)",
+    image: sandboxCalidrisImage,
+    description:
+      "Created as an artisans' paradise with no creative limits, Calidris thrived—until every living resident vanished overnight. Only the golems and robots remain, tirelessly working while ignoring their missing masters.",
+    shops: [],
+  },
+  {
+    key: "merricks-meadow",
+    name: "Merrick's Meadow (Howard)",
+    image: sandboxMerricksGroveImage,
+    description:
+      "This humble village boomed after discovering rare herbs. Newcomers flock to Merrick's Meadow for its newfound fame, while longtime residents grumble about the crowds disturbing their once-tranquil home.",
+    shops: [
+      "Robin's Ropes",
+      "Applegarth Guild",
+      "Changing Church",
+      "O-Papies Oracle Readings",
+      "Silent Oath",
+      "Necromancy Insurance Company",
+      "Provision's Paradise",
+      "Jazz's Portable Potions",
+    ],
+  },
+  {
+    key: "ballistic-bellows",
+    name: "Ballistic Bellows (Caleb)",
+    image: sandboxBallisticBellowsImage,
+    description:
+      "Punctual and industrious, every citizen can run a forge or clockwork device. Their advanced weapons self-destruct if reverse engineered, protecting the secrets behind their booming craft.",
+    shops: [
+      "Will's Weapons",
+      "Comedy Gold",
+      "Navigation Guild",
+      "Dungeon Crawler Guild",
+      "Pearl's Potions",
+      "Provision's Paradise",
+      "Ye Old Donkey",
+      "The Piggy Bank, no hammers inside.",
+    ],
+  },
+  {
+    key: "byford-dolphin",
+    name: "Byford Dolphin (Robertson)",
+    image: sandboxByfordDolphinImage,
+    description:
+      "Wealth dictates status in Byford Dolphin. Legendary metals pulled from the sea fund the Clockwork King's construction projects, while the richest citizen holds the House of Blades contract—and the bill that comes with it.",
+    shops: [
+      "Auntie Patty's Pies",
+      "Blossom Hotel",
+      "Jewelry Guild",
+      "N.M.E.",
+      "Labyrinthine Library",
+      "Sleuth University",
+      "Changing Church",
+      "O-Papies Oracle Readings",
+    ],
+  },
+  {
+    key: "hebron",
+    name: "Hebron (Joshua)",
+    image: sandboxHebronImage,
+    description:
+      "After the Missing Millennium, Hebron secured a monopoly on Thunder Cores by salvaging and purchasing every relic they could find. Now it's a hub for minds devoted to unlocking the power behind these remnants.",
+    shops: [
+      "Supreme Smithy",
+      "Runestone Relay",
+      "Robin's Ropes",
+      "Silent Oath",
+      "Applegarth Guild",
+      "Necromancy Insurance Company",
+      "Evan's Enchanting Emporium",
+      "Sleuth University",
+      "Jewelry Guild",
+    ],
+  },
+  {
+    key: "jelly-city",
+    name: "Jelly City",
+    image: sandboxJellyCityImage,
+    description:
+      "Built vertically inside a Wandering Titan jellyfish, this flexible city produces medicine that keeps the Disciples of Mother battle-ready. Its secrets are hard to see, but unforgettable once witnessed.",
+    shops: ["Goblin Market", "Book Bombs", "Robin's Ropes", "Changing Church"],
+  },
+  {
+    key: "pop-n-faith",
+    name: "Pop-n Faith (Eli)",
+    image: sandboxPopNFaithImage,
+    description:
+      "Deities literally walk among the people here, balancing each other so none gains dominance. Their collective aura keeps their Wandering Titan host cowering, while mortals navigate divine politics daily.",
+    shops: [
+      "Jazz's Portable Potions",
+      "Blossom Hotel",
+      "Jewelry Guild",
+      "N.M.E.",
+      "Labyrinthine Library",
+      "Archives Guild",
+      "Supreme Smithy",
+      "Silent Oath",
+      "Will's Weapons",
+      "Evan's Enchanting Emporium",
+    ],
+  },
+  {
+    key: "analeptic-holt",
+    name: "Analeptic Holt (Teag)",
+    image: sandboxAnalepticHoltImage,
+    description:
+      "Hidden beneath an ancient jungle canopy, Hadozee gliders live among massive roots and high branches. They cherish harmony with their environment but stay guarded with outsiders to protect their traditions.",
+    shops: [
+      "Bullets, Buffs, & Beyond",
+      "Robin's Ropes",
+      "Changing Church",
+      "Necromancy Insurance Company",
+      "Runestone Relay",
+      "Sleuth University",
+      "Blossom Hotel",
+      "Fairies of Flora",
+      "Evan's Enchanting Emporium",
+      "Jazz's Portable Potions",
+    ],
+  },
+  {
+    key: "seymours-drift",
+    name: "Seymour's Drift (Melanie)",
+    image: sandboxSeymoursDriftImage,
+    description:
+      "A sprawling city on a giant drifting lily pad, Seymour's Drift follows the tides while serving its enigmatic leader, Audrey the Second. Residents bond over devotion, firearms, and an unyielding love of meat.",
+    shops: [
+      "Blossom Hotel",
+      "Fairies of Flora",
+      "Sleuth University",
+      "Jewelry Guild",
+      "Evan's Enchanting Emporium",
+      "Labyrinthine Library",
+      "Will's Weapons",
+      "Archives Guild",
+      "Supreme Smithy",
+      "Applegarth Guild",
+    ],
+  },
+  {
+    key: "graveborn",
+    name: "Graveborn",
+    image: sandboxGraveBornImage,
+    description:
+      "A sanctuary for the undead, founded before the 75-year war so vampires, zombies, skeletons, and even dream visages could live free. Left alone, the undead eventually wander toward this vibrant necropolis.",
+    shops: [
+      "Iconic Dragonic",
+      "Make a Monster",
+      "Michael's Mount",
+      "Paws, Claws, & Maws",
+      "Valhalla Mart",
+      "Sleuth University",
+      "Evan's Enchanting Emporium",
+      "Labyrinthine Library",
+      "Jewelry Guild",
+      "Blossom Hotel",
+    ],
+  },
+  {
+    key: "orbiting-city",
+    name: "Orbiting City",
+    image: sandboxOrbitingCityImage,
+    description:
+      "Humanity pushed the impossible to reality, building a city that sails the sky thanks to alliances and generosity toward the Clockwork King. Its flight marks a new era of exploration and diplomacy.",
+    shops: [
+      "Iconic Dragonic",
+      "Evan's Enchanting Emporium",
+      "Supreme Smithy",
+      "Sleuth University",
+      "Navigation Guild",
+      "Will's Weapons",
+      "Runestone Relay",
+      "The Piggy Bank, no hammers inside.",
+      "Jewelry Guild",
+      "Michael's Mount",
+    ],
+  },
+  {
+    key: "big-home",
+    name: "Big Home",
+    image: sandboxBigHomeImage,
+    description:
+      "Orcs value family, honesty, and loyalty. After 'Mother' guided them to shun technology and guard the secrets of the Missing Millennium, their strength in numbers and conviction makes them formidable when provoked.",
+    shops: ["Every shop"],
+  },
+];
+
+export function SandboxMenu({ onBack }: { onBack: () => void }) {
+  const [openTown, setOpenTown] = useState<string | null>(null);
+
+  return (
+    <div className={styles.wrapper}>
+      <button type="button" className={styles.backButton} onClick={onBack}>
+        ← Back to main menu
+      </button>
+
+      <header className={styles.header}>
+        <img
+          src={sandboxWorldMapImage}
+          alt="Sandbox world map"
+          className={styles.heroImage}
+        />
+        <div>
+          <p className={styles.kicker}>Sandbox Destinations</p>
+          <h1 className={styles.title}>Pick a town to view its shops</h1>
+          <p className={styles.subtitle}>
+            Tap a destination to read its story, then see which shops you can dive into.
+            Each card uses its own world art as the backdrop.
+          </p>
+        </div>
+      </header>
+
+      <div className={styles.grid}>
+        {sandboxTowns.map((town) => {
+          const isOpen = openTown === town.key;
+          return (
+            <button
+              key={town.key}
+              type="button"
+              className={`${styles.card} ${isOpen ? styles.cardOpen : ""}`}
+              style={{
+                backgroundImage: `linear-gradient(180deg, rgba(15,23,42,0.65) 0%, rgba(15,23,42,0.8) 35%, rgba(15,23,42,0.95) 100%), url(${town.image})`,
+              }}
+              onClick={() => setOpenTown(isOpen ? null : town.key)}
+              aria-expanded={isOpen}
+            >
+              <div className={styles.cardTop}>
+                <span className={styles.cardTitle}>{town.name}</span>
+                <span aria-hidden className={styles.chevron}>
+                  {isOpen ? "▲" : "▼"}
+                </span>
+              </div>
+              {isOpen ? (
+                <div className={styles.cardBody}>
+                  <p className={styles.description}>{town.description}</p>
+                  <div className={styles.shopList}>
+                    <h3>Associated shops</h3>
+                    {town.shops.length > 0 ? (
+                      <ul>
+                        {town.shops.map((shop) => (
+                          <li key={shop}>{shop}</li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <p className={styles.emptyState}>No associated shops listed yet.</p>
+                    )}
+                  </div>
+                </div>
+              ) : (
+                <p className={styles.preview}>Tap to view description and shops</p>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- move Sandbox destinations into a dedicated component and CSS module with card backgrounds using each town’s artwork
- add per-town descriptions plus associated shop lists shown on expand, keeping a back control to return to the main menu
- keep the main menu Sandbox button while simplifying Map styling to rely on the new standalone view

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950b19ccc908329812b771325fe1159)