### PR TITLE
Add Withhold Parker destination

### DIFF
--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -36,6 +36,7 @@ import { RobinsRopes } from "./RobinsRopes";
 import { RunestoneRelay } from "./RunestoneRelay";
 import { SilentOath } from "./SilentOath";
 import { SupremeSmithy } from "./SupremeSmithy";
+import { WithholdParker } from "./WithholdParker";
 import { WillsWeapons } from "./WillsWeapons";
 import { YeOldDonkey } from "./YeOldDonkey";
 import oPapiesOracleReadingsImage from "./O Papies Oracle Readings.png";
@@ -334,6 +335,13 @@ export function Map() {
       return <SilentOath onBack={() => setNavigatedTo("")} />;
     case "SupremeSmithy":
       return <SupremeSmithy onBack={() => setNavigatedTo("")} />;
+    case "Withhold":
+      return (
+        <WithholdParker
+          onBack={() => setNavigatedTo("Sandbox")}
+          onNavigate={(key) => setNavigatedTo(key)}
+        />
+      );
     case "WillsWeapons":
       return <WillsWeapons onBack={() => setNavigatedTo("")} />;
     case "ProvisionsParadise":
@@ -696,18 +704,22 @@ function SandboxMenu({ onBack }: { onBack: () => void }) {
       </div>
       <div style={styles.sandboxGrid}>
         {sandboxTowns.map((town) => (
-          <FloatingButton
-            key={town.key}
-            label={town.name}
-            description={town.description}
-            imageSrc={town.image}
-            backgroundColor="rgba(30, 41, 59, 0.88)"
-            color="#e2e8f0"
-            delay="0s"
-            onClick={() => {}}
-          />
-        ))}
-      </div>
+            <FloatingButton
+              key={town.key}
+              label={town.name}
+              description={town.description}
+              imageSrc={town.image}
+              backgroundColor="rgba(30, 41, 59, 0.88)"
+              color="#e2e8f0"
+              delay="0s"
+              onClick={() =>
+                town.key === "withhold"
+                  ? setNavigatedTo("Withhold")
+                  : setNavigatedTo("Sandbox")
+              }
+            />
+          ))}
+        </div>
     </div>
   );
 }

--- a/src/WithholdParker.module.css
+++ b/src/WithholdParker.module.css
@@ -1,0 +1,140 @@
+.wrapper {
+  min-height: 100vh;
+  padding: 3.5rem 1.5rem 2.75rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  position: relative;
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: center;
+  overflow: hidden;
+  color: #e2e8f0;
+}
+
+.wrapper::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.7) 0%, rgba(15, 23, 42, 0.85) 100%);
+  backdrop-filter: blur(2px);
+  z-index: 0;
+}
+
+.content {
+  position: relative;
+  z-index: 1;
+  width: min(1100px, 96vw);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.75rem;
+}
+
+.hero {
+  width: 100%;
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 22px;
+  box-shadow: 0 18px 45px rgba(0, 0, 0, 0.35);
+  padding: 1.9rem 1.8rem;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.eyebrow {
+  font-size: 0.9rem;
+  letter-spacing: 0.18rem;
+  text-transform: uppercase;
+  color: #cbd5e1;
+  margin: 0;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.4rem;
+  color: #f8fafc;
+}
+
+.subtitle {
+  margin: 0;
+  color: #cbd5e1;
+  line-height: 1.5;
+}
+
+.buttonGrid {
+  display: grid;
+  width: 100%;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.shopButton {
+  background: rgba(30, 41, 59, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 18px;
+  padding: 1.25rem 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  color: #f8fafc;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.35);
+}
+
+.shopButton:hover,
+.shopButton:focus-visible {
+  transform: translateY(-4px);
+  border-color: rgba(255, 255, 255, 0.28);
+  box-shadow: 0 20px 42px rgba(0, 0, 0, 0.45);
+}
+
+.shopImage {
+  width: 180px;
+  height: 120px;
+  object-fit: contain;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.88);
+  border: 2px solid rgba(255, 255, 255, 0.7);
+  box-shadow: 0 10px 18px rgba(0, 0, 0, 0.28);
+}
+
+.shopLabel {
+  font-weight: 700;
+  font-size: 1.1rem;
+  text-align: center;
+  line-height: 1.35;
+}
+
+.shopHint {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #cbd5e1;
+  text-align: center;
+}
+
+.footer {
+  margin: 0;
+  color: #cbd5e1;
+  font-size: 0.95rem;
+}
+
+@media (max-width: 640px) {
+  .wrapper {
+    padding: 3rem 1rem 2.5rem;
+  }
+
+  .shopImage {
+    width: 160px;
+    height: 108px;
+  }
+
+  .title {
+    font-size: 2rem;
+  }
+}

--- a/src/WithholdParker.tsx
+++ b/src/WithholdParker.tsx
@@ -1,0 +1,104 @@
+import withholdBackground from "./SandboxWytheholde.webp";
+import applegarthImage from "./Applegarth.webp";
+import robinsRopesImage from "./Robins Ropes.png";
+import oPapiesOracleReadingsImage from "./O Papies Oracle Readings.png";
+import supremeSmithyImage from "./Supreme Smithy.png";
+import floralImage from "./Floral.webp";
+import silentOathImage from "./Silent Oath.png";
+import { BackButton } from "./BackButton";
+import styles from "./WithholdParker.module.css";
+
+type WithholdShop = {
+  key: string;
+  label: string;
+  image: string;
+  onClick: () => void;
+};
+
+export function WithholdParker({
+  onBack,
+  onNavigate,
+}: {
+  onBack: () => void;
+  onNavigate: (key: string) => void;
+}) {
+  const shops: WithholdShop[] = [
+    {
+      key: "applegarth",
+      label: "Applegarth Guild",
+      image: applegarthImage,
+      onClick: () => onNavigate("ApplegarthGuild"),
+    },
+    {
+      key: "robins-ropes",
+      label: "Robin's Ropes",
+      image: robinsRopesImage,
+      onClick: () => onNavigate("RobinsRopes"),
+    },
+    {
+      key: "o-papies",
+      label: "O-Papies Oracle Readings",
+      image: oPapiesOracleReadingsImage,
+      onClick: () => onNavigate("OPapiesOracleReadings"),
+    },
+    {
+      key: "supreme-smithy",
+      label: "Supreme Smithy",
+      image: supremeSmithyImage,
+      onClick: () => onNavigate("SupremeSmithy"),
+    },
+    {
+      key: "fairies-of-flora",
+      label: "Fairies of Flora",
+      image: floralImage,
+      onClick: () => onNavigate("FairiesOfFlora"),
+    },
+    {
+      key: "silent-oath",
+      label: "Silent Oath",
+      image: silentOathImage,
+      onClick: () => onNavigate("SilentOath"),
+    },
+  ];
+
+  return (
+    <div
+      className={styles.wrapper}
+      style={{ backgroundImage: `url(${withholdBackground})` }}
+    >
+      <BackButton onClick={onBack} />
+
+      <div className={styles.content}>
+        <div className={styles.hero}>
+          <p className={styles.eyebrow}>Sandbox · Withhold (Parker)</p>
+          <h1 className={styles.title}>Pick your next stop</h1>
+          <p className={styles.subtitle}>
+            Each shop uses its own icon so you always know where you&apos;re headed. Tap a
+            button to jump straight to the storefront.
+          </p>
+        </div>
+
+        <div className={styles.buttonGrid}>
+          {shops.map((shop) => (
+            <button
+              key={shop.key}
+              type="button"
+              className={styles.shopButton}
+              onClick={shop.onClick}
+            >
+              <img
+                src={shop.image}
+                alt={`${shop.label} icon`}
+                className={styles.shopImage}
+              />
+              <span className={styles.shopLabel}>{shop.label}</span>
+              <p className={styles.shopHint}>Jump into this storefront</p>
+            </button>
+          ))}
+        </div>
+
+        <p className={styles.footer}>Art credit: Withhold (Parker) world map</p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a dedicated Withhold (Parker) landing page with its own background styling
- link the Sandbox Withhold card to the new page and jump into each associated shop

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950bedd82948329b07a130a844dea75)