### PR TITLE
Add Meander sandbox experience

### DIFF
--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -37,6 +37,7 @@ import { RunestoneRelay } from "./RunestoneRelay";
 import { SilentOath } from "./SilentOath";
 import { SupremeSmithy } from "./SupremeSmithy";
 import { WithholdParker } from "./WithholdParker";
+import { MeanderMichael } from "./MeanderMichael";
 import { WillsWeapons } from "./WillsWeapons";
 import { ButtingRams } from "./ButtingRams";
 import { YeOldDonkey } from "./YeOldDonkey";
@@ -339,6 +340,13 @@ export function Map() {
     case "Withhold":
       return (
         <WithholdParker
+          onBack={() => setNavigatedTo("Sandbox")}
+          onNavigate={(key) => setNavigatedTo(key)}
+        />
+      );
+    case "Meander":
+      return (
+        <MeanderMichael
           onBack={() => setNavigatedTo("Sandbox")}
           onNavigate={(key) => setNavigatedTo(key)}
         />
@@ -736,6 +744,8 @@ function SandboxMenu({
                   ? onNavigate("Withhold")
                   : town.key === "butting-rams"
                   ? onNavigate("ButtingRams")
+                  : town.key === "meander"
+                  ? onNavigate("Meander")
                   : onNavigate("Sandbox")
               }
             />

--- a/src/MeanderMichael.module.css
+++ b/src/MeanderMichael.module.css
@@ -1,0 +1,140 @@
+.wrapper {
+  min-height: 100vh;
+  padding: 3.5rem 1.5rem 2.75rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  position: relative;
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: center;
+  overflow: hidden;
+  color: #e2e8f0;
+}
+
+.wrapper::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.7) 0%, rgba(15, 23, 42, 0.85) 100%);
+  backdrop-filter: blur(2px);
+  z-index: 0;
+}
+
+.content {
+  position: relative;
+  z-index: 1;
+  width: min(1100px, 96vw);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.75rem;
+}
+
+.hero {
+  width: 100%;
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 22px;
+  box-shadow: 0 18px 45px rgba(0, 0, 0, 0.35);
+  padding: 1.9rem 1.8rem;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.eyebrow {
+  font-size: 0.9rem;
+  letter-spacing: 0.18rem;
+  text-transform: uppercase;
+  color: #cbd5e1;
+  margin: 0;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.4rem;
+  color: #f8fafc;
+}
+
+.subtitle {
+  margin: 0;
+  color: #cbd5e1;
+  line-height: 1.5;
+}
+
+.buttonGrid {
+  display: grid;
+  width: 100%;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.shopButton {
+  background: rgba(30, 41, 59, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 18px;
+  padding: 1.25rem 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  color: #f8fafc;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.35);
+}
+
+.shopButton:hover,
+.shopButton:focus-visible {
+  transform: translateY(-4px);
+  border-color: rgba(255, 255, 255, 0.28);
+  box-shadow: 0 20px 42px rgba(0, 0, 0, 0.45);
+}
+
+.shopImage {
+  width: 180px;
+  height: 120px;
+  object-fit: contain;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.88);
+  border: 2px solid rgba(255, 255, 255, 0.7);
+  box-shadow: 0 10px 18px rgba(0, 0, 0, 0.28);
+}
+
+.shopLabel {
+  font-weight: 700;
+  font-size: 1.1rem;
+  text-align: center;
+  line-height: 1.35;
+}
+
+.shopHint {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #cbd5e1;
+  text-align: center;
+}
+
+.footer {
+  margin: 0;
+  color: #cbd5e1;
+  font-size: 0.95rem;
+}
+
+@media (max-width: 640px) {
+  .wrapper {
+    padding: 3rem 1rem 2.5rem;
+  }
+
+  .shopImage {
+    width: 160px;
+    height: 108px;
+  }
+
+  .title {
+    font-size: 2rem;
+  }
+}

--- a/src/MeanderMichael.tsx
+++ b/src/MeanderMichael.tsx
@@ -1,0 +1,131 @@
+import meanderBackground from "./SandboxMeander.webp";
+import monsterImage from "./Monster.webp";
+import mountsImage from "./Mounts.webp";
+import iconicDragonicImage from "./Iconic Dragonic.png";
+import pawsClawsMawsImage from "./Paws, Claws, & Maws.png";
+import valhallaMartImage from "./Valhalla Mart.png";
+import jewelryGuildImage from "./Jewelry Guild.png";
+import applegarthImage from "./Applegarth.webp";
+import archivesGuildImage from "./Archives Guild.png";
+import dungeonCrawlerGuildImage from "./Dungeon Crawler's Guild.png";
+import navigationGuildImage from "./NavigationGuild-ezgif.com-webp-to-png-converter.png";
+import { BackButton } from "./BackButton";
+import styles from "./MeanderMichael.module.css";
+
+type MeanderShop = {
+  key: string;
+  label: string;
+  image: string;
+  onClick: () => void;
+};
+
+export function MeanderMichael({
+  onBack,
+  onNavigate,
+}: {
+  onBack: () => void;
+  onNavigate: (key: string) => void;
+}) {
+  const shops: MeanderShop[] = [
+    {
+      key: "make-a-monster",
+      label: "Make a Monster",
+      image: monsterImage,
+      onClick: () => onNavigate("MonsterMaker"),
+    },
+    {
+      key: "michaels-mount",
+      label: "Michael's Mount",
+      image: mountsImage,
+      onClick: () => onNavigate("MichaelsMount"),
+    },
+    {
+      key: "iconic-dragonic",
+      label: "Iconic Dragonic",
+      image: iconicDragonicImage,
+      onClick: () => onNavigate("IconicDragonic"),
+    },
+    {
+      key: "paws-claws-maws",
+      label: "Paws, Claws, & Maws",
+      image: pawsClawsMawsImage,
+      onClick: () => onNavigate("PawsClawsMaws"),
+    },
+    {
+      key: "valhalla-mart",
+      label: "Valhalla Mart",
+      image: valhallaMartImage,
+      onClick: () => onNavigate("ValhallaMart"),
+    },
+    {
+      key: "jewelry-guild",
+      label: "Jewelry Guild",
+      image: jewelryGuildImage,
+      onClick: () => onNavigate("JewelryGuild"),
+    },
+    {
+      key: "applegarth-guild",
+      label: "Applegarth Guild",
+      image: applegarthImage,
+      onClick: () => onNavigate("ApplegarthGuild"),
+    },
+    {
+      key: "archives-guild",
+      label: "Archives Guild",
+      image: archivesGuildImage,
+      onClick: () => onNavigate("ArchivesGuild"),
+    },
+    {
+      key: "dungeon-crawler-guild",
+      label: "Dungeon Crawler Guild",
+      image: dungeonCrawlerGuildImage,
+      onClick: () => onNavigate("DungeonCrawlerGuild"),
+    },
+    {
+      key: "navigation-guild",
+      label: "Navigation Guild",
+      image: navigationGuildImage,
+      onClick: () => onNavigate("NavigationGuild"),
+    },
+  ];
+
+  return (
+    <div
+      className={styles.wrapper}
+      style={{ backgroundImage: `url(${meanderBackground})` }}
+    >
+      <BackButton onClick={onBack} />
+
+      <div className={styles.content}>
+        <div className={styles.hero}>
+          <p className={styles.eyebrow}>Sandbox</p>
+          <h1 className={styles.title}>Welcome to Meander</h1>
+          <p className={styles.subtitle}>
+            A roving cowboy haven where the caravan never stops and every shop keeps
+            the wagons rolling.
+          </p>
+        </div>
+
+        <div className={styles.buttonGrid}>
+          {shops.map((shop) => (
+            <button
+              key={shop.key}
+              type="button"
+              className={styles.shopButton}
+              onClick={shop.onClick}
+            >
+              <img
+                src={shop.image}
+                alt={`${shop.label} icon`}
+                className={styles.shopImage}
+              />
+              <span className={styles.shopLabel}>{shop.label}</span>
+            </button>
+          ))}
+        </div>
+
+        <p className={styles.footer}>This town was made by Michael</p>
+      </div>
+    </div>
+  );
+}

--- a/src/SandboxMenu.tsx
+++ b/src/SandboxMenu.tsx
@@ -61,7 +61,11 @@ const sandboxTowns: SandboxTown[] = [
       "Iconic Dragonic",
       "Paws, Claws, & Maws",
       "Valhalla Mart",
-      "Bullets, Buffs, & Beyond",
+      "Jewelry Guild",
+      "Applegarth Guild",
+      "Archives Guild",
+      "Dungeon Crawler Guild",
+      "Navigation Guild",
     ],
   },
   {


### PR DESCRIPTION
## Summary
- add a Meander town experience that mirrors Withhold with dedicated shop links
- wire Meander into sandbox navigation and add the requested shop lineup

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69518c5a532c8329a10e4c790937cb13)