### PR TITLE
Add Calidris Fisk sandbox shops

### DIFF
--- a/src/CalidrisFisk.module.css
+++ b/src/CalidrisFisk.module.css
@@ -1,0 +1,140 @@
+.wrapper {
+  min-height: 100vh;
+  padding: 3.5rem 1.5rem 2.75rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  position: relative;
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: center;
+  overflow: hidden;
+  color: #e2e8f0;
+}
+
+.wrapper::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.7) 0%, rgba(15, 23, 42, 0.85) 100%);
+  backdrop-filter: blur(2px);
+  z-index: 0;
+}
+
+.content {
+  position: relative;
+  z-index: 1;
+  width: min(1100px, 96vw);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.75rem;
+}
+
+.hero {
+  width: 100%;
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 22px;
+  box-shadow: 0 18px 45px rgba(0, 0, 0, 0.35);
+  padding: 1.9rem 1.8rem;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.eyebrow {
+  font-size: 0.9rem;
+  letter-spacing: 0.18rem;
+  text-transform: uppercase;
+  color: #cbd5e1;
+  margin: 0;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.4rem;
+  color: #f8fafc;
+}
+
+.subtitle {
+  margin: 0;
+  color: #cbd5e1;
+  line-height: 1.5;
+}
+
+.buttonGrid {
+  display: grid;
+  width: 100%;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.shopButton {
+  background: rgba(30, 41, 59, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 18px;
+  padding: 1.25rem 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  color: #f8fafc;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.35);
+}
+
+.shopButton:hover,
+.shopButton:focus-visible {
+  transform: translateY(-4px);
+  border-color: rgba(255, 255, 255, 0.28);
+  box-shadow: 0 20px 42px rgba(0, 0, 0, 0.45);
+}
+
+.shopImage {
+  width: 180px;
+  height: 120px;
+  object-fit: contain;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.88);
+  border: 2px solid rgba(255, 255, 255, 0.7);
+  box-shadow: 0 10px 18px rgba(0, 0, 0, 0.28);
+}
+
+.shopLabel {
+  font-weight: 700;
+  font-size: 1.1rem;
+  text-align: center;
+  line-height: 1.35;
+}
+
+.shopHint {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #cbd5e1;
+  text-align: center;
+}
+
+.footer {
+  margin: 0;
+  color: #cbd5e1;
+  font-size: 0.95rem;
+}
+
+@media (max-width: 640px) {
+  .wrapper {
+    padding: 3rem 1rem 2.5rem;
+  }
+
+  .shopImage {
+    width: 160px;
+    height: 108px;
+  }
+
+  .title {
+    font-size: 2rem;
+  }
+}

--- a/src/CalidrisFisk.tsx
+++ b/src/CalidrisFisk.tsx
@@ -1,0 +1,125 @@
+import calidrisBackground from "./SandboxCalidris.webp";
+import necromancyInsuranceImage from "./NecromanyInsuranceCo-ezgif.com-webp-to-png-converter.png";
+import floralImage from "./Floral.webp";
+import golemWorkshopImage from "./Golem Work Shop.png";
+import runestoneRelayImage from "./Runestone Relay.png";
+import silentOathImage from "./Silent Oath.png";
+import robinsRopesImage from "./Robins Ropes.png";
+import bulletsBuffsBeyondImage from "./Bullets Buffs and Beyond.webp";
+import supremeSmithyImage from "./Supreme Smithy.png";
+import willsWeaponsImage from "./Wills Weapons.png";
+import { BackButton } from "./BackButton";
+import styles from "./CalidrisFisk.module.css";
+
+type CalidrisShop = {
+  key: string;
+  label: string;
+  image: string;
+  onClick: () => void;
+};
+
+export function CalidrisFisk({
+  onBack,
+  onNavigate,
+}: {
+  onBack: () => void;
+  onNavigate: (key: string) => void;
+}) {
+  const shops: CalidrisShop[] = [
+    {
+      key: "necromancy-insurance",
+      label: "Necromancy Insurance Company",
+      image: necromancyInsuranceImage,
+      onClick: () => onNavigate("NecromancyInsuranceCompany"),
+    },
+    {
+      key: "fairies-of-flora",
+      label: "Fairies of Flora",
+      image: floralImage,
+      onClick: () => onNavigate("FairiesOfFlora"),
+    },
+    {
+      key: "golem-workshop",
+      label: "Golem Workshop",
+      image: golemWorkshopImage,
+      onClick: () => onNavigate("GolemWorkshop"),
+    },
+    {
+      key: "runestone-relay",
+      label: "Runestone Relay",
+      image: runestoneRelayImage,
+      onClick: () => onNavigate("RunestoneRelay"),
+    },
+    {
+      key: "silent-oath",
+      label: "Silent Oath",
+      image: silentOathImage,
+      onClick: () => onNavigate("SilentOath"),
+    },
+    {
+      key: "robins-ropes",
+      label: "Robin Ropes",
+      image: robinsRopesImage,
+      onClick: () => onNavigate("RobinsRopes"),
+    },
+    {
+      key: "bullets-buffs-beyond",
+      label: "Bullets, Buffs, & Beyond",
+      image: bulletsBuffsBeyondImage,
+      onClick: () => onNavigate("BulletsBuffsBeyond"),
+    },
+    {
+      key: "supreme-smithy",
+      label: "Supreme Smithy",
+      image: supremeSmithyImage,
+      onClick: () => onNavigate("SupremeSmithy"),
+    },
+    {
+      key: "wills-weapons",
+      label: "Will's Weapons",
+      image: willsWeaponsImage,
+      onClick: () => onNavigate("WillsWeapons"),
+    },
+  ];
+
+  return (
+    <div
+      className={styles.wrapper}
+      style={{ backgroundImage: `url(${calidrisBackground})` }}
+    >
+      <BackButton onClick={onBack} />
+
+      <div className={styles.content}>
+        <div className={styles.hero}>
+          <p className={styles.eyebrow}>Sandbox · Calidris</p>
+          <h1 className={styles.title}>Clockwork keeps Calidris turning</h1>
+          <p className={styles.subtitle}>
+            The golems never stopped working after the artisans disappeared—follow their hum
+            into the surviving storefronts below.
+          </p>
+        </div>
+
+        <div className={styles.buttonGrid}>
+          {shops.map((shop) => (
+            <button
+              key={shop.key}
+              type="button"
+              className={styles.shopButton}
+              onClick={shop.onClick}
+            >
+              <img
+                src={shop.image}
+                alt={`${shop.label} icon`}
+                className={styles.shopImage}
+              />
+              <span className={styles.shopLabel}>{shop.label}</span>
+              <p className={styles.shopHint}>Step into this silent storefront</p>
+            </button>
+          ))}
+        </div>
+
+        <p className={styles.footer}>This ghost town persists thanks to Fisk</p>
+      </div>
+    </div>
+  );
+}

--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -36,6 +36,7 @@ import { RobinsRopes } from "./RobinsRopes";
 import { RunestoneRelay } from "./RunestoneRelay";
 import { SilentOath } from "./SilentOath";
 import { SupremeSmithy } from "./SupremeSmithy";
+import { CalidrisFisk } from "./CalidrisFisk";
 import { WithholdParker } from "./WithholdParker";
 import { WillsWeapons } from "./WillsWeapons";
 import { ButtingRams } from "./ButtingRams";
@@ -336,6 +337,13 @@ export function Map() {
       return <SilentOath onBack={() => setNavigatedTo("")} />;
     case "SupremeSmithy":
       return <SupremeSmithy onBack={() => setNavigatedTo("")} />;
+    case "Calidris":
+      return (
+        <CalidrisFisk
+          onBack={() => setNavigatedTo("Sandbox")}
+          onNavigate={(key) => setNavigatedTo(key)}
+        />
+      );
     case "Withhold":
       return (
         <WithholdParker
@@ -734,6 +742,8 @@ function SandboxMenu({
               onClick={() =>
                 town.key === "withhold"
                   ? onNavigate("Withhold")
+                  : town.key === "calidris"
+                  ? onNavigate("Calidris")
                   : town.key === "butting-rams"
                   ? onNavigate("ButtingRams")
                   : onNavigate("Sandbox")

--- a/src/SandboxMenu.tsx
+++ b/src/SandboxMenu.tsx
@@ -70,7 +70,17 @@ const sandboxTowns: SandboxTown[] = [
     image: sandboxCalidrisImage,
     description:
       "Created as an artisans' paradise with no creative limits, Calidris thrived—until every living resident vanished overnight. Only the golems and robots remain, tirelessly working while ignoring their missing masters.",
-    shops: [],
+    shops: [
+      "Necromancy Insurance Company",
+      "Fairies of Flora",
+      "Golem Workshop",
+      "Runestone Relay",
+      "Silent Oath",
+      "Robin Ropes",
+      "Bullets, Buffs, & Beyond",
+      "Supreme Smithy",
+      "Will's Weapons",
+    ],
   },
   {
     key: "merricks-meadow",


### PR DESCRIPTION
## Summary
- add a Calidris Fisk sandbox page mirroring Withhold with the requested storefronts
- wire the sandbox navigation to open the Calidris page and surface its shop list

## Testing
- npm test -- --watch=false *(fails: jsdom lacks HTMLCanvasElement.getContext support used in Map test setup)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69518d9f6b4c8329a1551f6ec4ce574f)