### PR TITLE
Add Analeptic Holt sandbox town view

### DIFF
--- a/src/AnalepticHoltTeag.module.css
+++ b/src/AnalepticHoltTeag.module.css
@@ -1,0 +1,140 @@
+.wrapper {
+  min-height: 100vh;
+  padding: 3.5rem 1.5rem 2.75rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  position: relative;
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: center;
+  overflow: hidden;
+  color: #e2e8f0;
+}
+
+.wrapper::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.7) 0%, rgba(15, 23, 42, 0.85) 100%);
+  backdrop-filter: blur(2px);
+  z-index: 0;
+}
+
+.content {
+  position: relative;
+  z-index: 1;
+  width: min(1100px, 96vw);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.75rem;
+}
+
+.hero {
+  width: 100%;
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 22px;
+  box-shadow: 0 18px 45px rgba(0, 0, 0, 0.35);
+  padding: 1.9rem 1.8rem;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.eyebrow {
+  font-size: 0.9rem;
+  letter-spacing: 0.18rem;
+  text-transform: uppercase;
+  color: #cbd5e1;
+  margin: 0;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.4rem;
+  color: #f8fafc;
+}
+
+.subtitle {
+  margin: 0;
+  color: #cbd5e1;
+  line-height: 1.5;
+}
+
+.buttonGrid {
+  display: grid;
+  width: 100%;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.shopButton {
+  background: rgba(30, 41, 59, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 18px;
+  padding: 1.25rem 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  color: #f8fafc;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.35);
+}
+
+.shopButton:hover,
+.shopButton:focus-visible {
+  transform: translateY(-4px);
+  border-color: rgba(255, 255, 255, 0.28);
+  box-shadow: 0 20px 42px rgba(0, 0, 0, 0.45);
+}
+
+.shopImage {
+  width: 180px;
+  height: 120px;
+  object-fit: contain;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.88);
+  border: 2px solid rgba(255, 255, 255, 0.7);
+  box-shadow: 0 10px 18px rgba(0, 0, 0, 0.28);
+}
+
+.shopLabel {
+  font-weight: 700;
+  font-size: 1.1rem;
+  text-align: center;
+  line-height: 1.35;
+}
+
+.shopHint {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #cbd5e1;
+  text-align: center;
+}
+
+.footer {
+  margin: 0;
+  color: #cbd5e1;
+  font-size: 0.95rem;
+}
+
+@media (max-width: 640px) {
+  .wrapper {
+    padding: 3rem 1rem 2.5rem;
+  }
+
+  .shopImage {
+    width: 160px;
+    height: 108px;
+  }
+
+  .title {
+    font-size: 2rem;
+  }
+}

--- a/src/AnalepticHoltTeag.tsx
+++ b/src/AnalepticHoltTeag.tsx
@@ -1,0 +1,130 @@
+import analepticHoltBackground from "./SandboxAnalepticHolt.webp";
+import bulletsBuffsBeyondImage from "./Bullets Buffs and Beyond.webp";
+import robinsRopesImage from "./Robins Ropes.png";
+import changingChurchImage from "./Changing Church.png";
+import necromancyInsuranceImage from "./NecromanyInsuranceCo-ezgif.com-webp-to-png-converter.png";
+import runestoneRelayImage from "./Runestone Relay.png";
+import sleuthUniversityImage from "./Sleuth.webp";
+import blossomHotelImage from "./Blossom Hotel.png";
+import floralImage from "./Floral.webp";
+import evansEnchantingEmporiumImage from "./Evan's Enchanting Emporium.png";
+import jazzPortablePotionsImage from "./Jazz's Portable Potions.png";
+import { BackButton } from "./BackButton";
+import styles from "./AnalepticHoltTeag.module.css";
+
+type AnalepticShop = {
+  key: string;
+  label: string;
+  image: string;
+  onClick: () => void;
+};
+
+export function AnalepticHoltTeag({
+  onBack,
+  onNavigate,
+}: {
+  onBack: () => void;
+  onNavigate: (key: string) => void;
+}) {
+  const shops: AnalepticShop[] = [
+    {
+      key: "bullets-buffs-beyond",
+      label: "Bullets, Buffs, & Beyond",
+      image: bulletsBuffsBeyondImage,
+      onClick: () => onNavigate("BulletsBuffsBeyond"),
+    },
+    {
+      key: "robins-ropes",
+      label: "Robin's Ropes",
+      image: robinsRopesImage,
+      onClick: () => onNavigate("RobinsRopes"),
+    },
+    {
+      key: "changing-church",
+      label: "Changing Church",
+      image: changingChurchImage,
+      onClick: () => onNavigate("ChangingChurch"),
+    },
+    {
+      key: "necromancy-insurance",
+      label: "Necromancy Insurance Company",
+      image: necromancyInsuranceImage,
+      onClick: () => onNavigate("NecromancyInsuranceCompany"),
+    },
+    {
+      key: "runestone-relay",
+      label: "Runestone Relay",
+      image: runestoneRelayImage,
+      onClick: () => onNavigate("RunestoneRelay"),
+    },
+    {
+      key: "sleuth-university",
+      label: "Sleuth University",
+      image: sleuthUniversityImage,
+      onClick: () => onNavigate("SleuthUniversity"),
+    },
+    {
+      key: "blossom-hotel",
+      label: "Blossom Hotel",
+      image: blossomHotelImage,
+      onClick: () => onNavigate("BlossomHotel"),
+    },
+    {
+      key: "fairies-of-flora",
+      label: "Fairies of Flora",
+      image: floralImage,
+      onClick: () => onNavigate("FairiesOfFlora"),
+    },
+    {
+      key: "evans-enchanting-emporium",
+      label: "Evan's Enchanting Emporium",
+      image: evansEnchantingEmporiumImage,
+      onClick: () => onNavigate("EvansEnchantingEmporium"),
+    },
+    {
+      key: "jazz-portable-potions",
+      label: "Jazz's Portable Potions",
+      image: jazzPortablePotionsImage,
+      onClick: () => onNavigate("JazzPortablePotions"),
+    },
+  ];
+
+  return (
+    <div
+      className={styles.wrapper}
+      style={{ backgroundImage: `url(${analepticHoltBackground})` }}
+    >
+      <BackButton onClick={onBack} />
+
+      <div className={styles.content}>
+        <div className={styles.hero}>
+          <p className={styles.eyebrow}>Sandbox</p>
+          <h1 className={styles.title}>Welcome to Analeptic Holt</h1>
+          <p className={styles.subtitle}>
+            These treetop shops perch among the roots and branches—step carefully and enjoy the view.
+          </p>
+        </div>
+
+        <div className={styles.buttonGrid}>
+          {shops.map((shop) => (
+            <button
+              key={shop.key}
+              type="button"
+              className={styles.shopButton}
+              onClick={shop.onClick}
+            >
+              <img
+                src={shop.image}
+                alt={`${shop.label} icon`}
+                className={styles.shopImage}
+              />
+              <span className={styles.shopLabel}>{shop.label}</span>
+            </button>
+          ))}
+        </div>
+
+        <p className={styles.footer}>This town was made by Teag</p>
+      </div>
+    </div>
+  );
+}

--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -88,6 +88,7 @@ import labyrinthineLibraryImage from "./Labyrinthine Labrary.png";
 import { NME } from "./NME";
 import nmeImage from "./N.M.E.png";
 import { FizzyTales } from "./FizzyTales";
+import { AnalepticHoltTeag } from "./AnalepticHoltTeag";
 import { YeOldHomeDepot } from "./YeOldHomeDepot";
 import yeOldHomeDepotImage from "./Ye Old Home Depot.webp";
 import sandboxWorldMapImage from "./SandboxWorldMap.webp";
@@ -361,6 +362,13 @@ export function Map() {
     case "MerricksMeadow":
       return (
         <MerricksMeadowHoward
+          onBack={() => setNavigatedTo("Sandbox")}
+          onNavigate={(key) => setNavigatedTo(key)}
+        />
+      );
+    case "AnalepticHolt":
+      return (
+        <AnalepticHoltTeag
           onBack={() => setNavigatedTo("Sandbox")}
           onNavigate={(key) => setNavigatedTo(key)}
         />
@@ -811,6 +819,8 @@ function SandboxMenu({
                   ? onNavigate("MerricksMeadow")
                   : town.key === "calidris"
                   ? onNavigate("Calidris")
+                  : town.key === "analeptic-holt"
+                  ? onNavigate("AnalepticHolt")
                   : town.key === "butting-rams"
                   ? onNavigate("ButtingRams")
                   : town.key === "jelly-city"


### PR DESCRIPTION
## Summary
- add an Analeptic Holt (Teag) sandbox landing page with the requested shop roster and canopy-themed messaging
- wire the sandbox navigation to open the new Analeptic Holt view alongside the other towns
- mirror the existing Withhold styling for the new destination with its own assets

## Testing
- CI=true npm test -- --watch=false *(fails: jsdom lacks canvas support and existing App test expectations for the previous landing layout)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955afb0710c83299542af9118b98c9b)