### PR TITLE
Add Seymour's Drift town view

### DIFF
--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -38,6 +38,7 @@ import { SilentOath } from "./SilentOath";
 import { SupremeSmithy } from "./SupremeSmithy";
 import { CalidrisFisk } from "./CalidrisFisk";
 import { WithholdParker } from "./WithholdParker";
+import { SeymoursDriftMelanie } from "./SeymoursDriftMelanie";
 import { HebronJoshua } from "./HebronJoshua";
 import { BallisticBellowsCaleb } from "./BallisticBellowsCaleb";
 import { MeanderMichael } from "./MeanderMichael";
@@ -376,6 +377,13 @@ export function Map() {
     case "Withhold":
       return (
         <WithholdParker
+          onBack={() => setNavigatedTo("Sandbox")}
+          onNavigate={(key) => setNavigatedTo(key)}
+        />
+      );
+    case "SeymoursDrift":
+      return (
+        <SeymoursDriftMelanie
           onBack={() => setNavigatedTo("Sandbox")}
           onNavigate={(key) => setNavigatedTo(key)}
         />
@@ -827,6 +835,8 @@ function SandboxMenu({
                   ? onNavigate("JellyCity")
                   : town.key === "meander"
                   ? onNavigate("Meander")
+                  : town.key === "seymours-drift"
+                  ? onNavigate("SeymoursDrift")
                   : onNavigate("Sandbox")
               }
             />

--- a/src/SandboxMenu.tsx
+++ b/src/SandboxMenu.tsx
@@ -211,13 +211,10 @@ const sandboxTowns: SandboxTown[] = [
       "Blossom Hotel",
       "Fairies of Flora",
       "Sleuth University",
-      "Jewelry Guild",
       "Evan's Enchanting Emporium",
       "Labyrinthine Library",
       "Will's Weapons",
-      "Archives Guild",
       "Supreme Smithy",
-      "Applegarth Guild",
     ],
   },
   {

--- a/src/SeymoursDriftMelanie.module.css
+++ b/src/SeymoursDriftMelanie.module.css
@@ -1,0 +1,140 @@
+.wrapper {
+  min-height: 100vh;
+  padding: 3.5rem 1.5rem 2.75rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  position: relative;
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: center;
+  overflow: hidden;
+  color: #e2e8f0;
+}
+
+.wrapper::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.7) 0%, rgba(15, 23, 42, 0.85) 100%);
+  backdrop-filter: blur(2px);
+  z-index: 0;
+}
+
+.content {
+  position: relative;
+  z-index: 1;
+  width: min(1100px, 96vw);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.75rem;
+}
+
+.hero {
+  width: 100%;
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 22px;
+  box-shadow: 0 18px 45px rgba(0, 0, 0, 0.35);
+  padding: 1.9rem 1.8rem;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.eyebrow {
+  font-size: 0.9rem;
+  letter-spacing: 0.18rem;
+  text-transform: uppercase;
+  color: #cbd5e1;
+  margin: 0;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.4rem;
+  color: #f8fafc;
+}
+
+.subtitle {
+  margin: 0;
+  color: #cbd5e1;
+  line-height: 1.5;
+}
+
+.buttonGrid {
+  display: grid;
+  width: 100%;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.shopButton {
+  background: rgba(30, 41, 59, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 18px;
+  padding: 1.25rem 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  color: #f8fafc;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.35);
+}
+
+.shopButton:hover,
+.shopButton:focus-visible {
+  transform: translateY(-4px);
+  border-color: rgba(255, 255, 255, 0.28);
+  box-shadow: 0 20px 42px rgba(0, 0, 0, 0.45);
+}
+
+.shopImage {
+  width: 180px;
+  height: 120px;
+  object-fit: contain;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.88);
+  border: 2px solid rgba(255, 255, 255, 0.7);
+  box-shadow: 0 10px 18px rgba(0, 0, 0, 0.28);
+}
+
+.shopLabel {
+  font-weight: 700;
+  font-size: 1.1rem;
+  text-align: center;
+  line-height: 1.35;
+}
+
+.shopHint {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #cbd5e1;
+  text-align: center;
+}
+
+.footer {
+  margin: 0;
+  color: #cbd5e1;
+  font-size: 0.95rem;
+}
+
+@media (max-width: 640px) {
+  .wrapper {
+    padding: 3rem 1rem 2.5rem;
+  }
+
+  .shopImage {
+    width: 160px;
+    height: 108px;
+  }
+
+  .title {
+    font-size: 2rem;
+  }
+}

--- a/src/SeymoursDriftMelanie.tsx
+++ b/src/SeymoursDriftMelanie.tsx
@@ -1,0 +1,110 @@
+import seymoursDriftBackground from "./SandboxSeymoursDrift.webp";
+import blossomHotelImage from "./Blossom Hotel.png";
+import floralImage from "./Floral.webp";
+import sleuthUniversityImage from "./Sleuth.webp";
+import evansEnchantingEmporiumImage from "./Evan's Enchanting Emporium.png";
+import labyrinthineLibraryImage from "./Labyrinthine Labrary.png";
+import willsWeaponsImage from "./Wills Weapons.png";
+import supremeSmithyImage from "./Supreme Smithy.png";
+import { BackButton } from "./BackButton";
+import styles from "./SeymoursDriftMelanie.module.css";
+
+type SeymoursDriftShop = {
+  key: string;
+  label: string;
+  image: string;
+  onClick: () => void;
+};
+
+export function SeymoursDriftMelanie({
+  onBack,
+  onNavigate,
+}: {
+  onBack: () => void;
+  onNavigate: (key: string) => void;
+}) {
+  const shops: SeymoursDriftShop[] = [
+    {
+      key: "blossom-hotel",
+      label: "Blossom Hotel",
+      image: blossomHotelImage,
+      onClick: () => onNavigate("BlossomHotel"),
+    },
+    {
+      key: "fairies-of-flora",
+      label: "Fairies of Flora",
+      image: floralImage,
+      onClick: () => onNavigate("FairiesOfFlora"),
+    },
+    {
+      key: "sleuth-university",
+      label: "Sleuth University",
+      image: sleuthUniversityImage,
+      onClick: () => onNavigate("SleuthUniversity"),
+    },
+    {
+      key: "evans-enchanting-emporium",
+      label: "Evan's Enchanting Emporium",
+      image: evansEnchantingEmporiumImage,
+      onClick: () => onNavigate("EvansEnchantingEmporium"),
+    },
+    {
+      key: "labyrinthine-library",
+      label: "Labyrinthine Library",
+      image: labyrinthineLibraryImage,
+      onClick: () => onNavigate("LabyrinthineLibrary"),
+    },
+    {
+      key: "wills-weapons",
+      label: "Will's Weapons",
+      image: willsWeaponsImage,
+      onClick: () => onNavigate("WillsWeapons"),
+    },
+    {
+      key: "supreme-smithy",
+      label: "Supreme Smithy",
+      image: supremeSmithyImage,
+      onClick: () => onNavigate("SupremeSmithy"),
+    },
+  ];
+
+  return (
+    <div
+      className={styles.wrapper}
+      style={{ backgroundImage: `url(${seymoursDriftBackground})` }}
+    >
+      <BackButton onClick={onBack} />
+
+      <div className={styles.content}>
+        <div className={styles.hero}>
+          <p className={styles.eyebrow}>Sandbox</p>
+          <h1 className={styles.title}>Welcome to Seymour&apos;s Drift</h1>
+          <p className={styles.subtitle}>
+            Shops drifting along Melanie&apos;s lily pad city, always ready when the tide
+            brings you in
+          </p>
+        </div>
+
+        <div className={styles.buttonGrid}>
+          {shops.map((shop) => (
+            <button
+              key={shop.key}
+              type="button"
+              className={styles.shopButton}
+              onClick={shop.onClick}
+            >
+              <img
+                src={shop.image}
+                alt={`${shop.label} icon`}
+                className={styles.shopImage}
+              />
+              <span className={styles.shopLabel}>{shop.label}</span>
+            </button>
+          ))}
+        </div>
+
+        <p className={styles.footer}>This town was made by Melanie</p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a Seymour's Drift town screen mirroring the Withhold layout with Melanie's details
- wire Sandbox navigation to open the new Seymour's Drift experience
- update Seymour's Drift shop list to the new curated set of locations

## Testing
- npm run build (warnings about existing jsx-a11y aria-* props in unrelated files)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955b1586d508329862d07ad244e5f7b)