### PR TITLE
Add Graveborn sandbox town

### DIFF
--- a/src/Graveborn.module.css
+++ b/src/Graveborn.module.css
@@ -1,0 +1,140 @@
+.wrapper {
+  min-height: 100vh;
+  padding: 3.5rem 1.5rem 2.75rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  position: relative;
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: center;
+  overflow: hidden;
+  color: #e2e8f0;
+}
+
+.wrapper::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.72) 0%, rgba(15, 23, 42, 0.9) 100%);
+  backdrop-filter: blur(2px);
+  z-index: 0;
+}
+
+.content {
+  position: relative;
+  z-index: 1;
+  width: min(1100px, 96vw);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.75rem;
+}
+
+.hero {
+  width: 100%;
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 22px;
+  box-shadow: 0 18px 45px rgba(0, 0, 0, 0.35);
+  padding: 1.9rem 1.8rem;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.eyebrow {
+  font-size: 0.9rem;
+  letter-spacing: 0.18rem;
+  text-transform: uppercase;
+  color: #cbd5e1;
+  margin: 0;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.4rem;
+  color: #f8fafc;
+}
+
+.subtitle {
+  margin: 0;
+  color: #cbd5e1;
+  line-height: 1.5;
+}
+
+.buttonGrid {
+  display: grid;
+  width: 100%;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.shopButton {
+  background: rgba(30, 41, 59, 0.86);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 18px;
+  padding: 1.25rem 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  color: #f8fafc;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.35);
+}
+
+.shopButton:hover,
+.shopButton:focus-visible {
+  transform: translateY(-4px);
+  border-color: rgba(255, 255, 255, 0.28);
+  box-shadow: 0 20px 42px rgba(0, 0, 0, 0.45);
+}
+
+.shopImage {
+  width: 180px;
+  height: 120px;
+  object-fit: contain;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.9);
+  border: 2px solid rgba(255, 255, 255, 0.7);
+  box-shadow: 0 10px 18px rgba(0, 0, 0, 0.28);
+}
+
+.shopLabel {
+  font-weight: 700;
+  font-size: 1.1rem;
+  text-align: center;
+  line-height: 1.35;
+}
+
+.shopHint {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #cbd5e1;
+  text-align: center;
+}
+
+.footer {
+  margin: 0;
+  color: #cbd5e1;
+  font-size: 0.95rem;
+}
+
+@media (max-width: 640px) {
+  .wrapper {
+    padding: 3rem 1rem 2.5rem;
+  }
+
+  .shopImage {
+    width: 160px;
+    height: 108px;
+  }
+
+  .title {
+    font-size: 2rem;
+  }
+}

--- a/src/Graveborn.tsx
+++ b/src/Graveborn.tsx
@@ -1,0 +1,124 @@
+import gravebornBackground from "./SandboxGraveBorn.webp";
+import iconicDragonicImage from "./Iconic Dragonic.png";
+import monsterImage from "./Monster.webp";
+import mountsImage from "./Mounts.webp";
+import pawsClawsMawsImage from "./Paws, Claws, & Maws.png";
+import valhallaMartImage from "./Valhalla Mart.png";
+import sleuthUniversityImage from "./Sleuth.webp";
+import evansEnchantingEmporiumImage from "./Evan's Enchanting Emporium.png";
+import labyrinthineLibraryImage from "./Labyrinthine Labrary.png";
+import blossomHotelImage from "./Blossom Hotel.png";
+import { BackButton } from "./BackButton";
+import styles from "./Graveborn.module.css";
+
+type GravebornShop = {
+  key: string;
+  label: string;
+  image: string;
+  onClick: () => void;
+};
+
+export function Graveborn({
+  onBack,
+  onNavigate,
+}: {
+  onBack: () => void;
+  onNavigate: (key: string) => void;
+}) {
+  const shops: GravebornShop[] = [
+    {
+      key: "iconic-dragonic",
+      label: "Iconic Dragonic",
+      image: iconicDragonicImage,
+      onClick: () => onNavigate("IconicDragonic"),
+    },
+    {
+      key: "make-a-monster",
+      label: "Make a Monster",
+      image: monsterImage,
+      onClick: () => onNavigate("MonsterMaker"),
+    },
+    {
+      key: "michaels-mount",
+      label: "Michael's Mount",
+      image: mountsImage,
+      onClick: () => onNavigate("MichaelsMount"),
+    },
+    {
+      key: "paws-claws-maws",
+      label: "Paws, Claws, & Maws",
+      image: pawsClawsMawsImage,
+      onClick: () => onNavigate("PawsClawsMaws"),
+    },
+    {
+      key: "valhalla-mart",
+      label: "Valhalla Mart",
+      image: valhallaMartImage,
+      onClick: () => onNavigate("ValhallaMart"),
+    },
+    {
+      key: "sleuth-university",
+      label: "Sleuth University",
+      image: sleuthUniversityImage,
+      onClick: () => onNavigate("SleuthUniversity"),
+    },
+    {
+      key: "evans-enchanting-emporium",
+      label: "Evan's Enchanting Emporium",
+      image: evansEnchantingEmporiumImage,
+      onClick: () => onNavigate("EvansEnchantingEmporium"),
+    },
+    {
+      key: "labyrinthine-library",
+      label: "Labyrinthine Library",
+      image: labyrinthineLibraryImage,
+      onClick: () => onNavigate("LabyrinthineLibrary"),
+    },
+    {
+      key: "blossom-hotel",
+      label: "Blossom Hotel",
+      image: blossomHotelImage,
+      onClick: () => onNavigate("BlossomHotel"),
+    },
+  ];
+
+  return (
+    <div
+      className={styles.wrapper}
+      style={{ backgroundImage: `url(${gravebornBackground})` }}
+    >
+      <BackButton onClick={onBack} />
+
+      <div className={styles.content}>
+        <div className={styles.hero}>
+          <p className={styles.eyebrow}>Sandbox</p>
+          <h1 className={styles.title}>Welcome to Graveborn</h1>
+          <p className={styles.subtitle}>
+            A haven for the undead where every shop hums with eerie charm and endless
+            curiosity
+          </p>
+        </div>
+
+        <div className={styles.buttonGrid}>
+          {shops.map((shop) => (
+            <button
+              key={shop.key}
+              type="button"
+              className={styles.shopButton}
+              onClick={shop.onClick}
+            >
+              <img
+                src={shop.image}
+                alt={`${shop.label} icon`}
+                className={styles.shopImage}
+              />
+              <span className={styles.shopLabel}>{shop.label}</span>
+            </button>
+          ))}
+        </div>
+
+        <p className={styles.footer}>This town beckons every wandering spirit</p>
+      </div>
+    </div>
+  );
+}

--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -108,8 +108,9 @@ import sandboxOrbitingCityImage from "./SandboxOrbitingCity.webp";
 import sandboxPopNFaithImage from "./SandboxPop-nFaith.webp";
 import sandboxSeymoursDriftImage from "./SandboxSeymoursDrift.webp";
 import sandboxWytheholdeImage from "./SandboxWytheholde.webp";
-import { ByfordDolphinRobertson } from "./ByfordDolphinRobertson";
 import { JellyCity } from "./JellyCity";
+import { ByfordDolphinRobertson } from "./ByfordDolphinRobertson";
+import { Graveborn } from "./Graveborn";
 
 // Remove stray whitespace/newlines from data URIs (defensive)
 function cleanDataUrl(s?: string) {
@@ -419,6 +420,13 @@ export function Map() {
     case "ButtingRams":
       return (
         <ButtingRams
+          onBack={() => setNavigatedTo("Sandbox")}
+          onNavigate={(key) => setNavigatedTo(key)}
+        />
+      );
+    case "Graveborn":
+      return (
+        <Graveborn
           onBack={() => setNavigatedTo("Sandbox")}
           onNavigate={(key) => setNavigatedTo(key)}
         />
@@ -837,6 +845,8 @@ function SandboxMenu({
                   ? onNavigate("Meander")
                   : town.key === "seymours-drift"
                   ? onNavigate("SeymoursDrift")
+                  : town.key === "graveborn"
+                  ? onNavigate("Graveborn")
                   : onNavigate("Sandbox")
               }
             />


### PR DESCRIPTION
## Summary
- add a Graveborn sandbox hub modeled after Withhold with shops for Iconic Dragonic, Make a Monster, Michael's Mount, Paws, Claws, & Maws, Valhalla Mart, Sleuth University, Evan's Enchanting Emporium, Labyrinthine Library, and Blossom Hotel
- connect the Graveborn town to the sandbox menu and navigation map

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955b2bd5098832997d65f12bf4a02fe)