### PR TITLE
Add Orbiting City sandbox hub

### DIFF
--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -38,6 +38,7 @@ import { SilentOath } from "./SilentOath";
 import { SupremeSmithy } from "./SupremeSmithy";
 import { CalidrisFisk } from "./CalidrisFisk";
 import { WithholdParker } from "./WithholdParker";
+import { OrbitingCity } from "./OrbitingCity";
 import { SeymoursDriftMelanie } from "./SeymoursDriftMelanie";
 import { HebronJoshua } from "./HebronJoshua";
 import { BallisticBellowsCaleb } from "./BallisticBellowsCaleb";
@@ -370,6 +371,13 @@ export function Map() {
     case "AnalepticHolt":
       return (
         <AnalepticHoltTeag
+          onBack={() => setNavigatedTo("Sandbox")}
+          onNavigate={(key) => setNavigatedTo(key)}
+        />
+      );
+    case "OrbitingCity":
+      return (
+        <OrbitingCity
           onBack={() => setNavigatedTo("Sandbox")}
           onNavigate={(key) => setNavigatedTo(key)}
         />
@@ -829,6 +837,8 @@ function SandboxMenu({
                   ? onNavigate("Calidris")
                   : town.key === "analeptic-holt"
                   ? onNavigate("AnalepticHolt")
+                  : town.key === "orbiting-city"
+                  ? onNavigate("OrbitingCity")
                   : town.key === "butting-rams"
                   ? onNavigate("ButtingRams")
                   : town.key === "jelly-city"

--- a/src/OrbitingCity.module.css
+++ b/src/OrbitingCity.module.css
@@ -1,0 +1,140 @@
+.wrapper {
+  min-height: 100vh;
+  padding: 3.5rem 1.5rem 2.75rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  position: relative;
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: center;
+  overflow: hidden;
+  color: #e2e8f0;
+}
+
+.wrapper::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(14, 116, 144, 0.62) 0%, rgba(15, 23, 42, 0.88) 100%);
+  backdrop-filter: blur(2px);
+  z-index: 0;
+}
+
+.content {
+  position: relative;
+  z-index: 1;
+  width: min(1100px, 96vw);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.75rem;
+}
+
+.hero {
+  width: 100%;
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 22px;
+  box-shadow: 0 18px 45px rgba(0, 0, 0, 0.35);
+  padding: 1.9rem 1.8rem;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.eyebrow {
+  font-size: 0.9rem;
+  letter-spacing: 0.18rem;
+  text-transform: uppercase;
+  color: #bae6fd;
+  margin: 0;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.4rem;
+  color: #f8fafc;
+}
+
+.subtitle {
+  margin: 0;
+  color: #cbd5e1;
+  line-height: 1.5;
+}
+
+.buttonGrid {
+  display: grid;
+  width: 100%;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.shopButton {
+  background: rgba(30, 41, 59, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 18px;
+  padding: 1.25rem 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  color: #f8fafc;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.35);
+}
+
+.shopButton:hover,
+.shopButton:focus-visible {
+  transform: translateY(-4px);
+  border-color: rgba(255, 255, 255, 0.28);
+  box-shadow: 0 20px 42px rgba(0, 0, 0, 0.45);
+}
+
+.shopImage {
+  width: 180px;
+  height: 120px;
+  object-fit: contain;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.9);
+  border: 2px solid rgba(255, 255, 255, 0.7);
+  box-shadow: 0 10px 18px rgba(0, 0, 0, 0.28);
+}
+
+.shopLabel {
+  font-weight: 700;
+  font-size: 1.1rem;
+  text-align: center;
+  line-height: 1.35;
+}
+
+.shopHint {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #cbd5e1;
+  text-align: center;
+}
+
+.footer {
+  margin: 0;
+  color: #cbd5e1;
+  font-size: 0.95rem;
+}
+
+@media (max-width: 640px) {
+  .wrapper {
+    padding: 3rem 1rem 2.5rem;
+  }
+
+  .shopImage {
+    width: 160px;
+    height: 108px;
+  }
+
+  .title {
+    font-size: 2rem;
+  }
+}

--- a/src/OrbitingCity.tsx
+++ b/src/OrbitingCity.tsx
@@ -1,0 +1,117 @@
+import orbitingCityBackground from "./SandboxOrbitingCity.webp";
+import iconicDragonicImage from "./Iconic Dragonic.png";
+import evansEnchantingEmporiumImage from "./Evan's Enchanting Emporium.png";
+import supremeSmithyImage from "./Supreme Smithy.png";
+import sleuthUniversityImage from "./Sleuth.webp";
+import willsWeaponsImage from "./Wills Weapons.png";
+import runestoneRelayImage from "./Runestone Relay.png";
+import piggyBankImage from "./Piggy Bank.png";
+import mountsImage from "./Mounts.webp";
+import { BackButton } from "./BackButton";
+import styles from "./OrbitingCity.module.css";
+
+type OrbitingCityShop = {
+  key: string;
+  label: string;
+  image: string;
+  onClick: () => void;
+};
+
+export function OrbitingCity({
+  onBack,
+  onNavigate,
+}: {
+  onBack: () => void;
+  onNavigate: (key: string) => void;
+}) {
+  const shops: OrbitingCityShop[] = [
+    {
+      key: "iconic-dragonic",
+      label: "Iconic Dragonic",
+      image: iconicDragonicImage,
+      onClick: () => onNavigate("IconicDragonic"),
+    },
+    {
+      key: "evans-enchanting-emporium",
+      label: "Evan's Enchanting Emporium",
+      image: evansEnchantingEmporiumImage,
+      onClick: () => onNavigate("EvansEnchantingEmporium"),
+    },
+    {
+      key: "supreme-smithy",
+      label: "Supreme Smithy",
+      image: supremeSmithyImage,
+      onClick: () => onNavigate("SupremeSmithy"),
+    },
+    {
+      key: "sleuth-university",
+      label: "Sleuth University",
+      image: sleuthUniversityImage,
+      onClick: () => onNavigate("SleuthUniversity"),
+    },
+    {
+      key: "wills-weapons",
+      label: "Will's Weapons",
+      image: willsWeaponsImage,
+      onClick: () => onNavigate("WillsWeapons"),
+    },
+    {
+      key: "runestone-relay",
+      label: "Runestone Relay",
+      image: runestoneRelayImage,
+      onClick: () => onNavigate("RunestoneRelay"),
+    },
+    {
+      key: "piggy-bank",
+      label: "The Piggy Bank",
+      image: piggyBankImage,
+      onClick: () => onNavigate("PiggyBank"),
+    },
+    {
+      key: "michaels-mount",
+      label: "Michael's Mount",
+      image: mountsImage,
+      onClick: () => onNavigate("MichaelsMount"),
+    },
+  ];
+
+  return (
+    <div
+      className={styles.wrapper}
+      style={{ backgroundImage: `url(${orbitingCityBackground})` }}
+    >
+      <BackButton onClick={onBack} />
+
+      <div className={styles.content}>
+        <div className={styles.hero}>
+          <p className={styles.eyebrow}>Sandbox</p>
+          <h1 className={styles.title}>Welcome to Orbiting City</h1>
+          <p className={styles.subtitle}>
+            Keep pace with the floating metropolis by visiting the merchants that help
+            keep it aloft.
+          </p>
+        </div>
+
+        <div className={styles.buttonGrid}>
+          {shops.map((shop) => (
+            <button
+              key={shop.key}
+              type="button"
+              className={styles.shopButton}
+              onClick={shop.onClick}
+            >
+              <img
+                src={shop.image}
+                alt={`${shop.label} icon`}
+                className={styles.shopImage}
+              />
+              <span className={styles.shopLabel}>{shop.label}</span>
+            </button>
+          ))}
+        </div>
+
+        <p className={styles.footer}>This city sails the sky with your support.</p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add an Orbiting City sandbox page mirroring the Withhold layout with the requested shop links
- style the new Orbiting City view with a skyline-inspired overlay and hook it into sandbox navigation

## Testing
- npm test -- --watch=false *(fails: existing ReactDOMTestUtils.act deprecation warning and jsdom canvas getContext not implemented in tests)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955b3c992ec8329a26352f37bbf051c)