### PR TITLE
Fix BigHome switch case rendering

### DIFF
--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -436,6 +436,10 @@ export function Map() {
     case "BigHome":
       return (
         <BigHome
+          onBack={() => setNavigatedTo("")}
+          onNavigate={(key) => setNavigatedTo(key)}
+        />
+      );
     case "Graveborn":
       return (
         <Graveborn


### PR DESCRIPTION
## Summary
- close the Map navigation switch case for BigHome by rendering the component with its callbacks
- ensure BigHome navigation uses the same onBack and onNavigate handlers as other Sandbox locations

## Testing
- CI=true npm test -- --watch=false *(fails: jsdom lacks HTMLCanvasElement.getContext and existing heading expectation does not match UI)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955b6a5618c83299de023d300bee9e7)