### PR TITLE
Add Strenuous Portal main menu destination

### DIFF
--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -113,6 +113,8 @@ import sandboxWytheholdeImage from "./SandboxWytheholde.webp";
 import { JellyCity } from "./JellyCity";
 import { ByfordDolphinRobertson } from "./ByfordDolphinRobertson";
 import { Graveborn } from "./Graveborn";
+import { StrenuousPortal } from "./StrenuousPortal";
+import strenuousPortalButtonImage from "./StrenuousPortalButton2.webp";
 
 // Remove stray whitespace/newlines from data URIs (defensive)
 function cleanDataUrl(s?: string) {
@@ -391,6 +393,13 @@ export function Map() {
           onNavigate={(key) => setNavigatedTo(key)}
         />
       );
+    case "StrenuousPortal":
+      return (
+        <StrenuousPortal
+          onBack={() => setNavigatedTo("")}
+          onNavigate={(key) => setNavigatedTo(key)}
+        />
+      );
     case "SeymoursDrift":
       return (
         <SeymoursDriftMelanie
@@ -478,6 +487,14 @@ export function Map() {
               backgroundColor="rgba(15, 23, 42, 0.85)"
               color="#e2e8f0"
               imageSrc={sandboxWorldMapImage}
+            />
+            <FloatingButton
+              label="Strenuous Portal"
+              onClick={() => setNavigatedTo("StrenuousPortal")}
+              delay="2.5s"
+              backgroundColor="rgba(88, 28, 135, 0.9)"
+              color="#f1f5f9"
+              imageSrc={strenuousPortalButtonImage}
             />
             <FloatingButton
               label="Auction House"

--- a/src/StrenuousPortal.module.css
+++ b/src/StrenuousPortal.module.css
@@ -1,0 +1,140 @@
+.wrapper {
+  min-height: 100vh;
+  padding: 3.5rem 1.5rem 2.75rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  position: relative;
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: center;
+  overflow: hidden;
+  color: #e2e8f0;
+}
+
+.wrapper::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.7) 0%, rgba(15, 23, 42, 0.85) 100%);
+  backdrop-filter: blur(2px);
+  z-index: 0;
+}
+
+.content {
+  position: relative;
+  z-index: 1;
+  width: min(1100px, 96vw);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.75rem;
+}
+
+.hero {
+  width: 100%;
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 22px;
+  box-shadow: 0 18px 45px rgba(0, 0, 0, 0.35);
+  padding: 1.9rem 1.8rem;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.eyebrow {
+  font-size: 0.9rem;
+  letter-spacing: 0.18rem;
+  text-transform: uppercase;
+  color: #cbd5e1;
+  margin: 0;
+}
+
+.title {
+  margin: 0;
+  font-size: 2.4rem;
+  color: #f8fafc;
+}
+
+.subtitle {
+  margin: 0;
+  color: #cbd5e1;
+  line-height: 1.5;
+}
+
+.buttonGrid {
+  display: grid;
+  width: 100%;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.shopButton {
+  background: rgba(30, 41, 59, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 18px;
+  padding: 1.25rem 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  color: #f8fafc;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.35);
+}
+
+.shopButton:hover,
+.shopButton:focus-visible {
+  transform: translateY(-4px);
+  border-color: rgba(255, 255, 255, 0.28);
+  box-shadow: 0 20px 42px rgba(0, 0, 0, 0.45);
+}
+
+.shopImage {
+  width: 180px;
+  height: 120px;
+  object-fit: contain;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.88);
+  border: 2px solid rgba(255, 255, 255, 0.7);
+  box-shadow: 0 10px 18px rgba(0, 0, 0, 0.28);
+}
+
+.shopLabel {
+  font-weight: 700;
+  font-size: 1.1rem;
+  text-align: center;
+  line-height: 1.35;
+}
+
+.shopHint {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #cbd5e1;
+  text-align: center;
+}
+
+.footer {
+  margin: 0;
+  color: #cbd5e1;
+  font-size: 0.95rem;
+}
+
+@media (max-width: 640px) {
+  .wrapper {
+    padding: 3rem 1rem 2.5rem;
+  }
+
+  .shopImage {
+    width: 160px;
+    height: 108px;
+  }
+
+  .title {
+    font-size: 2rem;
+  }
+}

--- a/src/StrenuousPortal.tsx
+++ b/src/StrenuousPortal.tsx
@@ -1,0 +1,239 @@
+import backgroundImage from "./StrenuousPortalButton2.webp";
+import applegarthImage from "./Applegarth.webp";
+import archivesGuildImage from "./Archives Guild.png";
+import bookBombsImage from "./Book Bomb.png";
+import bulletsBuffsBeyondImage from "./Bullets Buffs and Beyond.webp";
+import changingChurchImage from "./Changing Church.png";
+import necromancyInsuranceImage from "./NecromanyInsuranceCo-ezgif.com-webp-to-png-converter.png";
+import oPapiesOracleReadingsImage from "./O Papies Oracle Readings.png";
+import robinsRopesImage from "./Robins Ropes.png";
+import runestoneRelayImage from "./Runestone Relay.png";
+import silentOathImage from "./Silent Oath.png";
+import supremeSmithyImage from "./Supreme Smithy.png";
+import willsWeaponsImage from "./Wills Weapons.png";
+import jellBellImage from "./Jell.webp";
+import monsterImage from "./Monster.webp";
+import mountsImage from "./Mounts.webp";
+import pawsClawsMawsImage from "./Paws, Claws, & Maws.png";
+import valhallaMartImage from "./Valhalla Mart.png";
+import evansEnchantingEmporiumImage from "./Evan's Enchanting Emporium.png";
+import floralImage from "./Floral.webp";
+import golemWorkshopImage from "./Golem Work Shop.png";
+import jewelryGuildImage from "./Jewelry Guild.png";
+import nmeImage from "./N.M.E.png";
+import sleuthUniversityImage from "./Sleuth.webp";
+import fizzyTaleImage from "./FizzyTale.png";
+import goblinMarketImage from "./GoblinMarket.png";
+import { BackButton } from "./BackButton";
+import styles from "./StrenuousPortal.module.css";
+
+type StrenuousShop = {
+  key: string;
+  label: string;
+  image: string;
+  onClick: () => void;
+};
+
+export function StrenuousPortal({
+  onBack,
+  onNavigate,
+}: {
+  onBack: () => void;
+  onNavigate: (key: string) => void;
+}) {
+  const shops: StrenuousShop[] = [
+    {
+      key: "applegarth",
+      label: "Applegarth Guild",
+      image: applegarthImage,
+      onClick: () => onNavigate("ApplegarthGuild"),
+    },
+    {
+      key: "archives-guild",
+      label: "Archives Guild",
+      image: archivesGuildImage,
+      onClick: () => onNavigate("ArchivesGuild"),
+    },
+    {
+      key: "book-bombs",
+      label: "Book Bombs",
+      image: bookBombsImage,
+      onClick: () => onNavigate("BookBombs"),
+    },
+    {
+      key: "bullets-buffs",
+      label: "Bullets, Buffs, & Beyond",
+      image: bulletsBuffsBeyondImage,
+      onClick: () => onNavigate("BulletsBuffsBeyond"),
+    },
+    {
+      key: "changing-church",
+      label: "Changing Church",
+      image: changingChurchImage,
+      onClick: () => onNavigate("ChangingChurch"),
+    },
+    {
+      key: "necromancy-insurance",
+      label: "Necromancy Insurance Company",
+      image: necromancyInsuranceImage,
+      onClick: () => onNavigate("NecromancyInsuranceCompany"),
+    },
+    {
+      key: "o-papies",
+      label: "O-Papies Oracle Readings",
+      image: oPapiesOracleReadingsImage,
+      onClick: () => onNavigate("OPapiesOracleReadings"),
+    },
+    {
+      key: "robins-ropes",
+      label: "Robin's Ropes",
+      image: robinsRopesImage,
+      onClick: () => onNavigate("RobinsRopes"),
+    },
+    {
+      key: "runestone-relay",
+      label: "Runestone Relay",
+      image: runestoneRelayImage,
+      onClick: () => onNavigate("RunestoneRelay"),
+    },
+    {
+      key: "silent-oath",
+      label: "Silent Oath",
+      image: silentOathImage,
+      onClick: () => onNavigate("SilentOath"),
+    },
+    {
+      key: "supreme-smithy",
+      label: "Supreme Smithy",
+      image: supremeSmithyImage,
+      onClick: () => onNavigate("SupremeSmithy"),
+    },
+    {
+      key: "wills-weapons",
+      label: "Will's Weapons",
+      image: willsWeaponsImage,
+      onClick: () => onNavigate("WillsWeapons"),
+    },
+    {
+      key: "jell-bell",
+      label: "Jell Bell",
+      image: jellBellImage,
+      onClick: () => onNavigate("JellBell"),
+    },
+    {
+      key: "make-a-monster",
+      label: "Make a Monster",
+      image: monsterImage,
+      onClick: () => onNavigate("MonsterMaker"),
+    },
+    {
+      key: "michaels-mount",
+      label: "Michael's Mount",
+      image: mountsImage,
+      onClick: () => onNavigate("MichaelsMount"),
+    },
+    {
+      key: "paws-claws",
+      label: "Paws, Claws, & Maws",
+      image: pawsClawsMawsImage,
+      onClick: () => onNavigate("PawsClawsMaws"),
+    },
+    {
+      key: "valhalla-mart",
+      label: "Valhalla Mart",
+      image: valhallaMartImage,
+      onClick: () => onNavigate("ValhallaMart"),
+    },
+    {
+      key: "evans-enchanting",
+      label: "Evan's Enchanting Emporium",
+      image: evansEnchantingEmporiumImage,
+      onClick: () => onNavigate("EvansEnchantingEmporium"),
+    },
+    {
+      key: "fairies-of-flora",
+      label: "Fairies of Flora",
+      image: floralImage,
+      onClick: () => onNavigate("FairiesOfFlora"),
+    },
+    {
+      key: "golem-workshop",
+      label: "Golem Workshop",
+      image: golemWorkshopImage,
+      onClick: () => onNavigate("GolemWorkshop"),
+    },
+    {
+      key: "jewelry-guild",
+      label: "Jewelry Guild",
+      image: jewelryGuildImage,
+      onClick: () => onNavigate("JewelryGuild"),
+    },
+    {
+      key: "nme",
+      label: "N.M.E.",
+      image: nmeImage,
+      onClick: () => onNavigate("NME"),
+    },
+    {
+      key: "sleuth-university",
+      label: "Sleuth University",
+      image: sleuthUniversityImage,
+      onClick: () => onNavigate("SleuthUniversity"),
+    },
+    {
+      key: "fizzy-tales",
+      label: "Fizzy Tales",
+      image: fizzyTaleImage,
+      onClick: () => onNavigate("FizzyTales"),
+    },
+    {
+      key: "goblins",
+      label: "Goblins",
+      image: goblinMarketImage,
+      onClick: () => onNavigate("goblins"),
+    },
+  ];
+
+  return (
+    <div
+      className={styles.wrapper}
+      style={{ backgroundImage: `url(${backgroundImage})` }}
+    >
+      <BackButton onClick={onBack} />
+
+      <div className={styles.content}>
+        <div className={styles.hero}>
+          <p className={styles.eyebrow}>Main Menu</p>
+          <h1 className={styles.title}>Welcome to the Strenuous Portal</h1>
+          <p className={styles.subtitle}>
+            Modeled after Withhold&apos;s cozy collection, this portal gathers bustling
+            favorites and arcane corners all in one launch point.
+          </p>
+        </div>
+
+        <div className={styles.buttonGrid}>
+          {shops.map((shop) => (
+            <button
+              key={shop.key}
+              type="button"
+              className={styles.shopButton}
+              onClick={shop.onClick}
+            >
+              <img
+                src={shop.image}
+                alt={`${shop.label} icon`}
+                className={styles.shopImage}
+              />
+              <span className={styles.shopLabel}>{shop.label}</span>
+            </button>
+          ))}
+        </div>
+
+        <p className={styles.footer}>
+          A fresh gateway inspired by Withhold&apos;s layout—now linked straight from the
+          main menu.
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a Strenuous Portal button to the main menu with the provided artwork
- create a Strenuous Portal destination modeled after Withhold, featuring the requested shop lineup

## Testing
- npm test -- --watch=false --runTestsByPath src/App.test.tsx *(fails: jsdom canvas implementation missing and existing heading query mismatch)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69586f7b8cf48329bf9ab4e16ff05ace)