### PR TITLE
Add rotating insult box for shop footers

### DIFF
--- a/src/ApplegarthGuild.tsx
+++ b/src/ApplegarthGuild.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import styles from "./ApplegarthGuild.module.css";
 import { tribeApplegarthGuild } from "./tribeApplegarthGuild";
 import { BackButton } from "./BackButton";
+import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import applegarthBackground from "./Applegarth.webp";
 
@@ -61,7 +62,11 @@ export function ApplegarthGuild({ onBack }: { onBack?: () => void }) {
           })}
         </section>
 
-        <p className={styles.footerNote}>{tribeApplegarthGuild.insults[0]}</p>
+        <InsultBox
+          className={styles.footerNote}
+          owner={tribeApplegarthGuild.owner}
+          insults={tribeApplegarthGuild.insults}
+        />
       </main>
     </div>
   );

--- a/src/ArchivesGuild.tsx
+++ b/src/ArchivesGuild.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import styles from "./ArchivesGuild.module.css";
 import { tribeArchivesGuild } from "./tribeArchivesGuild";
 import { BackButton } from "./BackButton";
+import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import archivesGuildBackground from "./Archives Guild.png";
 
@@ -52,9 +53,11 @@ export function ArchivesGuild({ onBack }: { onBack?: () => void }) {
           ))}
         </section>
 
-        <p className={styles.footerNote}>
-          {tribeArchivesGuild.insults[0]}
-        </p>
+        <InsultBox
+          className={styles.footerNote}
+          owner={tribeArchivesGuild.owner}
+          insults={tribeArchivesGuild.insults}
+        />
       </main>
     </div>
   );

--- a/src/AuntiePattysPies.tsx
+++ b/src/AuntiePattysPies.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import styles from "./AuntiePattysPies.module.css";
 import { tribeAuntiePattysPies } from "./tribeAuntiePattysPies";
 import { BackButton } from "./BackButton";
+import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import auntPattiePieBackground from "./Aunt Pattie Pie.png";
 
@@ -53,9 +54,11 @@ export function AuntiePattysPies({ onBack }: { onBack?: () => void }) {
           ))}
         </section>
 
-        <p className={styles.footerNote}>
-          {tribeAuntiePattysPies.insults[0]}
-        </p>
+        <InsultBox
+          className={styles.footerNote}
+          owner={tribeAuntiePattysPies.owner}
+          insults={tribeAuntiePattysPies.insults}
+        />
       </main>
     </div>
   );

--- a/src/BlossomHotel.tsx
+++ b/src/BlossomHotel.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import styles from "./BlossomHotel.module.css";
 import { BackButton } from "./BackButton";
+import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import { BlossomHotelItem, tribeBlossomHotel } from "./tribeBlossomHotel";
 import blossomHotelBackground from "./Blossom Hotel.png";
@@ -73,7 +74,11 @@ export function BlossomHotel({ onBack }: { onBack?: () => void }) {
           ))}
         </section>
 
-        <p className={styles.footerNote}>{tribeBlossomHotel.insults[0]}</p>
+        <InsultBox
+          className={styles.footerNote}
+          owner={tribeBlossomHotel.owner}
+          insults={tribeBlossomHotel.insults}
+        />
       </main>
     </div>
   );

--- a/src/BookBombs.tsx
+++ b/src/BookBombs.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import styles from "./BookBombs.module.css";
 import { tribeBookBombs } from "./tribeBookBombs";
 import { BackButton } from "./BackButton";
+import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import bookBombBackground from "./Book Bomb.png";
 
@@ -54,9 +55,11 @@ export function BookBombs({ onBack }: { onBack?: () => void }) {
           ))}
         </section>
 
-        <p className={styles.footerNote}>
-          {tribeBookBombs.insults[0]}
-        </p>
+        <InsultBox
+          className={styles.footerNote}
+          owner={tribeBookBombs.owner}
+          insults={tribeBookBombs.insults}
+        />
       </main>
     </div>
   );

--- a/src/BulletsBuffsBeyond.tsx
+++ b/src/BulletsBuffsBeyond.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import styles from "./BulletsBuffsBeyond.module.css";
 import { tribeBulletsBuffsBeyond } from "./tribeBulletsBuffsBeyond";
 import { BackButton } from "./BackButton";
+import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import bulletsBuffsBeyondBackground from "./Bullets Buffs and Beyond.webp";
 
@@ -62,9 +63,11 @@ export function BulletsBuffsBeyond({ onBack }: { onBack?: () => void }) {
           })}
         </section>
 
-        <p className={styles.footerNote}>
-          {tribeBulletsBuffsBeyond.insults[0]}
-        </p>
+        <InsultBox
+          className={styles.footerNote}
+          owner={tribeBulletsBuffsBeyond.owner}
+          insults={tribeBulletsBuffsBeyond.insults}
+        />
       </main>
     </div>
   );

--- a/src/ChangingChurch.tsx
+++ b/src/ChangingChurch.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import styles from "./ChangingChurch.module.css";
 import { tribeChangingChurch } from "./tribeChangingChurch";
 import { BackButton } from "./BackButton";
+import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import changingChurchBackground from "./Changing Church.png";
 
@@ -53,9 +54,11 @@ export function ChangingChurch({ onBack }: { onBack?: () => void }) {
           ))}
         </section>
 
-        <p className={styles.footerNote}>
-          {tribeChangingChurch.insults[0]}
-        </p>
+        <InsultBox
+          className={styles.footerNote}
+          owner={tribeChangingChurch.owner}
+          insults={tribeChangingChurch.insults}
+        />
       </main>
     </div>
   );

--- a/src/ComedyGold.tsx
+++ b/src/ComedyGold.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import styles from "./ComedyGold.module.css";
 import { tribeComedyGold } from "./tribeComedyGold";
 import { BackButton } from "./BackButton";
+import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import comedyGoldBackground from "./Comedy Gold.png";
 
@@ -62,9 +63,11 @@ export function ComedyGold({ onBack }: { onBack?: () => void }) {
           })}
         </section>
 
-        <p className={styles.footerNote}>
-          {tribeComedyGold.insults[0]}
-        </p>
+        <InsultBox
+          className={styles.footerNote}
+          owner={tribeComedyGold.owner}
+          insults={tribeComedyGold.insults}
+        />
       </main>
     </div>
   );

--- a/src/DungeonCrawlerGuild.tsx
+++ b/src/DungeonCrawlerGuild.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import styles from "./DungeonCrawlerGuild.module.css";
 import { tribeDungeonCrawlerGuild } from "./tribeDungeonCrawlerGuild";
 import { BackButton } from "./BackButton";
+import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import dungeonCrawlerGuildBackground from "./Dungeon Crawler's Guild.png";
 
@@ -53,9 +54,11 @@ export function DungeonCrawlerGuild({ onBack }: { onBack?: () => void }) {
           ))}
         </section>
 
-        <p className={styles.footerNote}>
-          {tribeDungeonCrawlerGuild.insults[0]}
-        </p>
+        <InsultBox
+          className={styles.footerNote}
+          owner={tribeDungeonCrawlerGuild.owner}
+          insults={tribeDungeonCrawlerGuild.insults}
+        />
       </main>
     </div>
   );

--- a/src/EvansEnchantingEmporium.tsx
+++ b/src/EvansEnchantingEmporium.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import styles from "./EvansEnchantingEmporium.module.css";
 import { BackButton } from "./BackButton";
+import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import {
   EvansEnchantingItem,
@@ -80,9 +81,11 @@ export function EvansEnchantingEmporium({ onBack }: { onBack?: () => void }) {
           ))}
         </section>
 
-        <p className={styles.footerNote}>
-          {tribeEvansEnchantingEmporium.insults[0]}
-        </p>
+        <InsultBox
+          className={styles.footerNote}
+          owner={tribeEvansEnchantingEmporium.owner}
+          insults={tribeEvansEnchantingEmporium.insults}
+        />
       </main>
     </div>
   );

--- a/src/FairiesOfFlora.tsx
+++ b/src/FairiesOfFlora.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import styles from "./FairiesOfFlora.module.css";
 import { BackButton } from "./BackButton";
+import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import { FairiesOfFloraItem, tribeFairiesOfFlora } from "./tribeFairiesOfFlora";
 import floralBackground from "./Floral.webp";
@@ -66,7 +67,11 @@ export function FairiesOfFlora({ onBack }: { onBack?: () => void }) {
           ))}
         </section>
 
-        <p className={styles.footerNote}>{tribeFairiesOfFlora.insults[0]}</p>
+        <InsultBox
+          className={styles.footerNote}
+          owner={tribeFairiesOfFlora.owner}
+          insults={tribeFairiesOfFlora.insults}
+        />
       </main>
     </div>
   );

--- a/src/FindAFriend.tsx
+++ b/src/FindAFriend.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import styles from "./FindAFriend.module.css";
 import { tribeFindAFriend } from "./tribeFindAFriend";
 import { BackButton } from "./BackButton";
+import { InsultBox } from "./InsultBox";
 import findAFriendBackground from "./Find a Friend.png";
 import { Item } from "./types";
 
@@ -57,9 +58,11 @@ export function FindAFriend({ onBack }: { onBack?: () => void }) {
           ))}
         </section>
 
-        <p className={styles.footerNote}>
-          {tribeFindAFriend.insults[0]}
-        </p>
+        <InsultBox
+          className={styles.footerNote}
+          owner={tribeFindAFriend.owner}
+          insults={tribeFindAFriend.insults}
+        />
       </main>
     </div>
   );

--- a/src/FizzyTales.tsx
+++ b/src/FizzyTales.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import styles from "./FizzyTales.module.css";
 import { BackButton } from "./BackButton";
+import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import { FizzyTalesItem, tribeFizzyTales } from "./tribeFizzyTales";
 import fizzyTalesBackground from "./FizzyTale.png";
@@ -64,7 +65,11 @@ export function FizzyTales({ onBack }: { onBack?: () => void }) {
           ))}
         </section>
 
-        <p className={styles.footerNote}>{tribeFizzyTales.insults[0]}</p>
+        <InsultBox
+          className={styles.footerNote}
+          owner={tribeFizzyTales.owner}
+          insults={tribeFizzyTales.insults}
+        />
       </main>
     </div>
   );

--- a/src/GolemWorkshop.tsx
+++ b/src/GolemWorkshop.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import styles from "./GolemWorkshop.module.css";
 import { BackButton } from "./BackButton";
+import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import { GolemWorkshopItem, tribeGolemWorkshop } from "./tribeGolemWorkshop";
 import golemWorkshopBackground from "./Golem Work Shop.png";
@@ -70,7 +71,11 @@ export function GolemWorkshop({ onBack }: { onBack?: () => void }) {
           ))}
         </section>
 
-        <p className={styles.footerNote}>{tribeGolemWorkshop.insults[0]}</p>
+        <InsultBox
+          className={styles.footerNote}
+          owner={tribeGolemWorkshop.owner}
+          insults={tribeGolemWorkshop.insults}
+        />
       </main>
     </div>
   );

--- a/src/IconicDragonic.tsx
+++ b/src/IconicDragonic.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import styles from "./IconicDragonic.module.css";
 import { tribeIconicDragonic } from "./tribeIconicDragonic";
 import { BackButton } from "./BackButton";
+import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import dragonicBackground from "./Iconic Dragonic.png";
 
@@ -66,9 +67,11 @@ export function IconicDragonic({ onBack }: { onBack?: () => void }) {
           ))}
         </section>
 
-        <p className={styles.footerNote}>
-          {tribeIconicDragonic.insults[0]}
-        </p>
+        <InsultBox
+          className={styles.footerNote}
+          owner={tribeIconicDragonic.owner}
+          insults={tribeIconicDragonic.insults}
+        />
       </main>
     </div>
   );

--- a/src/InsultBox.module.css
+++ b/src/InsultBox.module.css
@@ -1,0 +1,20 @@
+.insultBox {
+  background: #000;
+  border: 2px solid #fff;
+  border-radius: 10px;
+  color: #fff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.85rem 1.15rem;
+  font-weight: bold;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
+  max-width: 780px;
+  text-align: center;
+  margin-top: 1rem;
+}
+
+.ownerLabel {
+  white-space: nowrap;
+}

--- a/src/InsultBox.tsx
+++ b/src/InsultBox.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useMemo, useState } from "react";
+import styles from "./InsultBox.module.css";
+
+interface InsultBoxProps {
+  owner?: string;
+  insults: string[];
+  className?: string;
+  rotationMs?: number;
+}
+
+export function InsultBox({
+  owner,
+  insults,
+  className,
+  rotationMs = 5000,
+}: InsultBoxProps) {
+  const insultOptions = useMemo(
+    () => insults.map((insult) => insult?.trim() ?? ""),
+    [insults],
+  );
+
+  const rotationPool = useMemo(() => {
+    const meaningfulInsults = insultOptions.filter(Boolean);
+    return meaningfulInsults.length > 0 ? meaningfulInsults : insultOptions;
+  }, [insultOptions]);
+
+  const [activeInsult, setActiveInsult] = useState<string>(() =>
+    rotationPool.length > 0
+      ? rotationPool[Math.floor(Math.random() * rotationPool.length)]
+      : "",
+  );
+
+  useEffect(() => {
+    if (rotationPool.length === 0) {
+      setActiveInsult("");
+      return;
+    }
+
+    const pickInsult = (current: string) => {
+      if (rotationPool.length === 1) {
+        return rotationPool[0];
+      }
+
+      const remaining = rotationPool.filter((insult) => insult !== current);
+      return (
+        remaining[Math.floor(Math.random() * remaining.length)] ??
+        rotationPool[0]
+      );
+    };
+
+    setActiveInsult((current) => pickInsult(current));
+
+    if (rotationPool.length === 1) {
+      return;
+    }
+
+    const interval = setInterval(() => {
+      setActiveInsult((current) => pickInsult(current));
+    }, rotationMs);
+
+    return () => clearInterval(interval);
+  }, [rotationPool, rotationMs]);
+
+  const shouldRender = owner || rotationPool.length > 0;
+
+  if (!shouldRender) {
+    return null;
+  }
+
+  return (
+    <div className={className}>
+      <div className={styles.insultBox} role="status" aria-live="polite">
+        {owner && <span className={styles.ownerLabel}>{owner}:</span>}
+        <span>{rotationPool.length > 0 ? activeInsult : ""}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/JellBell.tsx
+++ b/src/JellBell.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import styles from "./JellBell.module.css";
 import { BackButton } from "./BackButton";
+import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import { JellBellItem, tribeJellBell } from "./tribeJellBell";
 import dragonicBackground from "./Iconic Dragonic.png";
@@ -70,7 +71,11 @@ export function JellBell({ onBack }: { onBack?: () => void }) {
           ))}
         </section>
 
-        <p className={styles.footerNote}>{tribeJellBell.insults[0]}</p>
+        <InsultBox
+          className={styles.footerNote}
+          owner={tribeJellBell.owner}
+          insults={tribeJellBell.insults}
+        />
       </main>
     </div>
   );

--- a/src/JewelryGuild.tsx
+++ b/src/JewelryGuild.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import styles from "./JewelryGuild.module.css";
 import { BackButton } from "./BackButton";
+import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import { JewelryGuildItem, tribeJewelryGuild } from "./tribeJewelryGuild";
 import jewelryGuildBackground from "./Jewelry Guild.png";
@@ -68,7 +69,11 @@ export function JewelryGuild({ onBack }: { onBack?: () => void }) {
           ))}
         </section>
 
-        <p className={styles.footerNote}>{tribeJewelryGuild.insults[0]}</p>
+        <InsultBox
+          className={styles.footerNote}
+          owner={tribeJewelryGuild.owner}
+          insults={tribeJewelryGuild.insults}
+        />
       </main>
     </div>
   );

--- a/src/LabyrinthineLibrary.tsx
+++ b/src/LabyrinthineLibrary.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import styles from "./LabyrinthineLibrary.module.css";
 import { BackButton } from "./BackButton";
+import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import {
   LabyrinthineLibraryItem,
@@ -76,7 +77,11 @@ export function LabyrinthineLibrary({ onBack }: { onBack?: () => void }) {
           ))}
         </section>
 
-        <p className={styles.footerNote}>{tribeLabyrinthineLibrary.insults[0]}</p>
+        <InsultBox
+          className={styles.footerNote}
+          owner={tribeLabyrinthineLibrary.owner}
+          insults={tribeLabyrinthineLibrary.insults}
+        />
       </main>
     </div>
   );

--- a/src/MichaelsMount.tsx
+++ b/src/MichaelsMount.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import styles from "./MichaelsMount.module.css";
 import { BackButton } from "./BackButton";
+import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import { MichaelsMountItem, tribeMichaelsMount } from "./tribeMichaelsMount";
 import mountsBackground from "./Mounts.webp";
@@ -70,7 +71,11 @@ export function MichaelsMount({ onBack }: { onBack?: () => void }) {
           ))}
         </section>
 
-        <p className={styles.footerNote}>{tribeMichaelsMount.insults[0]}</p>
+        <InsultBox
+          className={styles.footerNote}
+          owner={tribeMichaelsMount.owner}
+          insults={tribeMichaelsMount.insults}
+        />
       </main>
     </div>
   );

--- a/src/MonsterMaker.tsx
+++ b/src/MonsterMaker.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import styles from "./MonsterMaker.module.css";
 import { BackButton } from "./BackButton";
+import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import { MonsterMakerItem, tribeMonsterMaker } from "./tribeMonsterMaker";
 import monsterBackground from "./Monster.webp";
@@ -117,7 +118,11 @@ export function MonsterMaker({ onBack }: { onBack?: () => void }) {
           ))}
         </div>
 
-        <p className={styles.footerNote}>{tribeMonsterMaker.insults[0]}</p>
+        <InsultBox
+          className={styles.footerNote}
+          owner={tribeMonsterMaker.owner}
+          insults={tribeMonsterMaker.insults}
+        />
       </main>
     </div>
   );

--- a/src/NME.tsx
+++ b/src/NME.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import styles from "./NME.module.css";
 import { BackButton } from "./BackButton";
+import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import { NMEItem, tribeNME } from "./tribeNME";
 import nmeBackground from "./N.M.E.png";
@@ -68,7 +69,11 @@ export function NME({ onBack }: { onBack?: () => void }) {
           ))}
         </section>
 
-        <p className={styles.footerNote}>{tribeNME.insults[0]}</p>
+        <InsultBox
+          className={styles.footerNote}
+          owner={tribeNME.owner}
+          insults={tribeNME.insults}
+        />
       </main>
     </div>
   );

--- a/src/NecromancyInsuranceCompany.tsx
+++ b/src/NecromancyInsuranceCompany.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import styles from "./NecromancyInsuranceCompany.module.css";
 import { tribeNecromancyInsuranceCompany } from "./tribeNecromancyInsuranceCompany";
 import { BackButton } from "./BackButton";
+import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import necromancyInsuranceBackground from "./NecromanyInsuranceCo-ezgif.com-webp-to-png-converter.png";
 
@@ -53,9 +54,11 @@ export function NecromancyInsuranceCompany({ onBack }: { onBack?: () => void }) 
           ))}
         </section>
 
-        <p className={styles.footerNote}>
-          {tribeNecromancyInsuranceCompany.insults[0]}
-        </p>
+        <InsultBox
+          className={styles.footerNote}
+          owner={tribeNecromancyInsuranceCompany.owner}
+          insults={tribeNecromancyInsuranceCompany.insults}
+        />
       </main>
     </div>
   );

--- a/src/PawsClawsMaws.tsx
+++ b/src/PawsClawsMaws.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import styles from "./PawsClawsMaws.module.css";
 import { BackButton } from "./BackButton";
+import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import { PawsClawsMawsItem, tribePawsClawsMaws } from "./tribePawsClawsMaws";
 import pawsClawsMawsBackground from "./Paws, Claws, & Maws.png";
@@ -78,7 +79,11 @@ export function PawsClawsMaws({ onBack }: { onBack?: () => void }) {
           ))}
         </section>
 
-        <p className={styles.footerNote}>{tribePawsClawsMaws.insults[0]}</p>
+        <InsultBox
+          className={styles.footerNote}
+          owner={tribePawsClawsMaws.owner}
+          insults={tribePawsClawsMaws.insults}
+        />
       </main>
     </div>
   );

--- a/src/PearlsPotions.tsx
+++ b/src/PearlsPotions.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import styles from "./PearlsPotions.module.css";
 import { tribePearlsPotions } from "./tribePearlsPotions";
 import { BackButton } from "./BackButton";
+import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import pearlsPotionsBackground from "./Pearls Potions.png";
 
@@ -50,7 +51,11 @@ export function PearlsPotions({ onBack }: { onBack?: () => void }) {
           ))}
         </section>
 
-        <p className={styles.footerNote}>{tribePearlsPotions.insults[0]}</p>
+        <InsultBox
+          className={styles.footerNote}
+          owner={tribePearlsPotions.owner}
+          insults={tribePearlsPotions.insults}
+        />
       </main>
     </div>
   );

--- a/src/PiggyBank.tsx
+++ b/src/PiggyBank.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import styles from "./PiggyBank.module.css";
 import { BackButton } from "./BackButton";
+import { InsultBox } from "./InsultBox";
 import piggyBankBackground from "./Piggy Bank.png";
 import { PiggyBankItem, tribePiggyBank } from "./tribePiggyBank";
 
@@ -59,9 +60,11 @@ export function PiggyBank({ onBack }: { onBack?: () => void }) {
           ))}
         </section>
 
-        {tribePiggyBank.insults[0] && (
-          <p className={styles.footerNote}>{tribePiggyBank.insults[0]}</p>
-        )}
+        <InsultBox
+          className={styles.footerNote}
+          owner={tribePiggyBank.owner}
+          insults={tribePiggyBank.insults}
+        />
       </main>
     </div>
   );

--- a/src/RunestoneRelay.tsx
+++ b/src/RunestoneRelay.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import styles from "./RunestoneRelay.module.css";
 import { tribeRunestoneRelay } from "./tribeRunestoneRelay";
 import { BackButton } from "./BackButton";
+import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import runestoneRelayBackground from "./Runestone Relay.png";
 
@@ -58,7 +59,11 @@ export function RunestoneRelay({ onBack }: { onBack?: () => void }) {
           ))}
         </section>
 
-        <p className={styles.footerNote}>{tribeRunestoneRelay.insults[0]}</p>
+        <InsultBox
+          className={styles.footerNote}
+          owner={tribeRunestoneRelay.owner}
+          insults={tribeRunestoneRelay.insults}
+        />
       </main>
     </div>
   );

--- a/src/ShopTemplate.tsx
+++ b/src/ShopTemplate.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import defaultStyles from "./BookBombs.module.css";
 import { BackButton } from "./BackButton";
+import { InsultBox } from "./InsultBox";
 import { Item, Tribe } from "./types";
 
 type DisplayItem = Item & { finalPrice: number };
@@ -65,11 +66,11 @@ export function ShopTemplate({
           ))}
         </section>
 
-        {tribe.insults[0] && (
-          <p className={styles.footerNote}>
-            {tribe.insults[0]}
-          </p>
-        )}
+        <InsultBox
+          className={styles.footerNote}
+          owner={tribe.owner}
+          insults={tribe.insults}
+        />
       </main>
     </div>
   );

--- a/src/SleuthUniversity.tsx
+++ b/src/SleuthUniversity.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import styles from "./SleuthUniversity.module.css";
 import { BackButton } from "./BackButton";
+import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import {
   SleuthUniversityItem,
@@ -73,7 +74,11 @@ export function SleuthUniversity({ onBack }: { onBack?: () => void }) {
           ))}
         </section>
 
-        <p className={styles.footerNote}>{tribeSleuthUniversity.insults[0]}</p>
+        <InsultBox
+          className={styles.footerNote}
+          owner={tribeSleuthUniversity.owner}
+          insults={tribeSleuthUniversity.insults}
+        />
       </main>
     </div>
   );

--- a/src/ValhallaMart.tsx
+++ b/src/ValhallaMart.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import styles from "./ValhallaMart.module.css";
 import { BackButton } from "./BackButton";
+import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import { ValhallaMartItem, tribeValhallaMart } from "./tribeValhallaMart";
 import valhallaBackground from "./Valhalla Mart.png";
@@ -70,7 +71,11 @@ export function ValhallaMart({ onBack }: { onBack?: () => void }) {
           ))}
         </section>
 
-        <p className={styles.footerNote}>{tribeValhallaMart.insults[0]}</p>
+        <InsultBox
+          className={styles.footerNote}
+          owner={tribeValhallaMart.owner}
+          insults={tribeValhallaMart.insults}
+        />
       </main>
     </div>
   );

--- a/src/YeOldDonkey.tsx
+++ b/src/YeOldDonkey.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import styles from "./YeOldDonkey.module.css";
 import { tribeYeOldDonkey } from "./tribeYeOldDonkey";
 import { BackButton } from "./BackButton";
+import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import yeOldDonkeyBackground from "./Ye Old Donkey.png";
 
@@ -52,7 +53,11 @@ export function YeOldDonkey({ onBack }: { onBack?: () => void }) {
           ))}
         </section>
 
-        <p className={styles.footerNote}>{tribeYeOldDonkey.insults[0]}</p>
+        <InsultBox
+          className={styles.footerNote}
+          owner={tribeYeOldDonkey.owner}
+          insults={tribeYeOldDonkey.insults}
+        />
       </main>
     </div>
   );

--- a/src/YeOldHomeDepot.tsx
+++ b/src/YeOldHomeDepot.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import styles from "./YeOldHomeDepot.module.css";
 import { BackButton } from "./BackButton";
+import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import { YeOldHomeDepotItem, tribeYeOldHomeDepot } from "./tribeYeOldHomeDepot";
 import sleuthBackground from "./Ye Old Home Depot.webp";
@@ -73,7 +74,11 @@ export function YeOldHomeDepot({ onBack }: { onBack?: () => void }) {
           ))}
         </section>
 
-        <p className={styles.footerNote}>{tribeYeOldHomeDepot.insults[0]}</p>
+        <InsultBox
+          className={styles.footerNote}
+          owner={tribeYeOldHomeDepot.owner}
+          insults={tribeYeOldHomeDepot.insults}
+        />
       </main>
     </div>
   );


### PR DESCRIPTION
## Summary
- add a reusable InsultBox component with black/white styling and random insult rotation
- wire the new insult box into the shared shop template and individual shop screens to display owner-labelled insults
- ensure footer insults cycle through their lists instead of staying on the first entry

## Testing
- CI=true npm test -- --watch=false *(fails: existing App.test heading expectation and jsdom missing HTMLCanvasElement.getContext support)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69587b6ad1f08329a8dcbbcc95e339f1)