### PR TITLE
Align sandbox shop buttons with main menu styling

### DIFF
--- a/src/AnalepticHoltTeag.tsx
+++ b/src/AnalepticHoltTeag.tsx
@@ -11,6 +11,8 @@ import evansEnchantingEmporiumImage from "./Evan's Enchanting Emporium.png";
 import jazzPortablePotionsImage from "./Jazz's Portable Potions.png";
 import { BackButton } from "./BackButton";
 import styles from "./AnalepticHoltTeag.module.css";
+import { ShopButton } from "./ShopButton";
+import { getShopButtonStyle } from "./shopButtonStyles";
 
 type AnalepticShop = {
   key: string;
@@ -107,19 +109,13 @@ export function AnalepticHoltTeag({
 
         <div className={styles.buttonGrid}>
           {shops.map((shop) => (
-            <button
+            <ShopButton
               key={shop.key}
-              type="button"
-              className={styles.shopButton}
+              label={shop.label}
+              imageSrc={shop.image}
               onClick={shop.onClick}
-            >
-              <img
-                src={shop.image}
-                alt={`${shop.label} icon`}
-                className={styles.shopImage}
-              />
-              <span className={styles.shopLabel}>{shop.label}</span>
-            </button>
+              {...getShopButtonStyle(shop.label)}
+            />
           ))}
         </div>
 

--- a/src/BallisticBellowsCaleb.tsx
+++ b/src/BallisticBellowsCaleb.tsx
@@ -9,6 +9,8 @@ import yeOldDonkeyImage from "./Ye Old Donkey.png";
 import piggyBankImage from "./Piggy Bank.png";
 import { BackButton } from "./BackButton";
 import styles from "./BallisticBellowsCaleb.module.css";
+import { ShopButton } from "./ShopButton";
+import { getShopButtonStyle } from "./shopButtonStyles";
 
 type BallisticBellowsShop = {
   key: string;
@@ -93,19 +95,13 @@ export function BallisticBellowsCaleb({
 
         <div className={styles.buttonGrid}>
           {shops.map((shop) => (
-            <button
+            <ShopButton
               key={shop.key}
-              type="button"
-              className={styles.shopButton}
+              label={shop.label}
+              imageSrc={shop.image}
               onClick={shop.onClick}
-            >
-              <img
-                src={shop.image}
-                alt={`${shop.label} icon`}
-                className={styles.shopImage}
-              />
-              <span className={styles.shopLabel}>{shop.label}</span>
-            </button>
+              {...getShopButtonStyle(shop.label)}
+            />
           ))}
         </div>
 

--- a/src/BigHome.tsx
+++ b/src/BigHome.tsx
@@ -42,6 +42,8 @@ import auctionHouseImage from "./Auction House.png";
 import blackMarketImage from "./Black Market.jpg";
 import { BackButton } from "./BackButton";
 import styles from "./BigHome.module.css";
+import { ShopButton } from "./ShopButton";
+import { getShopButtonStyle } from "./shopButtonStyles";
 
 type BigHomeShop = {
   key: string;
@@ -325,19 +327,13 @@ export function BigHome({
 
         <div className={styles.buttonGrid}>
           {shops.map((shop) => (
-            <button
+            <ShopButton
               key={shop.key}
-              type="button"
-              className={styles.shopButton}
+              label={shop.label}
+              imageSrc={shop.image}
               onClick={shop.onClick}
-            >
-              <img
-                src={shop.image}
-                alt={`${shop.label} icon`}
-                className={styles.shopImage}
-              />
-              <span className={styles.shopLabel}>{shop.label}</span>
-            </button>
+              {...getShopButtonStyle(shop.label)}
+            />
           ))}
         </div>
 

--- a/src/ButtingRams.tsx
+++ b/src/ButtingRams.tsx
@@ -7,6 +7,8 @@ import supremeSmithyImage from "./Supreme Smithy.png";
 import willsWeaponsImage from "./Wills Weapons.png";
 import { BackButton } from "./BackButton";
 import styles from "./ButtingRams.module.css";
+import { ShopButton } from "./ShopButton";
+import { getShopButtonStyle } from "./shopButtonStyles";
 
 type ButtingRamsShop = {
   key: string;
@@ -80,19 +82,13 @@ export function ButtingRams({
 
         <div className={styles.buttonGrid}>
           {shops.map((shop) => (
-            <button
+            <ShopButton
               key={shop.key}
-              type="button"
-              className={styles.shopButton}
+              label={shop.label}
+              imageSrc={shop.image}
               onClick={shop.onClick}
-            >
-              <img
-                src={shop.image}
-                alt={`${shop.label} icon`}
-                className={styles.shopImage}
-              />
-              <span className={styles.shopLabel}>{shop.label}</span>
-            </button>
+              {...getShopButtonStyle(shop.label)}
+            />
           ))}
         </div>
 

--- a/src/ByfordDolphinRobertson.tsx
+++ b/src/ByfordDolphinRobertson.tsx
@@ -9,6 +9,8 @@ import changingChurchImage from "./Changing Church.png";
 import oPapiesOracleReadingsImage from "./O Papies Oracle Readings.png";
 import { BackButton } from "./BackButton";
 import styles from "./ByfordDolphinRobertson.module.css";
+import { ShopButton } from "./ShopButton";
+import { getShopButtonStyle } from "./shopButtonStyles";
 
 type ByfordShop = {
   key: string;
@@ -93,19 +95,13 @@ export function ByfordDolphinRobertson({
 
         <div className={styles.buttonGrid}>
           {shops.map((shop) => (
-            <button
+            <ShopButton
               key={shop.key}
-              type="button"
-              className={styles.shopButton}
+              label={shop.label}
+              imageSrc={shop.image}
               onClick={shop.onClick}
-            >
-              <img
-                src={shop.image}
-                alt={`${shop.label} icon`}
-                className={styles.shopImage}
-              />
-              <span className={styles.shopLabel}>{shop.label}</span>
-            </button>
+              {...getShopButtonStyle(shop.label)}
+            />
           ))}
         </div>
 

--- a/src/CalidrisFisk.tsx
+++ b/src/CalidrisFisk.tsx
@@ -10,6 +10,8 @@ import supremeSmithyImage from "./Supreme Smithy.png";
 import willsWeaponsImage from "./Wills Weapons.png";
 import { BackButton } from "./BackButton";
 import styles from "./CalidrisFisk.module.css";
+import { ShopButton } from "./ShopButton";
+import { getShopButtonStyle } from "./shopButtonStyles";
 
 type CalidrisShop = {
   key: string;
@@ -101,20 +103,13 @@ export function CalidrisFisk({
 
         <div className={styles.buttonGrid}>
           {shops.map((shop) => (
-            <button
+            <ShopButton
               key={shop.key}
-              type="button"
-              className={styles.shopButton}
+              label={shop.label}
+              imageSrc={shop.image}
               onClick={shop.onClick}
-            >
-              <img
-                src={shop.image}
-                alt={`${shop.label} icon`}
-                className={styles.shopImage}
-              />
-              <span className={styles.shopLabel}>{shop.label}</span>
-              <p className={styles.shopHint}>Step into this silent storefront</p>
-            </button>
+              {...getShopButtonStyle(shop.label)}
+            />
           ))}
         </div>
 

--- a/src/Graveborn.tsx
+++ b/src/Graveborn.tsx
@@ -10,6 +10,8 @@ import labyrinthineLibraryImage from "./Labyrinthine Labrary.png";
 import blossomHotelImage from "./Blossom Hotel.png";
 import { BackButton } from "./BackButton";
 import styles from "./Graveborn.module.css";
+import { ShopButton } from "./ShopButton";
+import { getShopButtonStyle } from "./shopButtonStyles";
 
 type GravebornShop = {
   key: string;
@@ -101,19 +103,13 @@ export function Graveborn({
 
         <div className={styles.buttonGrid}>
           {shops.map((shop) => (
-            <button
+            <ShopButton
               key={shop.key}
-              type="button"
-              className={styles.shopButton}
+              label={shop.label}
+              imageSrc={shop.image}
               onClick={shop.onClick}
-            >
-              <img
-                src={shop.image}
-                alt={`${shop.label} icon`}
-                className={styles.shopImage}
-              />
-              <span className={styles.shopLabel}>{shop.label}</span>
-            </button>
+              {...getShopButtonStyle(shop.label)}
+            />
           ))}
         </div>
 

--- a/src/HebronJoshua.tsx
+++ b/src/HebronJoshua.tsx
@@ -8,6 +8,8 @@ import evansEnchantingEmporiumImage from "./Evan's Enchanting Emporium.png";
 import sleuthUniversityImage from "./Sleuth.webp";
 import { BackButton } from "./BackButton";
 import styles from "./HebronJoshua.module.css";
+import { ShopButton } from "./ShopButton";
+import { getShopButtonStyle } from "./shopButtonStyles";
 
 type HebronShop = {
   key: string;
@@ -87,19 +89,13 @@ export function HebronJoshua({
 
         <div className={styles.buttonGrid}>
           {shops.map((shop) => (
-            <button
+            <ShopButton
               key={shop.key}
-              type="button"
-              className={styles.shopButton}
+              label={shop.label}
+              imageSrc={shop.image}
               onClick={shop.onClick}
-            >
-              <img
-                src={shop.image}
-                alt={`${shop.label} icon`}
-                className={styles.shopImage}
-              />
-              <span className={styles.shopLabel}>{shop.label}</span>
-            </button>
+              {...getShopButtonStyle(shop.label)}
+            />
           ))}
         </div>
 

--- a/src/JellyCity.tsx
+++ b/src/JellyCity.tsx
@@ -5,6 +5,8 @@ import robinsRopesImage from "./Robins Ropes.png";
 import changingChurchImage from "./Changing Church.png";
 import { BackButton } from "./BackButton";
 import styles from "./JellyCity.module.css";
+import { ShopButton } from "./ShopButton";
+import { getShopButtonStyle } from "./shopButtonStyles";
 
 type JellyCityShop = {
   key: string;
@@ -66,19 +68,13 @@ export function JellyCity({
 
         <div className={styles.buttonGrid}>
           {shops.map((shop) => (
-            <button
+            <ShopButton
               key={shop.key}
-              type="button"
-              className={styles.shopButton}
+              label={shop.label}
+              imageSrc={shop.image}
               onClick={shop.onClick}
-            >
-              <img
-                src={shop.image}
-                alt={`${shop.label} icon`}
-                className={styles.shopImage}
-              />
-              <span className={styles.shopLabel}>{shop.label}</span>
-            </button>
+              {...getShopButtonStyle(shop.label)}
+            />
           ))}
         </div>
 

--- a/src/MeanderMichael.tsx
+++ b/src/MeanderMichael.tsx
@@ -11,6 +11,8 @@ import dungeonCrawlerGuildImage from "./Dungeon Crawler's Guild.png";
 import navigationGuildImage from "./NavigationGuild-ezgif.com-webp-to-png-converter.png";
 import { BackButton } from "./BackButton";
 import styles from "./MeanderMichael.module.css";
+import { ShopButton } from "./ShopButton";
+import { getShopButtonStyle } from "./shopButtonStyles";
 
 type MeanderShop = {
   key: string;
@@ -108,19 +110,13 @@ export function MeanderMichael({
 
         <div className={styles.buttonGrid}>
           {shops.map((shop) => (
-            <button
+            <ShopButton
               key={shop.key}
-              type="button"
-              className={styles.shopButton}
+              label={shop.label}
+              imageSrc={shop.image}
               onClick={shop.onClick}
-            >
-              <img
-                src={shop.image}
-                alt={`${shop.label} icon`}
-                className={styles.shopImage}
-              />
-              <span className={styles.shopLabel}>{shop.label}</span>
-            </button>
+              {...getShopButtonStyle(shop.label)}
+            />
           ))}
         </div>
 

--- a/src/MerricksMeadowHoward.tsx
+++ b/src/MerricksMeadowHoward.tsx
@@ -9,6 +9,8 @@ import provisionsParadiseImage from "./Provisions Paradise.png";
 import jazzPortablePotionsImage from "./Jazz's Portable Potions.png";
 import { BackButton } from "./BackButton";
 import styles from "./MerricksMeadowHoward.module.css";
+import { ShopButton } from "./ShopButton";
+import { getShopButtonStyle } from "./shopButtonStyles";
 
 type MerricksShop = {
   key: string;
@@ -94,20 +96,13 @@ export function MerricksMeadowHoward({
 
         <div className={styles.buttonGrid}>
           {shops.map((shop) => (
-            <button
+            <ShopButton
               key={shop.key}
-              type="button"
-              className={styles.shopButton}
+              label={shop.label}
+              imageSrc={shop.image}
               onClick={shop.onClick}
-            >
-              <img
-                src={shop.image}
-                alt={`${shop.label} icon`}
-                className={styles.shopImage}
-              />
-              <span className={styles.shopLabel}>{shop.label}</span>
-              <p className={styles.shopHint}>Follow the footpaths to this stall</p>
-            </button>
+              {...getShopButtonStyle(shop.label)}
+            />
           ))}
         </div>
 

--- a/src/OrbitingCity.tsx
+++ b/src/OrbitingCity.tsx
@@ -9,6 +9,8 @@ import piggyBankImage from "./Piggy Bank.png";
 import mountsImage from "./Mounts.webp";
 import { BackButton } from "./BackButton";
 import styles from "./OrbitingCity.module.css";
+import { ShopButton } from "./ShopButton";
+import { getShopButtonStyle } from "./shopButtonStyles";
 
 type OrbitingCityShop = {
   key: string;
@@ -63,7 +65,7 @@ export function OrbitingCity({
     },
     {
       key: "piggy-bank",
-      label: "The Piggy Bank",
+      label: "The Piggy Bank, no hammers inside.",
       image: piggyBankImage,
       onClick: () => onNavigate("PiggyBank"),
     },
@@ -94,19 +96,13 @@ export function OrbitingCity({
 
         <div className={styles.buttonGrid}>
           {shops.map((shop) => (
-            <button
+            <ShopButton
               key={shop.key}
-              type="button"
-              className={styles.shopButton}
+              label={shop.label}
+              imageSrc={shop.image}
               onClick={shop.onClick}
-            >
-              <img
-                src={shop.image}
-                alt={`${shop.label} icon`}
-                className={styles.shopImage}
-              />
-              <span className={styles.shopLabel}>{shop.label}</span>
-            </button>
+              {...getShopButtonStyle(shop.label)}
+            />
           ))}
         </div>
 

--- a/src/SeymoursDriftMelanie.tsx
+++ b/src/SeymoursDriftMelanie.tsx
@@ -8,6 +8,8 @@ import willsWeaponsImage from "./Wills Weapons.png";
 import supremeSmithyImage from "./Supreme Smithy.png";
 import { BackButton } from "./BackButton";
 import styles from "./SeymoursDriftMelanie.module.css";
+import { ShopButton } from "./ShopButton";
+import { getShopButtonStyle } from "./shopButtonStyles";
 
 type SeymoursDriftShop = {
   key: string;
@@ -87,19 +89,13 @@ export function SeymoursDriftMelanie({
 
         <div className={styles.buttonGrid}>
           {shops.map((shop) => (
-            <button
+            <ShopButton
               key={shop.key}
-              type="button"
-              className={styles.shopButton}
+              label={shop.label}
+              imageSrc={shop.image}
               onClick={shop.onClick}
-            >
-              <img
-                src={shop.image}
-                alt={`${shop.label} icon`}
-                className={styles.shopImage}
-              />
-              <span className={styles.shopLabel}>{shop.label}</span>
-            </button>
+              {...getShopButtonStyle(shop.label)}
+            />
           ))}
         </div>
 

--- a/src/ShopButton.tsx
+++ b/src/ShopButton.tsx
@@ -1,0 +1,125 @@
+import type { CSSProperties, ReactNode } from "react";
+import { useEffect } from "react";
+
+export type ShopButtonProps = {
+  label: string;
+  onClick: () => void;
+  backgroundColor: string;
+  color?: string;
+  imageSrc?: string;
+  description?: ReactNode;
+  delay?: string;
+};
+
+const buttonStyles: Record<string, CSSProperties> = {
+  button: {
+    fontSize: "1.5rem",
+    padding: "1.25rem 1.5rem",
+    borderRadius: "18px",
+    border: "2px solid #ffffffff",
+    boxShadow: "0 7px 12px rgba(0, 0, 0, 0.5)",
+    cursor: "pointer",
+    animation: "float 12s ease-in-out infinite",
+    transition: "transform 0.3s ease",
+    fontFamily: "'Times New Roman', serif",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    gap: "0.85rem",
+    width: "100%",
+    maxWidth: "100%",
+    textAlign: "center",
+  },
+  buttonContent: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    gap: "0.5rem",
+    width: "100%",
+  },
+  buttonImage: {
+    width: "160px",
+    height: "auto",
+    objectFit: "contain",
+    borderRadius: "14px",
+    border: "2px solid rgba(255, 255, 255, 0.6)",
+    backgroundColor: "rgba(255,255,255,0.85)",
+    boxShadow: "4 4px 8px rgba(0,0,0,0.35)",
+  },
+  buttonLabel: {
+    display: "block",
+    fontWeight: 700,
+    textAlign: "center",
+  },
+  buttonDescription: {
+    margin: 0,
+    fontSize: "0.95rem",
+    lineHeight: 1.45,
+    textAlign: "center",
+    maxWidth: "720px",
+  },
+};
+
+let floatKeyframesInjected = false;
+
+function ensureFloatKeyframes() {
+  if (floatKeyframesInjected || typeof document === "undefined") {
+    return;
+  }
+
+  const styleSheet = document.createElement("style");
+  styleSheet.id = "floating-keyframes";
+  styleSheet.innerHTML = `
+  @keyframes float {
+    0% { transform: translate(0px, 0px); }
+    25% { transform: translate(4px, -4px); }
+    50% { transform: translate(0px, -8px); }
+    75% { transform: translate(-4px, -4px); }
+    100% { transform: translate(0px, 0px); }
+  }`;
+  document.head.appendChild(styleSheet);
+  floatKeyframesInjected = true;
+}
+
+export function ShopButton({
+  label,
+  onClick,
+  delay = "0s",
+  backgroundColor,
+  color = "#000",
+  imageSrc,
+  description,
+}: ShopButtonProps) {
+  useEffect(() => {
+    ensureFloatKeyframes();
+  }, []);
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        ...buttonStyles.button,
+        animationDelay: delay,
+        backgroundColor,
+        color,
+      }}
+    >
+      {imageSrc ? (
+        <div style={buttonStyles.buttonContent}>
+          <img src={imageSrc} alt={`${label} logo`} style={buttonStyles.buttonImage} />
+          <span style={buttonStyles.buttonLabel}>{label}</span>
+          {description ? (
+            typeof description === "string" ? (
+              <p style={buttonStyles.buttonDescription}>{description}</p>
+            ) : (
+              description
+            )
+          ) : null}
+        </div>
+      ) : (
+        label
+      )}
+    </button>
+  );
+}

--- a/src/StrenuousPortal.tsx
+++ b/src/StrenuousPortal.tsx
@@ -26,6 +26,8 @@ import fizzyTaleImage from "./FizzyTale.png";
 import goblinMarketImage from "./GoblinMarket.png";
 import { BackButton } from "./BackButton";
 import styles from "./StrenuousPortal.module.css";
+import { ShopButton } from "./ShopButton";
+import { getShopButtonStyle } from "./shopButtonStyles";
 
 type StrenuousShop = {
   key: string;
@@ -213,19 +215,13 @@ export function StrenuousPortal({
 
         <div className={styles.buttonGrid}>
           {shops.map((shop) => (
-            <button
+            <ShopButton
               key={shop.key}
-              type="button"
-              className={styles.shopButton}
+              label={shop.label}
+              imageSrc={shop.image}
               onClick={shop.onClick}
-            >
-              <img
-                src={shop.image}
-                alt={`${shop.label} icon`}
-                className={styles.shopImage}
-              />
-              <span className={styles.shopLabel}>{shop.label}</span>
-            </button>
+              {...getShopButtonStyle(shop.label)}
+            />
           ))}
         </div>
 

--- a/src/WithholdParker.tsx
+++ b/src/WithholdParker.tsx
@@ -7,6 +7,8 @@ import floralImage from "./Floral.webp";
 import silentOathImage from "./Silent Oath.png";
 import { BackButton } from "./BackButton";
 import styles from "./WithholdParker.module.css";
+import { ShopButton } from "./ShopButton";
+import { getShopButtonStyle } from "./shopButtonStyles";
 
 type WithholdShop = {
   key: string;
@@ -79,19 +81,13 @@ export function WithholdParker({
 
         <div className={styles.buttonGrid}>
           {shops.map((shop) => (
-            <button
+            <ShopButton
               key={shop.key}
-              type="button"
-              className={styles.shopButton}
+              label={shop.label}
+              imageSrc={shop.image}
               onClick={shop.onClick}
-            >
-              <img
-                src={shop.image}
-                alt={`${shop.label} icon`}
-                className={styles.shopImage}
-              />
-              <span className={styles.shopLabel}>{shop.label}</span>
-            </button>
+              {...getShopButtonStyle(shop.label)}
+            />
           ))}
         </div>
 

--- a/src/shopButtonStyles.ts
+++ b/src/shopButtonStyles.ts
@@ -1,0 +1,93 @@
+export type ShopButtonStyle = {
+  backgroundColor: string;
+  color?: string;
+};
+
+const defaultStyle: ShopButtonStyle = {
+  backgroundColor: "rgba(30, 41, 59, 0.82)",
+  color: "#f8fafc",
+};
+
+const styleMap: Record<string, ShopButtonStyle> = {
+  "auction house": { backgroundColor: "rgba(138, 253, 244, 0.712)" },
+  "black market": { backgroundColor: "rgba(0, 0, 0, 0.712)", color: "white" },
+  "goblin market": { backgroundColor: "rgba(37, 99, 235, 0.95)", color: "#e2e8f0" },
+  goblins: { backgroundColor: "rgba(37, 99, 235, 0.95)", color: "#e2e8f0" },
+  "applegarth guild": { backgroundColor: "rgba(255, 255, 255, 0.9)" },
+  "archives guild": { backgroundColor: "rgba(255, 255, 255, 0.9)" },
+  "book bombs": { backgroundColor: "rgba(255, 255, 255, 0.9)" },
+  "bullets, buffs, & beyond": { backgroundColor: "rgba(255, 255, 255, 0.9)" },
+  "changing church": { backgroundColor: "rgba(255, 255, 255, 0.9)" },
+  "necromancy insurance company": { backgroundColor: "rgba(255, 255, 255, 0.9)" },
+  "o-papies oracle readings": { backgroundColor: "rgba(255, 255, 255, 0.9)" },
+  "robin's ropes": { backgroundColor: "rgba(255, 255, 255, 0.9)" },
+  "robin ropes": { backgroundColor: "rgba(255, 255, 255, 0.9)" },
+  "runestone relay": { backgroundColor: "rgba(255, 255, 255, 0.9)" },
+  "silent oath": { backgroundColor: "rgba(255, 255, 255, 0.9)" },
+  "supreme smithy": { backgroundColor: "rgba(255, 255, 255, 0.9)" },
+  "will's weapons": { backgroundColor: "rgba(255, 255, 255, 0.9)" },
+  "auntie patty's pies": {
+    backgroundColor: "rgba(220, 38, 38, 0.9)",
+    color: "#e0f2fe",
+  },
+  "comedy gold": { backgroundColor: "rgba(220, 38, 38, 0.9)", color: "#e0f2fe" },
+  "dungeon crawler guild": {
+    backgroundColor: "rgba(220, 38, 38, 0.9)",
+    color: "#e0f2fe",
+  },
+  "find a friend": { backgroundColor: "rgba(220, 38, 38, 0.9)", color: "#e0f2fe" },
+  "navigation guild": { backgroundColor: "rgba(220, 38, 38, 0.9)", color: "#e0f2fe" },
+  "pearl's potions": { backgroundColor: "rgba(220, 38, 38, 0.9)", color: "#e0f2fe" },
+  "provision's paradise": { backgroundColor: "rgba(220, 38, 38, 0.9)", color: "#e0f2fe" },
+  "the piggy bank, no hammers inside.": {
+    backgroundColor: "rgba(220, 38, 38, 0.9)",
+    color: "#e0f2fe",
+  },
+  "ye old donkey": { backgroundColor: "rgba(220, 38, 38, 0.9)", color: "#e0f2fe" },
+  "hug cartel": { backgroundColor: "rgba(250, 204, 21, 0.9)" },
+  "iconic dragonic": { backgroundColor: "rgba(250, 204, 21, 0.95)" },
+  "jell bell": { backgroundColor: "rgba(250, 204, 21, 0.9)" },
+  "make a monster": { backgroundColor: "rgba(250, 204, 21, 0.95)" },
+  "paws, claws, & maws": { backgroundColor: "rgba(250, 204, 21, 0.95)" },
+  "michael's mount": { backgroundColor: "rgba(250, 204, 21, 0.95)" },
+  "valhalla mart": { backgroundColor: "rgba(250, 204, 21, 0.95)" },
+  "blossom hotel": {
+    backgroundColor: "rgba(34, 197, 94, 0.9)",
+    color: "#0a2f14",
+  },
+  "evan's enchanting emporium": {
+    backgroundColor: "rgba(34, 197, 94, 0.9)",
+    color: "#0a2f14",
+  },
+  "fairies of flora": { backgroundColor: "rgba(34, 197, 94, 0.95)", color: "#0a2f14" },
+  "golem workshop": { backgroundColor: "rgba(34, 197, 94, 0.95)", color: "#0a2f14" },
+  "jazz's portable potions": {
+    backgroundColor: "rgba(34, 197, 94, 0.95)",
+    color: "#0a2f14",
+  },
+  "jewelry guild": { backgroundColor: "rgba(34, 197, 94, 0.92)", color: "#0b1f16" },
+  "labyrinthine library": {
+    backgroundColor: "rgba(34, 197, 94, 0.95)",
+    color: "#0a2f14",
+  },
+  "n.m.e.": { backgroundColor: "rgba(34, 197, 94, 0.95)", color: "#04260f" },
+  "sleuth university": {
+    backgroundColor: "rgba(34, 197, 94, 0.95)",
+    color: "#0a2f14",
+  },
+  "fizzy tales": { backgroundColor: "rgba(37, 99, 235, 0.95)", color: "#e2e8f0" },
+  "ye old homedepot": { backgroundColor: "rgba(37, 99, 235, 0.95)", color: "#e0f2fe" },
+};
+
+function normalizeLabel(label: string) {
+  return label.replace(/’/g, "'").trim().toLowerCase();
+}
+
+export function getShopButtonStyle(label: string): ShopButtonStyle {
+  const normalized = normalizeLabel(label);
+  return styleMap[normalized] ?? defaultStyle;
+}
+
+export function getDefaultShopButtonStyle(): ShopButtonStyle {
+  return defaultStyle;
+}


### PR DESCRIPTION
## Summary
- add reusable ShopButton plus shared style map to mirror main menu colors and layout
- update sandbox town and Strenuous Portal shop grids to reuse the shared button styling and consistent labels
- align Piggy Bank label with main menu phrasing for Orbiting City

## Testing
- CI=true npm test -- --watch=false *(fails: jsdom missing canvas getContext and existing heading text mismatch in App.test.tsx)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69588021172c8329a6fd94b62df32ddf)