### PR TITLE
Sandbox menu: center map, use loading GIF background, and remove button float

### DIFF
--- a/src/SandboxMenu.module.css
+++ b/src/SandboxMenu.module.css
@@ -5,9 +5,7 @@
   justify-content: flex-start;
   min-height: 100vh;
   padding: 2rem 1.25rem 3rem;
-  background: radial-gradient(circle at 25% 20%, rgba(94, 234, 212, 0.08), transparent 32%),
-    radial-gradient(circle at 80% 10%, rgba(129, 140, 248, 0.12), transparent 35%),
-    radial-gradient(circle at 50% 60%, rgba(248, 113, 113, 0.08), transparent 40%),
+  background: url("./Loading screen closer.gif") center / cover no-repeat,
     #0b1220;
   color: #e2e8f0;
 }
@@ -24,18 +22,17 @@
   box-shadow: 0 8px 16px rgba(0, 0, 0, 0.35);
   font-family: "Times New Roman", serif;
   font-weight: 700;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition: box-shadow 0.2s ease;
 }
 
 .backButton:hover {
-  transform: translateY(-1px);
   box-shadow: 0 10px 18px rgba(0, 0, 0, 0.45);
 }
 
 .header {
-  display: grid;
-  grid-template-columns: 240px 1fr;
-  gap: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
   align-items: center;
   padding: 1.5rem;
   border-radius: 18px;
@@ -43,10 +40,11 @@
   border: 1px solid rgba(148, 163, 184, 0.35);
   box-shadow: 0 20px 45px rgba(0, 0, 0, 0.35);
   width: min(1100px, 100%);
+  text-align: center;
 }
 
 .heroImage {
-  width: 100%;
+  width: min(560px, 100%);
   height: auto;
   border-radius: 16px;
   border: 2px solid rgba(255, 255, 255, 0.7);
@@ -93,11 +91,10 @@
   text-align: left;
   cursor: pointer;
   box-shadow: 0 16px 32px rgba(0, 0, 0, 0.35);
-  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+  transition: box-shadow 0.25s ease, border-color 0.25s ease;
 }
 
 .card:hover {
-  transform: translateY(-3px);
   box-shadow: 0 20px 38px rgba(0, 0, 0, 0.45);
   border-color: rgba(255, 255, 255, 0.5);
 }
@@ -171,10 +168,4 @@
 .emptyState {
   margin: 0;
   color: #cbd5e1;
-}
-
-@media (max-width: 768px) {
-  .header {
-    grid-template-columns: 1fr;
-  }
 }


### PR DESCRIPTION
### Motivation
- Prevent buttons/cards from visually "floating" on hover so the Sandbox menu feels stable and predictable.
- Make the Sandbox world map larger and centered in the header so the map is more prominent.
- Use the loading animation as the Sandbox menu background to match the requested aesthetic.

### Description
- Updated `src/SandboxMenu.module.css` to set the wrapper background to `url("./Loading screen closer.gif") center / cover no-repeat` and retain the dark base color.
- Replaced the header grid with a centered column layout and applied `text-align: center` to center the map and header copy, and constrained the map size with `width: min(560px, 100%)` on `.heroImage`.
- Removed transform-based hover lift effects by deleting `transform` from `.backButton:hover` and `.card:hover`, and removed `transform` from transition lists so hover no longer shifts elements.
- Removed the small-screen header grid media query (header now stacks via flex column) and simplified transition declarations.

### Testing
- Started the dev server with `npm start`, which compiled the app successfully but emitted ESLint warnings for `src/BookBombs.tsx` and `src/RunestoneRelay.tsx` about an invalid ARIA attribute.
- Attempted an automated Playwright screenshot of the Sandbox menu, but the browser process crashed (TargetClosedError / SIGSEGV) so no screenshot was captured.
- Changes were committed locally to `src/SandboxMenu.module.css` and are ready for review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695daf90e3648329ad467361c63c4786)