### PR TITLE
Update sandbox menu visuals

### DIFF
--- a/src/SandboxMenu.module.css
+++ b/src/SandboxMenu.module.css
@@ -5,10 +5,7 @@
   justify-content: flex-start;
   min-height: 100vh;
   padding: 2rem 1.25rem 3rem;
-  background: radial-gradient(circle at 25% 20%, rgba(94, 234, 212, 0.08), transparent 32%),
-    radial-gradient(circle at 80% 10%, rgba(129, 140, 248, 0.12), transparent 35%),
-    radial-gradient(circle at 50% 60%, rgba(248, 113, 113, 0.08), transparent 40%),
-    #0b1220;
+  background: url("./Loading screen closer.gif") center / cover no-repeat;
   color: #e2e8f0;
 }
 
@@ -24,17 +21,16 @@
   box-shadow: 0 8px 16px rgba(0, 0, 0, 0.35);
   font-family: "Times New Roman", serif;
   font-weight: 700;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition: box-shadow 0.2s ease;
 }
 
 .backButton:hover {
-  transform: translateY(-1px);
   box-shadow: 0 10px 18px rgba(0, 0, 0, 0.45);
 }
 
 .header {
   display: grid;
-  grid-template-columns: 240px 1fr;
+  grid-template-columns: minmax(280px, 380px) 1fr;
   gap: 1.5rem;
   align-items: center;
   padding: 1.5rem;
@@ -51,6 +47,7 @@
   border-radius: 16px;
   border: 2px solid rgba(255, 255, 255, 0.7);
   box-shadow: 0 14px 24px rgba(0, 0, 0, 0.35);
+  justify-self: center;
 }
 
 .kicker {
@@ -93,11 +90,10 @@
   text-align: left;
   cursor: pointer;
   box-shadow: 0 16px 32px rgba(0, 0, 0, 0.35);
-  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+  transition: box-shadow 0.25s ease, border-color 0.25s ease;
 }
 
 .card:hover {
-  transform: translateY(-3px);
   box-shadow: 0 20px 38px rgba(0, 0, 0, 0.45);
   border-color: rgba(255, 255, 255, 0.5);
 }


### PR DESCRIPTION
### Motivation
- Make Sandbox menu buttons visually static so they no longer lift or move on hover.  
- Increase and center the Sandbox world map so the map is more prominent in the header.  
- Replace the page background with the loading-screen GIF for the Sandbox menu.  

### Description
- Updated `src/SandboxMenu.module.css` to replace the radial gradient background with `url("./Loading screen closer.gif") center / cover no-repeat`.  
- Removed translate-based hover transforms and adjusted transitions so `.backButton` and `.card` no longer move (kept shadow/border effects).  
- Enlarged/centered the map area by changing `.header` `grid-template-columns` to `minmax(280px, 380px) 1fr` and added `justify-self: center` to `.heroImage`.  

### Testing
- Ran `npm start` and the dev server compiled and served the app successfully (webpack compiled with warnings).  
- Executed a Playwright script to open the app, navigate to the Sandbox menu, and capture a screenshot which saved to `artifacts/.../sandbox-menu.png` (succeeded).  
- Noted ESLint warnings about invalid ARIA attributes in `src/BookBombs.tsx` and `src/RunestoneRelay.tsx` during the dev run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695db26b3cec832981deff7937c5e38a)