### PR TITLE
Fix typos in Dungeon Crawler Guild descriptions

### DIFF
--- a/src/tribeDungeonCrawlerGuild.ts
+++ b/src/tribeDungeonCrawlerGuild.ts
@@ -14,7 +14,7 @@ export const tribeDungeonCrawlerGuild: Tribe = {
     },
     {
       name: "Retrieval Team",
-      description: "Pay before you enter the dungeon. If you don't return after a set amount of time we'll send a team to retrieve you. Whether you get lost or make have kicked the bucket.",
+      description: "Pay before you enter the dungeon. If you don't return after a set amount of time we'll send a team to retrieve you. Whether you get lost or may have kicked the bucket.",
       price: 20,
     },
     {
@@ -29,22 +29,22 @@ export const tribeDungeonCrawlerGuild: Tribe = {
     },
     {
       name: "Ultra Membership (Tax-free)",
-      description: "Our ultimate package for the true dungeon enthusiast. Enjoy tax-free status on all your dungeon loot and services. Additionally, you'll receive exclusive access to members-only dungeons and events throughout the year. Tho will need to occationally babysit people who want to be escorted through a dungeon.",
+      description: "Our ultimate package for the true dungeon enthusiast. Enjoy tax-free status on all your dungeon loot and services. Additionally, you'll receive exclusive access to members-only dungeons and events throughout the year. Though you will need to occasionally babysit people who want to be escorted through a dungeon.",
       price: 1000,
     },
     {
       name: "Greeting Adventurers!",
-      description: "We welcome you to this public dungeon! Feel free to explore and have fun. Though we will have to tax any loot you find here. Becuase we put that money back into maintaining the dungeon and making sure that it doesn't spawn more monsters cuasing an outbreak in the nearby town. Any money left over from that we put towards setting up new adventures like yourself!",
+      description: "We welcome you to this public dungeon! Feel free to explore and have fun. Though we will have to tax any loot you find here. Because we put that money back into maintaining the dungeon and making sure that it doesn't spawn more monsters causing an outbreak in the nearby town. Any money left over from that we put towards setting up new adventures like yourself!",
       price: 0,
     },
     {
       name: "Sack of Sand",
-      description: "Well it's a sack of sand. We feel bad charging for it but it's surpisingly useful for setting off traps early or weighing down pressure plates for puzzles.",
+      description: "Well it's a sack of sand. We feel bad charging for it but it's surprisingly useful for setting off traps early or weighing down pressure plates for puzzles.",
       price: 2,
     },
     {
       name: "Cooking Kit",
-      description: "It's basic cooking kit for preparing meals in almost any environment. Includes a small pot, pan, utensils, basic spices, and a little booklet on how to prep and cook monsters you can find in dungeons.",
+      description: "It's a basic cooking kit for preparing meals in almost any environment. Includes a small pot, pan, utensils, basic spices, and a little booklet on how to prep and cook monsters you can find in dungeons.",
       price: 7,
     },
   ],


### PR DESCRIPTION
### Motivation
- Improve readability and user-facing copy by correcting spelling and grammar in guild item descriptions.
- Ensure in-game text is clear and professional when rendered in the UI.
- Standardize phrasing across related item descriptions in the same file.

### Description
- Updated string literals in `src/tribeDungeonCrawlerGuild.ts` to fix several typos and grammatical issues.
- Replaced phrases such as "make have" -> "may have", "Tho will need to occationally" -> "Though you will need to occasionally", and fixed "Becuase" -> "Because" and "cuasing" -> "causing".
- Corrected "surpisingly" -> "surprisingly" and added the missing article in "It's a basic cooking kit".
- These are text-only changes; no runtime logic or types were modified.

### Testing
- No automated tests were run after these edits.
- No test failures were reported because no tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dc102e04c8329b9d81747f951bdca)