### PR TITLE
Move insult box above item grid in ShopTemplate

### DIFF
--- a/src/ShopTemplate.tsx
+++ b/src/ShopTemplate.tsx
@@ -52,6 +52,12 @@ export function ShopTemplate({
           </div>
         </header>
 
+        <InsultBox
+          className={styles.footerNote}
+          owner={tribe.owner}
+          insults={tribe.insults}
+        />
+
         <section className={styles.grid} aria-label="Available items">
           {displayItems.map((item) => (
             <article key={item.name} className={styles.card}>
@@ -65,12 +71,6 @@ export function ShopTemplate({
             </article>
           ))}
         </section>
-
-        <InsultBox
-          className={styles.footerNote}
-          owner={tribe.owner}
-          insults={tribe.insults}
-        />
       </main>
     </div>
   );


### PR DESCRIPTION
### Motivation
- Improve visibility by moving the insult display out of the footer and into the main content area under the shop title.  
- Make the insulting text more prominent and contextual before the list of items is shown.

### Description
- Updated `src/ShopTemplate.tsx` to render the `InsultBox` immediately after the header and before the item grid.  
- Removed the previous `InsultBox` instance that was rendered after the item `section`.  
- The `InsultBox` still receives the same props (`className`, `owner`, `insults`) so behavior and styling remain unchanged.

### Testing
- Ran `npm start` to boot the dev server and the app compiled successfully with warnings about unused imports.  
- Executed a Playwright script to load `http://localhost:3000` and captured a screenshot artifact verifying the layout change.  
- No unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f37ed7f1c8329aa9df32e91b2417d)