### PR TITLE
Preserve multiline tribe descriptions

### DIFF
--- a/src/FindAFriend.module.css
+++ b/src/FindAFriend.module.css
@@ -116,6 +116,7 @@
   color: #14304f;
   font-size: 1rem;
   text-align: center;
+  white-space: pre-line;
 }
 
 .price {

--- a/src/WillsWeapons.module.css
+++ b/src/WillsWeapons.module.css
@@ -125,6 +125,7 @@
   color: #c3cedb;
   font-size: 0.98rem;
   text-align: center;
+  white-space: pre-line;
 }
 
 .price {

--- a/src/YeOldDonkey.module.css
+++ b/src/YeOldDonkey.module.css
@@ -118,6 +118,7 @@
   color: #1d2b2f;
   font-size: 1.05rem;
   text-align: center;
+  white-space: pre-line;
 }
 
 .price {


### PR DESCRIPTION
### Motivation
- Several tribes include multiline item descriptions using template literals and should preserve line breaks when rendered, like `Changing Church` does.  
- This improves readability for shops that list detailed multiline item/spec text.  

### Description
- Added `white-space: pre-line` to the `.description` rule in `src/WillsWeapons.module.css`, `src/FindAFriend.module.css`, and `src/YeOldDonkey.module.css`.  
- No JavaScript or component logic was changed; this is a CSS-only fix to align rendering with `ChangingChurch` styles.  

### Testing
- Started the development server with `npm start`, which compiled the app successfully (compiled with warnings).  
- Ran a Playwright script to open the app and capture a screenshot of the Will's Weapons view, which completed and produced an artifact.  
- No unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696464bad23c83298a17f4deb9073e57)