### PR TITLE
Pick single insult and animate word-by-word reveal

### DIFF
--- a/src/InsultBox.module.css
+++ b/src/InsultBox.module.css
@@ -18,3 +18,24 @@
 .ownerLabel {
   white-space: nowrap;
 }
+
+.insultText {
+  display: inline-flex;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.word {
+  display: inline-block;
+  opacity: 0;
+  transform: translateY(6px);
+  animation: wordPop var(--word-duration, 500ms) ease-out forwards;
+  animation-delay: var(--word-delay, 0ms);
+}
+
+@keyframes wordPop {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/src/InsultBox.tsx
+++ b/src/InsultBox.tsx
@@ -24,11 +24,7 @@ export function InsultBox({
     return meaningfulInsults.length > 0 ? meaningfulInsults : insultOptions;
   }, [insultOptions]);
 
-  const [activeInsult, setActiveInsult] = useState<string>(() =>
-    rotationPool.length > 0
-      ? rotationPool[Math.floor(Math.random() * rotationPool.length)]
-      : "",
-  );
+  const [activeInsult, setActiveInsult] = useState<string>("");
 
   useEffect(() => {
     if (rotationPool.length === 0) {
@@ -36,32 +32,20 @@ export function InsultBox({
       return;
     }
 
-    const pickInsult = (current: string) => {
-      if (rotationPool.length === 1) {
-        return rotationPool[0];
-      }
-
-      const remaining = rotationPool.filter((insult) => insult !== current);
-      return (
-        remaining[Math.floor(Math.random() * remaining.length)] ??
-        rotationPool[0]
-      );
-    };
-
-    setActiveInsult((current) => pickInsult(current));
-
-    if (rotationPool.length === 1) {
-      return;
-    }
-
-    const interval = setInterval(() => {
-      setActiveInsult((current) => pickInsult(current));
-    }, rotationMs);
-
-    return () => clearInterval(interval);
-  }, [rotationPool, rotationMs]);
+    setActiveInsult(
+      rotationPool[Math.floor(Math.random() * rotationPool.length)] ?? "",
+    );
+  }, [rotationPool]);
 
   const shouldRender = owner || rotationPool.length > 0;
+  const activeWords = useMemo(
+    () => activeInsult.split(/\s+/).filter(Boolean),
+    [activeInsult],
+  );
+  const wordDurationMs =
+    activeWords.length > 0
+      ? Math.max(350, Math.floor(rotationMs / activeWords.length))
+      : rotationMs;
 
   if (!shouldRender) {
     return null;
@@ -71,7 +55,25 @@ export function InsultBox({
     <div className={className}>
       <div className={styles.insultBox} role="status" aria-live="polite">
         {owner && <span className={styles.ownerLabel}>{owner}:</span>}
-        <span>{rotationPool.length > 0 ? activeInsult : ""}</span>
+        <span className={styles.insultText} aria-live="polite">
+          {activeWords.map((word, index) => (
+            <span
+              key={`${word}-${index}`}
+              className={styles.word}
+              style={{
+                ["--word-delay" as string]: `${
+                  activeWords.length > 1
+                    ? Math.floor((rotationMs / activeWords.length) * index)
+                    : 0
+                }ms`,
+                ["--word-duration" as string]: `${wordDurationMs}ms`,
+              }}
+            >
+              {word}
+              {index < activeWords.length - 1 ? " " : ""}
+            </span>
+          ))}
+        </span>
       </div>
     </div>
   );


### PR DESCRIPTION
### Motivation
- Prevent the insult text from cycling through multiple insults every few seconds and instead show one randomly selected insult per view. 
- Provide a nicer reveal by having each word appear gradually instead of replacing the whole line. 
- Respect the existing `rotationMs` duration as the total reveal time so callers can control timing. 

### Description
- Update `src/InsultBox.tsx` to pick a single random insult once from the pool and remove the interval-based rotation. 
- Split the selected insult into words and compute per-word timing using the `rotationMs` prop with a small minimum duration. 
- Inject per-word CSS variables for `--word-delay` and `--word-duration` and render words as individual spans to allow staggered animation. 
- Add `.insultText`, `.word` and `@keyframes wordPop` to `src/InsultBox.module.css` to implement the pop-in animation.

### Testing
- Ran the development server with `npm start`, which compiled successfully but emitted existing ESLint warnings. 
- Executed an automated Playwright script to load `http://127.0.0.1:3000` and capture a screenshot, producing `artifacts/insult-box.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964675fc6308329a5eb56876c322940)