### PR TITLE
Space out insult word reveal

### DIFF
--- a/src/InsultBox.module.css
+++ b/src/InsultBox.module.css
@@ -18,3 +18,26 @@
 .ownerLabel {
   white-space: nowrap;
 }
+
+.insultText {
+  display: inline-flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.5rem;
+  row-gap: 0.6rem;
+}
+
+.word {
+  display: inline-block;
+  opacity: 0;
+  transform: translateY(6px);
+  animation: wordPop var(--word-duration, 500ms) ease-out forwards;
+  animation-delay: var(--word-delay, 0ms);
+}
+
+@keyframes wordPop {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}


### PR DESCRIPTION
### Motivation
- Prevent insult words from clustering together and improve readability of the reveal animation.
- Use layout spacing instead of manual space characters so the spacing is consistent and responsive.
- Preserve the per-word staggered reveal animation while making the text visually separated.

### Description
- Add `gap` and `row-gap` to `.insultText` in `src/InsultBox.module.css` to space words with flex layout.
- Add `.word` rules and `@keyframes wordPop` in `src/InsultBox.module.css` to keep the pop-in animation for each word.
- Remove the manual trailing space insertion between word spans in `src/InsultBox.tsx` so spacing is handled by CSS.
- Continue rendering each word as an individual span with per-word `--word-delay` and `--word-duration` styles in `src/InsultBox.tsx`.

### Testing
- Ran the development server with `npm start`, which compiled and served the app but emitted existing ESLint warnings.
- Executed a Playwright script to load `http://127.0.0.1:3000` and capture a screenshot saved to `artifacts/insult-box-spaced.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964675fc6308329a5eb56876c322940)