### PR TITLE
Add shop-specific insult box fonts

### DIFF
--- a/src/ApplegarthGuild.tsx
+++ b/src/ApplegarthGuild.tsx
@@ -52,6 +52,7 @@ export function ApplegarthGuild({ onBack }: { onBack?: () => void }) {
           className={styles.footerNote}
           owner={tribeApplegarthGuild.owner}
           insults={tribeApplegarthGuild.insults}
+          shopName={tribeApplegarthGuild.name}
         />
         <section className={styles.grid} aria-label="Available items">
           {displayItems.map((item) => {

--- a/src/ArchivesGuild.tsx
+++ b/src/ArchivesGuild.tsx
@@ -45,6 +45,7 @@ export function ArchivesGuild({ onBack }: { onBack?: () => void }) {
           className={styles.footerNote}
           owner={tribeArchivesGuild.owner}
           insults={tribeArchivesGuild.insults}
+          shopName={tribeArchivesGuild.name}
         />
         <section className={styles.grid} aria-label="Available items">
           {displayItems.map((item) => (

--- a/src/AuntiePattysPies.tsx
+++ b/src/AuntiePattysPies.tsx
@@ -46,6 +46,7 @@ export function AuntiePattysPies({ onBack }: { onBack?: () => void }) {
           className={styles.footerNote}
           owner={tribeAuntiePattysPies.owner}
           insults={tribeAuntiePattysPies.insults}
+          shopName={tribeAuntiePattysPies.name}
         />
         <section className={styles.grid} aria-label="Available items">
           {displayItems.map((item) => (

--- a/src/BlossomHotel.tsx
+++ b/src/BlossomHotel.tsx
@@ -63,6 +63,7 @@ export function BlossomHotel({ onBack }: { onBack?: () => void }) {
           className={styles.footerNote}
           owner={tribeBlossomHotel.owner}
           insults={tribeBlossomHotel.insults}
+          shopName={tribeBlossomHotel.name}
         />
         <section className={styles.grid} aria-label="Available items">
           {displayItems.map((item, index) => (

--- a/src/BookBombs.tsx
+++ b/src/BookBombs.tsx
@@ -47,6 +47,7 @@ export function BookBombs({ onBack }: { onBack?: () => void }) {
           className={styles.footerNote}
           owner={tribeBookBombs.owner}
           insults={tribeBookBombs.insults}
+          shopName={tribeBookBombs.name}
         />
         <section className={styles.grid} aria-label="Available items">
           {displayItems.map((item) => (

--- a/src/BulletsBuffsBeyond.tsx
+++ b/src/BulletsBuffsBeyond.tsx
@@ -53,6 +53,7 @@ export function BulletsBuffsBeyond({ onBack }: { onBack?: () => void }) {
           className={styles.footerNote}
           owner={tribeBulletsBuffsBeyond.owner}
           insults={tribeBulletsBuffsBeyond.insults}
+          shopName={tribeBulletsBuffsBeyond.name}
         />
         <section className={styles.grid} aria-label="Available items">
           {displayItems.map((item) => {

--- a/src/ChangingChurch.tsx
+++ b/src/ChangingChurch.tsx
@@ -46,6 +46,7 @@ export function ChangingChurch({ onBack }: { onBack?: () => void }) {
           className={styles.footerNote}
           owner={tribeChangingChurch.owner}
           insults={tribeChangingChurch.insults}
+          shopName={tribeChangingChurch.name}
         />
         <section className={styles.grid} aria-label="Available items">
           {displayItems.map((item) => (

--- a/src/ComedyGold.tsx
+++ b/src/ComedyGold.tsx
@@ -53,6 +53,7 @@ export function ComedyGold({ onBack }: { onBack?: () => void }) {
           className={styles.footerNote}
           owner={tribeComedyGold.owner}
           insults={tribeComedyGold.insults}
+          shopName={tribeComedyGold.name}
         />
         <section className={styles.grid} aria-label="Available items">
           {displayItems.map((item) => {

--- a/src/DungeonCrawlerGuild.tsx
+++ b/src/DungeonCrawlerGuild.tsx
@@ -46,6 +46,7 @@ export function DungeonCrawlerGuild({ onBack }: { onBack?: () => void }) {
           className={styles.footerNote}
           owner={tribeDungeonCrawlerGuild.owner}
           insults={tribeDungeonCrawlerGuild.insults}
+          shopName={tribeDungeonCrawlerGuild.name}
         />
         <section className={styles.grid} aria-label="Available items">
           {displayItems.map((item) => (

--- a/src/EvansEnchantingEmporium.tsx
+++ b/src/EvansEnchantingEmporium.tsx
@@ -71,6 +71,7 @@ export function EvansEnchantingEmporium({ onBack }: { onBack?: () => void }) {
           className={styles.footerNote}
           owner={tribeEvansEnchantingEmporium.owner}
           insults={tribeEvansEnchantingEmporium.insults}
+          shopName={tribeEvansEnchantingEmporium.name}
         />
         <section className={styles.grid} aria-label="Available items">
           {displayItems.map((item, index) => (

--- a/src/FairiesOfFlora.tsx
+++ b/src/FairiesOfFlora.tsx
@@ -61,6 +61,7 @@ export function FairiesOfFlora({ onBack }: { onBack?: () => void }) {
           className={styles.footerNote}
           owner={tribeFairiesOfFlora.owner}
           insults={tribeFairiesOfFlora.insults}
+          shopName={tribeFairiesOfFlora.name}
         />
         <section className={styles.grid} aria-label="Available items">
           {displayItems.map((item, index) => (

--- a/src/FindAFriend.tsx
+++ b/src/FindAFriend.tsx
@@ -50,6 +50,7 @@ export function FindAFriend({ onBack }: { onBack?: () => void }) {
           className={styles.footerNote}
           owner={tribeFindAFriend.owner}
           insults={tribeFindAFriend.insults}
+          shopName={tribeFindAFriend.name}
         />
         <section className={styles.grid} aria-label="Available items">
           {displayItems.map((item) => (

--- a/src/FizzyTales.tsx
+++ b/src/FizzyTales.tsx
@@ -59,6 +59,7 @@ export function FizzyTales({ onBack }: { onBack?: () => void }) {
           className={styles.footerNote}
           owner={tribeFizzyTales.owner}
           insults={tribeFizzyTales.insults}
+          shopName={tribeFizzyTales.name}
         />
         <section className={styles.grid} aria-label="Available items">
           {displayItems.map((item, index) => (

--- a/src/GolemWorkshop.tsx
+++ b/src/GolemWorkshop.tsx
@@ -63,6 +63,7 @@ export function GolemWorkshop({ onBack }: { onBack?: () => void }) {
           className={styles.footerNote}
           owner={tribeGolemWorkshop.owner}
           insults={tribeGolemWorkshop.insults}
+          shopName={tribeGolemWorkshop.name}
         />
         <section className={styles.grid} aria-label="Available items">
           {displayItems.map((item, index) => (

--- a/src/IconicDragonic.tsx
+++ b/src/IconicDragonic.tsx
@@ -56,6 +56,7 @@ export function IconicDragonic({ onBack }: { onBack?: () => void }) {
           className={styles.footerNote}
           owner={tribeIconicDragonic.owner}
           insults={tribeIconicDragonic.insults}
+          shopName={tribeIconicDragonic.name}
         />
         <section className={styles.grid} aria-label="Available items">
           {displayItems.map((item, index) => (

--- a/src/InsultBox.module.css
+++ b/src/InsultBox.module.css
@@ -9,6 +9,7 @@
   gap: 0.35rem;
   padding: 0.85rem 1.15rem;
   font-weight: bold;
+  font-family: var(--insult-font, inherit);
   box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
   max-width: 780px;
   text-align: center;

--- a/src/InsultBox.tsx
+++ b/src/InsultBox.tsx
@@ -6,13 +6,61 @@ interface InsultBoxProps {
   insults: string[];
   className?: string;
   rotationMs?: number;
+  shopName?: string;
 }
+
+const insultFontByShop: Record<string, string> = {
+  "Applegarth Guild": '"Palatino Linotype", "Book Antiqua", Palatino, serif',
+  "Archives Guild": '"Garamond", "Baskerville", serif',
+  "Book Bombs": '"Courier New", Courier, monospace',
+  "Bullets, Buffs, & Beyond":
+    '"Lucida Console", Monaco, "Courier New", monospace',
+  "Changing Church": '"Copperplate", "Copperplate Gothic Light", serif',
+  "Necromancy Insurance Company": '"Papyrus", "Segoe Print", fantasy',
+  "O-Papies Oracle Readings": '"Georgia", "Times New Roman", serif',
+  "Robin's Ropes": '"Trebuchet MS", "Lucida Sans Unicode", sans-serif',
+  "Runestone Relay":
+    '"Impact", "Haettenschweiler", "Arial Narrow Bold", sans-serif',
+  "Silent Oath": '"Brush Script MT", "Segoe Script", cursive',
+  "Supreme Smithy": '"Cinzel", "Trajan Pro", serif',
+  "Will's Weapons":
+    '"Franklin Gothic Medium", "Arial Narrow", Arial, sans-serif',
+  "Auntie Patty's Pies": '"Comic Sans MS", "Comic Sans", cursive',
+  "Comedy Gold": '"Segoe UI", Tahoma, Geneva, Verdana, sans-serif',
+  "Dungeon Crawler Guild": '"Gill Sans", "Gill Sans MT", Calibri, sans-serif',
+  "Find a Friend": '"Tahoma", Geneva, sans-serif',
+  "Navigation Guild": '"Optima", "Segoe UI", sans-serif',
+  "Pearl's Potions": '"Didot", "Bodoni MT", serif',
+  "Provision's Paradise": '"Rockwell", "Courier Bold", serif',
+  "The Piggy Bank, no hammers inside.":
+    '"Bookman Old Style", "Bookman", serif',
+  "Ye Old Donkey": '"Candara", "Calibri", sans-serif',
+  "Hug Cartel": '"American Typewriter", "Courier", serif',
+  "Iconic Dragonic": '"Perpetua", "Times New Roman", serif',
+  "Jell Bell": '"Chalkduster", "Comic Sans MS", fantasy',
+  "Make a Monster": '"Futura", "Trebuchet MS", Arial, sans-serif',
+  "Michael's Mount": '"Hoefler Text", "Palatino Linotype", serif',
+  "Paws, Claws, & Maws": '"Lucida Handwriting", "Brush Script MT", cursive',
+  "Valhalla Mart": '"Consolas", "Lucida Console", monospace',
+  "Blossom Hotel": '"Verdana", Geneva, sans-serif',
+  "Evan's Enchanting Emporium": '"Calibri", "Segoe UI", sans-serif',
+  "Fairies of Flora": '"Cambria", "Georgia", serif',
+  "Golem Workshop": '"Century Gothic", "Futura", sans-serif',
+  "Jazz's Portable Potions": '"Monaco", "Consolas", monospace',
+  "Jewelry Guild": '"Goudy Old Style", "Garamond", serif',
+  "Labyrinthine Library": '"Lucida Sans", "Lucida Grande", sans-serif',
+  "N.M.E.": '"Times New Roman", Times, serif',
+  "Sleuth University": '"Arial Black", "Arial Bold", sans-serif',
+  "Fizzy Tales": '"Helvetica Neue", Helvetica, Arial, sans-serif',
+  "Ye Old Home Depot": '"Courier Prime", "Courier New", monospace',
+};
 
 export function InsultBox({
   owner,
   insults,
   className,
   rotationMs = 5000,
+  shopName,
 }: InsultBoxProps) {
   const insultOptions = useMemo(
     () => insults.map((insult) => insult?.trim() ?? ""),
@@ -51,9 +99,23 @@ export function InsultBox({
     return null;
   }
 
+  const resolvedFontFamily = shopName
+    ? insultFontByShop[shopName]
+    : undefined;
+  const insultStyle = resolvedFontFamily
+    ? ({
+        ["--insult-font" as string]: resolvedFontFamily,
+      } as const)
+    : undefined;
+
   return (
     <div className={className}>
-      <div className={styles.insultBox} role="status" aria-live="polite">
+      <div
+        className={styles.insultBox}
+        role="status"
+        aria-live="polite"
+        style={insultStyle}
+      >
         {owner && <span className={styles.ownerLabel}>{owner}:</span>}
         <span className={styles.insultText} aria-live="polite">
           {activeWords.map((word, index) => (

--- a/src/JellBell.tsx
+++ b/src/JellBell.tsx
@@ -62,6 +62,7 @@ export function JellBell({ onBack }: { onBack?: () => void }) {
           className={styles.footerNote}
           owner={tribeJellBell.owner}
           insults={tribeJellBell.insults}
+          shopName={tribeJellBell.name}
         />
         <section className={styles.grid} aria-label="Available items">
           {displayItems.map((item, index) => (

--- a/src/JewelryGuild.tsx
+++ b/src/JewelryGuild.tsx
@@ -61,6 +61,7 @@ export function JewelryGuild({ onBack }: { onBack?: () => void }) {
           className={styles.footerNote}
           owner={tribeJewelryGuild.owner}
           insults={tribeJewelryGuild.insults}
+          shopName={tribeJewelryGuild.name}
         />
         <section className={styles.grid} aria-label="Available items">
           {displayItems.map((item, index) => (

--- a/src/LabyrinthineLibrary.tsx
+++ b/src/LabyrinthineLibrary.tsx
@@ -69,6 +69,7 @@ export function LabyrinthineLibrary({ onBack }: { onBack?: () => void }) {
           className={styles.footerNote}
           owner={tribeLabyrinthineLibrary.owner}
           insults={tribeLabyrinthineLibrary.insults}
+          shopName={tribeLabyrinthineLibrary.name}
         />
         <section className={styles.grid} aria-label="Available items">
           {displayItems.map((item, index) => (

--- a/src/MichaelsMount.tsx
+++ b/src/MichaelsMount.tsx
@@ -62,6 +62,7 @@ export function MichaelsMount({ onBack }: { onBack?: () => void }) {
           className={styles.footerNote}
           owner={tribeMichaelsMount.owner}
           insults={tribeMichaelsMount.insults}
+          shopName={tribeMichaelsMount.name}
         />
         <section className={styles.grid} aria-label="Available items">
           {displayItems.map((item, index) => (

--- a/src/MonsterMaker.tsx
+++ b/src/MonsterMaker.tsx
@@ -100,6 +100,7 @@ export function MonsterMaker({ onBack }: { onBack?: () => void }) {
           className={styles.footerNote}
           owner={tribeMonsterMaker.owner}
           insults={tribeMonsterMaker.insults}
+          shopName={tribeMonsterMaker.name}
         />
 
         <div className={styles.categories}>

--- a/src/NME.tsx
+++ b/src/NME.tsx
@@ -61,6 +61,7 @@ export function NME({ onBack }: { onBack?: () => void }) {
           className={styles.footerNote}
           owner={tribeNME.owner}
           insults={tribeNME.insults}
+          shopName={tribeNME.name}
         />
         <section className={styles.grid} aria-label="Available items">
           {displayItems.map((item, index) => (

--- a/src/NecromancyInsuranceCompany.tsx
+++ b/src/NecromancyInsuranceCompany.tsx
@@ -46,6 +46,7 @@ export function NecromancyInsuranceCompany({ onBack }: { onBack?: () => void }) 
           className={styles.footerNote}
           owner={tribeNecromancyInsuranceCompany.owner}
           insults={tribeNecromancyInsuranceCompany.insults}
+          shopName={tribeNecromancyInsuranceCompany.name}
         />
         <section className={styles.grid} aria-label="Available items">
           {displayItems.map((item) => (

--- a/src/PawsClawsMaws.tsx
+++ b/src/PawsClawsMaws.tsx
@@ -70,6 +70,7 @@ export function PawsClawsMaws({ onBack }: { onBack?: () => void }) {
           className={styles.footerNote}
           owner={tribePawsClawsMaws.owner}
           insults={tribePawsClawsMaws.insults}
+          shopName={tribePawsClawsMaws.name}
         />
         <section className={styles.grid} aria-label="Available items">
           {displayItems.map((item, index) => (

--- a/src/PearlsPotions.tsx
+++ b/src/PearlsPotions.tsx
@@ -45,6 +45,7 @@ export function PearlsPotions({ onBack }: { onBack?: () => void }) {
           className={styles.footerNote}
           owner={tribePearlsPotions.owner}
           insults={tribePearlsPotions.insults}
+          shopName={tribePearlsPotions.name}
         />
         <section className={styles.grid} aria-label="Available items">
           {displayItems.map((item) => (

--- a/src/PiggyBank.tsx
+++ b/src/PiggyBank.tsx
@@ -52,6 +52,7 @@ export function PiggyBank({ onBack }: { onBack?: () => void }) {
           className={styles.footerNote}
           owner={tribePiggyBank.owner}
           insults={tribePiggyBank.insults}
+          shopName={tribePiggyBank.name}
         />
         <section className={styles.grid} aria-label="Available items">
           {displayItems.map((item) => (

--- a/src/RunestoneRelay.tsx
+++ b/src/RunestoneRelay.tsx
@@ -51,6 +51,7 @@ export function RunestoneRelay({ onBack }: { onBack?: () => void }) {
           className={styles.footerNote}
           owner={tribeRunestoneRelay.owner}
           insults={tribeRunestoneRelay.insults}
+          shopName={tribeRunestoneRelay.name}
         />
         <section className={styles.grid} aria-label="Available items">
           {displayItems.map((item) => (

--- a/src/ShopTemplate.tsx
+++ b/src/ShopTemplate.tsx
@@ -56,6 +56,7 @@ export function ShopTemplate({
           className={styles.footerNote}
           owner={tribe.owner}
           insults={tribe.insults}
+          shopName={tribe.name}
         />
 
         <section className={styles.grid} aria-label="Available items">

--- a/src/SleuthUniversity.tsx
+++ b/src/SleuthUniversity.tsx
@@ -66,6 +66,7 @@ export function SleuthUniversity({ onBack }: { onBack?: () => void }) {
           className={styles.footerNote}
           owner={tribeSleuthUniversity.owner}
           insults={tribeSleuthUniversity.insults}
+          shopName={tribeSleuthUniversity.name}
         />
         <section className={styles.grid} aria-label="Available items">
           {displayItems.map((item, index) => (

--- a/src/ValhallaMart.tsx
+++ b/src/ValhallaMart.tsx
@@ -62,6 +62,7 @@ export function ValhallaMart({ onBack }: { onBack?: () => void }) {
           className={styles.footerNote}
           owner={tribeValhallaMart.owner}
           insults={tribeValhallaMart.insults}
+          shopName={tribeValhallaMart.name}
         />
         <section className={styles.grid} aria-label="Available items">
           {displayItems.map((item, index) => (

--- a/src/YeOldDonkey.tsx
+++ b/src/YeOldDonkey.tsx
@@ -45,6 +45,7 @@ export function YeOldDonkey({ onBack }: { onBack?: () => void }) {
           className={styles.footerNote}
           owner={tribeYeOldDonkey.owner}
           insults={tribeYeOldDonkey.insults}
+          shopName={tribeYeOldDonkey.name}
         />
         <section className={styles.grid} aria-label="Available items">
           {displayItems.map((item) => (

--- a/src/YeOldHomeDepot.tsx
+++ b/src/YeOldHomeDepot.tsx
@@ -63,6 +63,7 @@ export function YeOldHomeDepot({ onBack }: { onBack?: () => void }) {
           className={styles.footerNote}
           owner={tribeYeOldHomeDepot.owner}
           insults={tribeYeOldHomeDepot.insults}
+          shopName={tribeYeOldHomeDepot.name}
         />
         <section className={styles.grid} aria-label="Available items">
           {displayItems.map((item, index) => (


### PR DESCRIPTION
### Motivation
- Give each shop a distinctive typeface for its insult box so the UI feels thematically consistent across different shops.

### Description
- Add a `shopName` prop to `InsultBox` and a `insultFontByShop` mapping in `src/InsultBox.tsx` to resolve a font-family per shop.
- Emit the font via a CSS variable `--insult-font` and apply it in `src/InsultBox.module.css` with `font-family: var(--insult-font, inherit)`.
- Pass `shopName={tribe.name}` from `ShopTemplate` and update individual shop views that render `InsultBox` so each insult box receives the shop name.
- Small mapping tweak: change the `Jewelry Guild` entry to use `"Goudy Old Style"` in the font map.

### Testing
- Launched the dev server with `npm start`; the app compiled and served but with ESLint warnings (unused imports and an invalid ARIA attribute), webpack compiled successfully.
- Ran an automated Playwright script that opened the app, navigated to the Book Bombs screen, and captured a screenshot (`artifacts/insult-fonts-book-bombs.png`) to verify the font was applied; the script completed successfully.
- No unit tests (`npm test`) were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d238f347c8329b0aeb5b7afbd274c)