### PR TITLE
Pearl's Potions: translucent insults with per-word shake

### DIFF
--- a/src/InsultBox.module.css
+++ b/src/InsultBox.module.css
@@ -27,6 +27,10 @@
   gap: 0.4rem;
 }
 
+.pearlInsultBox .insultText {
+  color: rgba(255, 255, 255, 0.25);
+}
+
 .word {
   display: inline-block;
   opacity: 0;
@@ -35,9 +39,33 @@
   animation-delay: var(--word-delay, 0ms);
 }
 
+.wordInner {
+  display: inline-block;
+}
+
+.pearlInsultBox .wordInner {
+  animation: pearlShake 520ms ease-in-out infinite;
+}
+
 @keyframes wordPop {
   to {
     opacity: 1;
     transform: translateY(0);
+  }
+}
+
+@keyframes pearlShake {
+  0%,
+  100% {
+    transform: translate(0, 0);
+  }
+  25% {
+    transform: translate(-1px, 1px);
+  }
+  50% {
+    transform: translate(1px, -1px);
+  }
+  75% {
+    transform: translate(-1px, 0);
   }
 }

--- a/src/InsultBox.tsx
+++ b/src/InsultBox.tsx
@@ -102,16 +102,20 @@ export function InsultBox({
   const resolvedFontFamily = shopName
     ? insultFontByShop[shopName]
     : undefined;
+  const isPearlsPotions = shopName === "Pearl's Potions";
   const insultStyle = resolvedFontFamily
     ? ({
         ["--insult-font" as string]: resolvedFontFamily,
       } as const)
     : undefined;
+  const insultBoxClassName = isPearlsPotions
+    ? `${styles.insultBox} ${styles.pearlInsultBox}`
+    : styles.insultBox;
 
   return (
     <div className={className}>
       <div
-        className={styles.insultBox}
+        className={insultBoxClassName}
         role="status"
         aria-live="polite"
         style={insultStyle}
@@ -131,7 +135,7 @@ export function InsultBox({
                 ["--word-duration" as string]: `${wordDurationMs}ms`,
               }}
             >
-              {word}
+              <span className={styles.wordInner}>{word}</span>
             </span>
           ))}
         </span>


### PR DESCRIPTION
### Motivation
- Make Pearl's Potions insults visually distinct by reducing opacity and adding a subtle per-word motion to match the shop's character.

### Description
- Added shop detection and class hook in `src/InsultBox.tsx` to apply Pearl-specific styling by checking `shopName === "Pearl's Potions"` and appending `styles.pearlInsultBox` to the insult box container.
- Wrapped each rendered word in a nested `<span className={styles.wordInner}>` so individual words can animate independently in `src/InsultBox.tsx`.
- Updated `src/InsultBox.module.css` to set Pearl's insults to 25% opacity (`rgba(255,255,255,0.25)`) and add a `pearlShake` keyframes animation applied to each `.wordInner` with a subtle infinite shake.

### Testing
- Started the dev server with `npm start`, which compiled the app with warnings but successfully served the site. (Compilation succeeded.)
- Ran an automated Playwright script to navigate to the Sandbox view and capture a screenshot of Pearl's Potions insults, which completed and produced the artifact screenshot successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d28b84cf883298ac4f943b7ac0219)