### PR TITLE
Allow insult owner labels to wrap in smaller boxes

### DIFF
--- a/src/InsultBox.module.css
+++ b/src/InsultBox.module.css
@@ -4,6 +4,7 @@
   border-radius: 10px;
   color: #fff;
   display: inline-flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: center;
   gap: 0.35rem;
@@ -17,7 +18,7 @@
 }
 
 .ownerLabel {
-  white-space: nowrap;
+  white-space: normal;
 }
 
 .insultText {


### PR DESCRIPTION
### Motivation
- Prevent owner names from overflowing or staying on one line by letting the label and rotating insult text reflow when the insult box is narrow.

### Description
- Enable wrapping on the insult container (`flex-wrap: wrap`) and allow `.ownerLabel` to break lines (`white-space: normal`) in `src/InsultBox.module.css`.

### Testing
- Started the dev server with `npm start` and rendered the UI to capture a screenshot; the app compiled and served with ESLint warnings but no runtime errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dc2108c348329bc410164c6859242)