### PR TITLE
Left-align owner label and enable wrapping in InsultBox

### DIFF
--- a/src/InsultBox.module.css
+++ b/src/InsultBox.module.css
@@ -4,8 +4,9 @@
   border-radius: 10px;
   color: #fff;
   display: inline-flex;
+  flex-wrap: wrap;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   gap: 0.35rem;
   padding: 0.85rem 1.15rem;
   font-weight: bold;
@@ -17,12 +18,17 @@
 }
 
 .ownerLabel {
-  white-space: nowrap;
+  white-space: normal;
+  max-width: 100%;
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .insultText {
   display: inline-flex;
   flex-wrap: wrap;
+  flex: 1 1 0;
+  min-width: 0;
   justify-content: center;
   gap: 0.4rem;
 }


### PR DESCRIPTION
### Motivation
- Prevent long owner names from forcing the insult text out of the container and satisfy the preference to have the owner name aligned to the left.

### Description
- Update `.insultBox` to allow wrapping with `flex-wrap: wrap` and left-align items with `justify-content: flex-start` so the owner label sits on the left.
- Change `.ownerLabel` to allow breaking and wrapping by setting `white-space: normal`, `max-width: 100%`, `min-width: 0`, and `overflow-wrap: anywhere`.
- Make `.insultText` flexible beside the label by adding `flex: 1 1 0` and `min-width: 0` while keeping its centered content.

### Testing
- Started the dev server with `npm start`, the app compiled and served with ESLint warnings (warnings only).
- Captured a UI screenshot via Playwright which shows the owner label left-aligned and wrapping as expected (screenshot artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dc2108c348329bc410164c6859242)