### PR TITLE
Left-align InsultBox and allow long owner names to wrap

### DIFF
--- a/src/InsultBox.module.css
+++ b/src/InsultBox.module.css
@@ -5,7 +5,7 @@
   color: #fff;
   display: inline-flex;
   flex-wrap: wrap;
-  align-items: center;
+  align-items: flex-start;
   justify-content: flex-start;
   gap: 0.35rem;
   padding: 0.85rem 1.15rem;
@@ -13,20 +13,23 @@
   font-family: var(--insult-font, inherit);
   box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
   max-width: 780px;
-  text-align: center;
+  text-align: left;
   margin-top: 1rem;
 }
 
 .ownerLabel {
   white-space: normal;
+  flex: 0 1 auto;
+  max-width: 100%;
+  overflow-wrap: anywhere;
 }
 
 .insultText {
   display: inline-flex;
   flex-wrap: wrap;
-  flex: 1 1 0;
+  flex: 1 1 12rem;
   min-width: 0;
-  justify-content: center;
+  justify-content: flex-start;
   gap: 0.4rem;
 }
 


### PR DESCRIPTION
### Motivation
- Prevent long `owner` names from pushing or collapsing the insult text inside the insult box by improving flex rules and text alignment in `src/InsultBox.module.css`.
- Keep the visual order so the owner label remains left of the insult text while giving the insult area enough room to display even with long owner names.

### Description
- Updated `.insultBox` to `text-align: left; align-items: flex-start;` while retaining `flex-wrap: wrap` to left-align and top-align contents.
- Changed `.ownerLabel` to `flex: 0 1 auto; max-width: 100%; overflow-wrap: anywhere;` so long owner names wrap inside the box instead of expanding it.
- Adjusted `.insultText` to `flex: 1 1 12rem; min-width: 0; justify-content: flex-start;` to reserve room for the insult and prevent collapse when the owner label is long.
- Confirmed in `src/InsultBox.tsx` that the `ownerLabel` and `insultText` spans remain in the same order so the owner text appears to the left of the insult text.

### Testing
- Started the dev server with `npm start`, which compiled and served the app (webpack compiled with warnings but no errors).
- Captured a page screenshot using a Playwright script which completed successfully and produced `artifacts/insult-box.png`.
- No unit tests were run since this is a CSS-only layout change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f0f7710348329a31070fa090f0f69)