### PR TITLE
Add pastel item card palettes for key shops

### DIFF
--- a/src/ApplegarthGuild.module.css
+++ b/src/ApplegarthGuild.module.css
@@ -85,11 +85,11 @@
 }
 
 .card {
-  background: #ffffff;
-  border: 3px solid #2f1f1d;
+  background: #f6e2d4;
+  border: 4px solid #c58a5c;
   border-radius: 18px;
   padding: 1.5rem 1.25rem;
-  color: #ffffff;
+  color: #4a2a1f;
   font-family: monospace; 
   font-size: 24px;
   font-weight: bolder;
@@ -99,20 +99,19 @@
   margin-left: auto;
   margin-right: auto;
   border-radius: 50% 20% / 10% 40%;
-  box-shadow: 5px 5px rgba(0, 0, 0, 0.67);
-  border: 5px solid rgb(0, 0, 0);
+  box-shadow: 5px 5px rgba(96, 52, 24, 0.35);
 }
 
 .cardTitle {
   margin: 0;
   font-size: 1.25rem;
-  color: #3a211f;
+  color: #4a2a1f;
 }
 
 .description {
   margin: 0;
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  color: #4b3a35;
+  color: #5b3b2b;
   font-size: 0.95rem;
   text-align: center;
 }
@@ -120,7 +119,7 @@
 .price {
   margin: 0;
   font-weight: bold;
-  color: #2f1f1d;
+  color: #8b4f2d;
 }
 
 .footerNote {

--- a/src/ArchivesGuild.module.css
+++ b/src/ArchivesGuild.module.css
@@ -85,11 +85,11 @@
 }
 
 .card {
-  background: #ffffff;
-  border: 3px solid #2f1f1d;
+  background: #dbe7f7;
+  border: 4px solid #7a8fb4;
   border-radius: 18px;
   padding: 1.5rem 1.25rem;
-  color: #ffffff;
+  color: #2f3f5c;
   font-family: monospace; 
   font-size: 24px;
   font-weight: bolder;
@@ -99,20 +99,19 @@
   margin-left: auto;
   margin-right: auto;
   border-radius: 50% 20% / 10% 40%;
-  box-shadow: 5px 5px rgba(0, 0, 0, 0.67);
-  border: 5px solid rgb(0, 0, 0);
+  box-shadow: 5px 5px rgba(58, 76, 116, 0.35);
 }
 
 .cardTitle {
   margin: 0;
   font-size: 1.25rem;
-  color: #3a211f;
+  color: #2f3f5c;
 }
 
 .description {
   margin: 0;
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  color: #4b3a35;
+  color: #3a4a66;
   font-size: 0.95rem;
   text-align: center;
 }
@@ -120,7 +119,7 @@
 .price {
   margin: 0;
   font-weight: bold;
-  color: #2f1f1d;
+  color: #516f93;
 }
 
 .footerNote {

--- a/src/BookBombs.module.css
+++ b/src/BookBombs.module.css
@@ -89,11 +89,11 @@
 }
 
 .card {
-  background: #ffffff;
-  border: 3px solid #2f1f1d;
+  background: #f7d7ea;
+  border: 4px solid #b881b2;
   border-radius: 18px;
   padding: 1.5rem 1.25rem;
-  color: #ffffff;
+  color: #4a2a4a;
   font-family: monospace; 
   font-size: 24px;
   font-weight: bolder;
@@ -103,20 +103,19 @@
   margin-left: auto;
   margin-right: auto;
   border-radius: 50% 20% / 10% 40%;
-  box-shadow: 5px 5px rgba(0, 0, 0, 0.67);
-  border: 5px solid rgb(0, 0, 0);
+  box-shadow: 5px 5px rgba(90, 45, 88, 0.35);
 }
 
 .cardTitle {
   margin: 0;
   font-size: 1.25rem;
-  color: #3a211f;
+  color: #4a2a4a;
 }
 
 .description {
   margin: 0;
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  color: #4b3a35;
+  color: #5c3562;
   font-size: 0.95rem;
   text-align: center;
 }
@@ -124,5 +123,5 @@
 .price {
   margin: 0;
   font-weight: bold;
-  color: #2f1f1d;
+  color: #8b4c86;
 }

--- a/src/BulletsBuffsBeyond.module.css
+++ b/src/BulletsBuffsBeyond.module.css
@@ -85,11 +85,11 @@
 }
 
 .card {
-  background: #ffffff;
-  border: 3px solid #2f1f1d;
+  background: #e0f0d5;
+  border: 4px solid #82a878;
   border-radius: 18px;
   padding: 1.5rem 1.25rem;
-  color: #ffffff;
+  color: #2f4d2c;
   font-family: monospace;
   font-size: 24px;
   font-weight: bolder;
@@ -99,20 +99,19 @@
   margin-left: auto;
   margin-right: auto;
   border-radius: 50% 20% / 10% 40%;
-  box-shadow: 5px 5px rgba(0, 0, 0, 0.67);
-  border: 5px solid rgb(0, 0, 0);
+  box-shadow: 5px 5px rgba(45, 74, 44, 0.35);
 }
 
 .cardTitle {
   margin: 0;
   font-size: 1.25rem;
-  color: #3a211f;
+  color: #2f4d2c;
 }
 
 .description {
   margin: 0;
   font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
-  color: #4b3a35;
+  color: #3e5b3c;
   font-size: 0.95rem;
   text-align: center;
 }
@@ -120,7 +119,7 @@
 .price {
   margin: 0;
   font-weight: bold;
-  color: #2f1f1d;
+  color: #5d7f57;
 }
 
 .footerNote {

--- a/src/ChangingChurch.module.css
+++ b/src/ChangingChurch.module.css
@@ -85,11 +85,11 @@
 }
 
 .card {
-  background: #ffffff;
-  border: 3px solid #2f1f1d;
+  background: #fdeac8;
+  border: 4px solid #caa269;
   border-radius: 18px;
   padding: 1.5rem 1.25rem;
-  color: #ffffff;
+  color: #4b3720;
   font-family: monospace; 
   font-size: 24px;
   font-weight: bolder;
@@ -99,20 +99,19 @@
   margin-left: auto;
   margin-right: auto;
   border-radius: 50% 20% / 10% 40%;
-  box-shadow: 5px 5px rgba(0, 0, 0, 0.67);
-  border: 5px solid rgb(0, 0, 0);
+  box-shadow: 5px 5px rgba(101, 75, 40, 0.35);
 }
 
 .cardTitle {
   margin: 0;
   font-size: 1.25rem;
-  color: #3a211f;
+  color: #4b3720;
 }
 
 .description {
   margin: 0;
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  color: #4b3a35;
+  color: #5d4631;
   font-size: 0.95rem;
   text-align: center;
   line-height: 1.55;
@@ -122,5 +121,5 @@
 .price {
   margin: 0;
   font-weight: bold;
-  color: #2f1f1d;
+  color: #8b6a3d;
 }

--- a/src/NecromancyInsuranceCompany.module.css
+++ b/src/NecromancyInsuranceCompany.module.css
@@ -85,11 +85,11 @@
 }
 
 .card {
-  background: #ffffff;
-  border: 3px solid #2f1f1d;
+  background: #d6f1f0;
+  border: 4px solid #6fa8ad;
   border-radius: 18px;
   padding: 1.5rem 1.25rem;
-  color: #ffffff;
+  color: #1f4046;
   font-family: monospace; 
   font-size: 24px;
   font-weight: bolder;
@@ -99,20 +99,19 @@
   margin-left: auto;
   margin-right: auto;
   border-radius: 50% 20% / 10% 40%;
-  box-shadow: 5px 5px rgba(0, 0, 0, 0.67);
-  border: 5px solid rgb(0, 0, 0);
+  box-shadow: 5px 5px rgba(38, 83, 89, 0.35);
 }
 
 .cardTitle {
   margin: 0;
   font-size: 1.25rem;
-  color: #3a211f;
+  color: #1f4046;
 }
 
 .description {
   margin: 0;
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  color: #4b3a35;
+  color: #2b4f55;
   font-size: 0.95rem;
   text-align: center;
 }
@@ -120,5 +119,5 @@
 .price {
   margin: 0;
   font-weight: bold;
-  color: #2f1f1d;
+  color: #3f7480;
 }

--- a/src/RobinsRopes.module.css
+++ b/src/RobinsRopes.module.css
@@ -89,11 +89,11 @@
 }
 
 .card {
-  background: #ffffff;
-  border: 3px solid #2f1f1d;
+  background: #d9eef9;
+  border: 4px solid #6ea5c8;
   border-radius: 18px;
   padding: 1.5rem 1.25rem;
-  color: #ffffff;
+  color: #1f3f55;
   font-family: monospace; 
   font-size: 24px;
   font-weight: bolder;
@@ -103,20 +103,19 @@
   margin-left: auto;
   margin-right: auto;
   border-radius: 50% 20% / 10% 40%;
-  box-shadow: 5px 5px rgba(0, 0, 0, 0.67);
-  border: 5px solid rgb(0, 0, 0);
+  box-shadow: 5px 5px rgba(45, 85, 110, 0.35);
 }
 
 .cardTitle {
   margin: 0;
   font-size: 1.25rem;
-  color: #3a211f;
+  color: #1f3f55;
 }
 
 .description {
   margin: 0;
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  color: #4b3a35;
+  color: #2b4e66;
   font-size: 0.95rem;
   text-align: center;
 }
@@ -124,5 +123,5 @@
 .price {
   margin: 0;
   font-weight: bold;
-  color: #2f1f1d;
+  color: #3f7292;
 }

--- a/src/RunestoneRelay.module.css
+++ b/src/RunestoneRelay.module.css
@@ -89,11 +89,11 @@
 }
 
 .card {
-  background: #ffffff;
-  border: 3px solid #2f1f1d;
+  background: #e6def7;
+  border: 4px solid #8b78c6;
   border-radius: 18px;
   padding: 1.5rem 1.25rem;
-  color: #ffffff;
+  color: #33275a;
   font-family: monospace; 
   font-size: 24px;
   font-weight: bolder;
@@ -103,20 +103,19 @@
   margin-left: auto;
   margin-right: auto;
   border-radius: 50% 20% / 10% 40%;
-  box-shadow: 5px 5px rgba(0, 0, 0, 0.67);
-  border: 5px solid rgb(0, 0, 0);
+  box-shadow: 5px 5px rgba(64, 48, 115, 0.35);
 }
 
 .cardTitle {
   margin: 0;
   font-size: 1.25rem;
-  color: #3a211f;
+  color: #33275a;
 }
 
 .description {
   margin: 0;
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  color: #4b3a35;
+  color: #3f3268;
   font-size: 0.95rem;
   text-align: center;
 }
@@ -124,5 +123,5 @@
 .price {
   margin: 0;
   font-weight: bold;
-  color: #2f1f1d;
+  color: #5a4a86;
 }


### PR DESCRIPTION
### Motivation
- Give each shop's item cards a unique pastel palette that complements its background image while keeping text readable. 
- Replace the default white/black card styling with softer backgrounds, tuned borders, shadows, and accessible text colors for thematic consistency.

### Description
- Updated item card styles in eight modules to apply unique pastel backgrounds, stronger pastel-appropriate border colors, and softer colored shadows: `src/ApplegarthGuild.module.css`, `src/ArchivesGuild.module.css`, `src/BookBombs.module.css`, `src/BulletsBuffsBeyond.module.css`, `src/ChangingChurch.module.css`, `src/NecromancyInsuranceCompany.module.css`, `src/RobinsRopes.module.css`, and `src/RunestoneRelay.module.css`.
- Tuned card text colors (`.cardTitle`, `.description`, `.price`) to ensure contrast and readability against each new background. 
- Increased card border widths from `3px` to `4px` and replaced heavy black box-shadows with tinted shadows matching each palette.
- Kept existing layout and markup so behavior and item rendering code were not changed.

### Testing
- Ran the dev server with `npm start`, which compiled and served the app successfully but emitted existing ESLint warnings (no new errors). 
- Automated browser checks captured screenshots via Playwright of the home and Applegarth shop views producing artifacts `artifacts/pastel-palettes-home.png` and `artifacts/pastel-palettes-applegarth.png`, confirming visual updates. 
- All automated runs completed; no runtime errors were observed, only the project’s prior lint warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fb44d18e4832991ba22d2ef9fcd8d)