### PR TITLE
Remove floating animation and add color-grouped + alphabetized shop sorting

### DIFF
--- a/src/AnalepticHoltTeag.tsx
+++ b/src/AnalepticHoltTeag.tsx
@@ -12,7 +12,7 @@ import jazzPortablePotionsImage from "./Jazz's Portable Potions.png";
 import { BackButton } from "./BackButton";
 import styles from "./AnalepticHoltTeag.module.css";
 import { ShopButton } from "./ShopButton";
-import { getShopButtonStyle } from "./shopButtonStyles";
+import { getShopButtonStyle, sortShopButtons } from "./shopButtonStyles";
 
 type AnalepticShop = {
   key: string;
@@ -91,6 +91,8 @@ export function AnalepticHoltTeag({
     },
   ];
 
+  const sortedShops = sortShopButtons(shops);
+
   return (
     <div
       className={styles.wrapper}
@@ -108,7 +110,7 @@ export function AnalepticHoltTeag({
         </div>
 
         <div className={styles.buttonGrid}>
-          {shops.map((shop) => (
+            {sortedShops.map((shop) => (
             <ShopButton
               key={shop.key}
               label={shop.label}

--- a/src/BallisticBellowsCaleb.tsx
+++ b/src/BallisticBellowsCaleb.tsx
@@ -10,7 +10,7 @@ import piggyBankImage from "./Piggy Bank.png";
 import { BackButton } from "./BackButton";
 import styles from "./BallisticBellowsCaleb.module.css";
 import { ShopButton } from "./ShopButton";
-import { getShopButtonStyle } from "./shopButtonStyles";
+import { getShopButtonStyle, sortShopButtons } from "./shopButtonStyles";
 
 type BallisticBellowsShop = {
   key: string;
@@ -77,6 +77,8 @@ export function BallisticBellowsCaleb({
     },
   ];
 
+  const sortedShops = sortShopButtons(shops);
+
   return (
     <div
       className={styles.wrapper}
@@ -94,7 +96,7 @@ export function BallisticBellowsCaleb({
         </div>
 
         <div className={styles.buttonGrid}>
-          {shops.map((shop) => (
+            {sortedShops.map((shop) => (
             <ShopButton
               key={shop.key}
               label={shop.label}

--- a/src/BigHome.tsx
+++ b/src/BigHome.tsx
@@ -43,7 +43,7 @@ import blackMarketImage from "./Black Market.jpg";
 import { BackButton } from "./BackButton";
 import styles from "./BigHome.module.css";
 import { ShopButton } from "./ShopButton";
-import { getShopButtonStyle } from "./shopButtonStyles";
+import { getShopButtonStyle, sortShopButtons } from "./shopButtonStyles";
 
 type BigHomeShop = {
   key: string;
@@ -272,6 +272,8 @@ export function BigHome({
     },
   ];
 
+  const sortedShops = sortShopButtons(shops);
+
   return (
     <div
       className={styles.wrapper}
@@ -289,7 +291,7 @@ export function BigHome({
         </div>
 
         <div className={styles.buttonGrid}>
-          {shops.map((shop) => (
+            {sortedShops.map((shop) => (
             <ShopButton
               key={shop.key}
               label={shop.label}

--- a/src/ButtingRams.tsx
+++ b/src/ButtingRams.tsx
@@ -8,7 +8,7 @@ import willsWeaponsImage from "./Wills Weapons.png";
 import { BackButton } from "./BackButton";
 import styles from "./ButtingRams.module.css";
 import { ShopButton } from "./ShopButton";
-import { getShopButtonStyle } from "./shopButtonStyles";
+import { getShopButtonStyle, sortShopButtons } from "./shopButtonStyles";
 
 type ButtingRamsShop = {
   key: string;
@@ -63,6 +63,8 @@ export function ButtingRams({
     },
   ];
 
+  const sortedShops = sortShopButtons(shops);
+
   return (
     <div
       className={styles.wrapper}
@@ -80,7 +82,7 @@ export function ButtingRams({
         </div>
 
         <div className={styles.buttonGrid}>
-          {shops.map((shop) => (
+            {sortedShops.map((shop) => (
             <ShopButton
               key={shop.key}
               label={shop.label}

--- a/src/ByfordDolphinRobertson.tsx
+++ b/src/ByfordDolphinRobertson.tsx
@@ -8,7 +8,7 @@ import oPapiesOracleReadingsImage from "./O Papies Oracle Readings.png";
 import { BackButton } from "./BackButton";
 import styles from "./ByfordDolphinRobertson.module.css";
 import { ShopButton } from "./ShopButton";
-import { getShopButtonStyle } from "./shopButtonStyles";
+import { getShopButtonStyle, sortShopButtons } from "./shopButtonStyles";
 
 type ByfordShop = {
   key: string;
@@ -63,6 +63,8 @@ export function ByfordDolphinRobertson({
     },
   ];
 
+  const sortedShops = sortShopButtons(shops);
+
   return (
     <div
       className={styles.wrapper}
@@ -80,7 +82,7 @@ export function ByfordDolphinRobertson({
         </div>
 
         <div className={styles.buttonGrid}>
-          {shops.map((shop) => (
+            {sortedShops.map((shop) => (
             <ShopButton
               key={shop.key}
               label={shop.label}

--- a/src/CalidrisFisk.tsx
+++ b/src/CalidrisFisk.tsx
@@ -11,7 +11,7 @@ import willsWeaponsImage from "./Wills Weapons.png";
 import { BackButton } from "./BackButton";
 import styles from "./CalidrisFisk.module.css";
 import { ShopButton } from "./ShopButton";
-import { getShopButtonStyle } from "./shopButtonStyles";
+import { getShopButtonStyle, sortShopButtons } from "./shopButtonStyles";
 
 type CalidrisShop = {
   key: string;
@@ -84,6 +84,8 @@ export function CalidrisFisk({
     },
   ];
 
+  const sortedShops = sortShopButtons(shops);
+
   return (
     <div
       className={styles.wrapper}
@@ -101,7 +103,7 @@ export function CalidrisFisk({
         </div>
 
         <div className={styles.buttonGrid}>
-          {shops.map((shop) => (
+            {sortedShops.map((shop) => (
             <ShopButton
               key={shop.key}
               label={shop.label}

--- a/src/Graveborn.tsx
+++ b/src/Graveborn.tsx
@@ -11,7 +11,7 @@ import blossomHotelImage from "./Blossom Hotel.png";
 import { BackButton } from "./BackButton";
 import styles from "./Graveborn.module.css";
 import { ShopButton } from "./ShopButton";
-import { getShopButtonStyle } from "./shopButtonStyles";
+import { getShopButtonStyle, sortShopButtons } from "./shopButtonStyles";
 
 type GravebornShop = {
   key: string;
@@ -84,6 +84,8 @@ export function Graveborn({
     },
   ];
 
+  const sortedShops = sortShopButtons(shops);
+
   return (
     <div
       className={styles.wrapper}
@@ -101,7 +103,7 @@ export function Graveborn({
         </div>
 
         <div className={styles.buttonGrid}>
-          {shops.map((shop) => (
+            {sortedShops.map((shop) => (
             <ShopButton
               key={shop.key}
               label={shop.label}

--- a/src/HebronJoshua.tsx
+++ b/src/HebronJoshua.tsx
@@ -9,7 +9,7 @@ import sleuthUniversityImage from "./Sleuth.webp";
 import { BackButton } from "./BackButton";
 import styles from "./HebronJoshua.module.css";
 import { ShopButton } from "./ShopButton";
-import { getShopButtonStyle } from "./shopButtonStyles";
+import { getShopButtonStyle, sortShopButtons } from "./shopButtonStyles";
 
 type HebronShop = {
   key: string;
@@ -70,6 +70,8 @@ export function HebronJoshua({
     },
   ];
 
+  const sortedShops = sortShopButtons(shops);
+
   return (
     <div
       className={styles.wrapper}
@@ -87,7 +89,7 @@ export function HebronJoshua({
         </div>
 
         <div className={styles.buttonGrid}>
-          {shops.map((shop) => (
+          {sortedShops.map((shop) => (
             <ShopButton
               key={shop.key}
               label={shop.label}

--- a/src/JellyCity.tsx
+++ b/src/JellyCity.tsx
@@ -6,7 +6,7 @@ import changingChurchImage from "./Changing Church.png";
 import { BackButton } from "./BackButton";
 import styles from "./JellyCity.module.css";
 import { ShopButton } from "./ShopButton";
-import { getShopButtonStyle } from "./shopButtonStyles";
+import { getShopButtonStyle, sortShopButtons } from "./shopButtonStyles";
 
 type JellyCityShop = {
   key: string;
@@ -49,6 +49,8 @@ export function JellyCity({
     },
   ];
 
+  const sortedShops = sortShopButtons(shops);
+
   return (
     <div
       className={styles.wrapper}
@@ -66,7 +68,7 @@ export function JellyCity({
         </div>
 
         <div className={styles.buttonGrid}>
-          {shops.map((shop) => (
+            {sortedShops.map((shop) => (
             <ShopButton
               key={shop.key}
               label={shop.label}

--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -60,6 +60,7 @@ import FizzyTale  from "./FizzyTale.png";
 import provisionsParadiseImage from "./Provisions Paradise.png";
 import { ProvisionsParadise } from "./ProvisionsParadise";
 import { useEffect, useState } from "react";
+import { sortShopButtons } from "./shopButtonStyles";
 import { HugInfo } from "./HugInfo";
 import hugImage from "./Hug.webp";
 import jellBellImage from "./Jell.webp";
@@ -618,6 +619,8 @@ export function Map() {
     },
   ];
 
+  const sortedEveryShopButtons = sortShopButtons(everyShopButtons);
+
   switch (navigatedTo) {
     case "goblins":
 
@@ -821,7 +824,7 @@ export function Map() {
         <EveryShopMenu
           onBack={handleBack}
           onNavigate={handleNavigate}
-          buttons={everyShopButtons}
+          buttons={sortedEveryShopButtons}
         />
       );
     default:
@@ -865,6 +868,10 @@ function SandboxMenu({
   onBack: () => void;
   onNavigate: (key: string) => void;
 }) {
+  const sortedSandboxTowns = [...sandboxTowns].sort((a, b) =>
+    a.name.localeCompare(b.name)
+  );
+
   return (
     <div style={styles.wrapper}>
       <button type="button" onClick={onBack} style={styles.backButton}>
@@ -886,7 +893,7 @@ function SandboxMenu({
         </div>
       </div>
       <div style={styles.sandboxGrid}>
-        {sandboxTowns.map((town) => (
+        {sortedSandboxTowns.map((town) => (
             <FloatingButton
               key={town.key}
               label={town.name}

--- a/src/MeanderMichael.tsx
+++ b/src/MeanderMichael.tsx
@@ -12,7 +12,7 @@ import navigationGuildImage from "./NavigationGuild-ezgif.com-webp-to-png-conver
 import { BackButton } from "./BackButton";
 import styles from "./MeanderMichael.module.css";
 import { ShopButton } from "./ShopButton";
-import { getShopButtonStyle } from "./shopButtonStyles";
+import { getShopButtonStyle, sortShopButtons } from "./shopButtonStyles";
 
 type MeanderShop = {
   key: string;
@@ -91,6 +91,8 @@ export function MeanderMichael({
     },
   ];
 
+  const sortedShops = sortShopButtons(shops);
+
   return (
     <div
       className={styles.wrapper}
@@ -108,7 +110,7 @@ export function MeanderMichael({
         </div>
 
         <div className={styles.buttonGrid}>
-          {shops.map((shop) => (
+            {sortedShops.map((shop) => (
             <ShopButton
               key={shop.key}
               label={shop.label}

--- a/src/MerricksMeadowHoward.tsx
+++ b/src/MerricksMeadowHoward.tsx
@@ -10,7 +10,7 @@ import jazzPortablePotionsImage from "./Jazz's Portable Potions.png";
 import { BackButton } from "./BackButton";
 import styles from "./MerricksMeadowHoward.module.css";
 import { ShopButton } from "./ShopButton";
-import { getShopButtonStyle } from "./shopButtonStyles";
+import { getShopButtonStyle, sortShopButtons } from "./shopButtonStyles";
 
 type MerricksShop = {
   key: string;
@@ -77,6 +77,8 @@ export function MerricksMeadowHoward({
     },
   ];
 
+  const sortedShops = sortShopButtons(shops);
+
   return (
     <div
       className={styles.wrapper}
@@ -94,7 +96,7 @@ export function MerricksMeadowHoward({
         </div>
 
         <div className={styles.buttonGrid}>
-          {shops.map((shop) => (
+            {sortedShops.map((shop) => (
             <ShopButton
               key={shop.key}
               label={shop.label}

--- a/src/OrbitingCity.tsx
+++ b/src/OrbitingCity.tsx
@@ -10,7 +10,7 @@ import mountsImage from "./Mounts.webp";
 import { BackButton } from "./BackButton";
 import styles from "./OrbitingCity.module.css";
 import { ShopButton } from "./ShopButton";
-import { getShopButtonStyle } from "./shopButtonStyles";
+import { getShopButtonStyle, sortShopButtons } from "./shopButtonStyles";
 
 type OrbitingCityShop = {
   key: string;
@@ -77,6 +77,8 @@ export function OrbitingCity({
     },
   ];
 
+  const sortedShops = sortShopButtons(shops);
+
   return (
     <div
       className={styles.wrapper}
@@ -94,7 +96,7 @@ export function OrbitingCity({
         </div>
 
         <div className={styles.buttonGrid}>
-          {shops.map((shop) => (
+            {sortedShops.map((shop) => (
             <ShopButton
               key={shop.key}
               label={shop.label}

--- a/src/SeymoursDriftMelanie.tsx
+++ b/src/SeymoursDriftMelanie.tsx
@@ -9,7 +9,7 @@ import supremeSmithyImage from "./Supreme Smithy.png";
 import { BackButton } from "./BackButton";
 import styles from "./SeymoursDriftMelanie.module.css";
 import { ShopButton } from "./ShopButton";
-import { getShopButtonStyle } from "./shopButtonStyles";
+import { getShopButtonStyle, sortShopButtons } from "./shopButtonStyles";
 
 type SeymoursDriftShop = {
   key: string;
@@ -70,6 +70,8 @@ export function SeymoursDriftMelanie({
     },
   ];
 
+  const sortedShops = sortShopButtons(shops);
+
   return (
     <div
       className={styles.wrapper}
@@ -87,7 +89,7 @@ export function SeymoursDriftMelanie({
         </div>
 
         <div className={styles.buttonGrid}>
-          {shops.map((shop) => (
+            {sortedShops.map((shop) => (
             <ShopButton
               key={shop.key}
               label={shop.label}

--- a/src/ShopButton.tsx
+++ b/src/ShopButton.tsx
@@ -1,5 +1,4 @@
 import type { CSSProperties, ReactNode } from "react";
-import { useEffect } from "react";
 
 export type ShopButtonProps = {
   label: string;
@@ -19,7 +18,6 @@ const buttonStyles: Record<string, CSSProperties> = {
     border: "2px solid #ffffffff",
     boxShadow: "0 7px 12px rgba(0, 0, 0, 0.5)",
     cursor: "pointer",
-    animation: "float 12s ease-in-out infinite",
     transition: "transform 0.3s ease",
     fontFamily: "'Times New Roman', serif",
     display: "flex",
@@ -60,27 +58,6 @@ const buttonStyles: Record<string, CSSProperties> = {
   },
 };
 
-let floatKeyframesInjected = false;
-
-function ensureFloatKeyframes() {
-  if (floatKeyframesInjected || typeof document === "undefined") {
-    return;
-  }
-
-  const styleSheet = document.createElement("style");
-  styleSheet.id = "floating-keyframes";
-  styleSheet.innerHTML = `
-  @keyframes float {
-    0% { transform: translate(0px, 0px); }
-    25% { transform: translate(4px, -4px); }
-    50% { transform: translate(0px, -8px); }
-    75% { transform: translate(-4px, -4px); }
-    100% { transform: translate(0px, 0px); }
-  }`;
-  document.head.appendChild(styleSheet);
-  floatKeyframesInjected = true;
-}
-
 export function ShopButton({
   label,
   onClick,
@@ -90,10 +67,6 @@ export function ShopButton({
   imageSrc,
   description,
 }: ShopButtonProps) {
-  useEffect(() => {
-    ensureFloatKeyframes();
-  }, []);
-
   return (
     <button
       type="button"

--- a/src/StrenuousPortal.tsx
+++ b/src/StrenuousPortal.tsx
@@ -28,7 +28,7 @@ import goblinMarketImage from "./GoblinMarket.png";
 import { BackButton } from "./BackButton";
 import styles from "./StrenuousPortal.module.css";
 import { ShopButton } from "./ShopButton";
-import { getShopButtonStyle } from "./shopButtonStyles";
+import { getShopButtonStyle, sortShopButtons } from "./shopButtonStyles";
 
 type StrenuousShop = {
   key: string;
@@ -197,6 +197,8 @@ export function StrenuousPortal({
     },
   ];
 
+  const sortedShops = sortShopButtons(shops);
+
   return (
     <div
       className={styles.wrapper}
@@ -214,7 +216,7 @@ export function StrenuousPortal({
         </div>
 
         <div className={styles.buttonGrid}>
-          {shops.map((shop) => (
+          {sortedShops.map((shop) => (
             <ShopButton
               key={shop.key}
               label={shop.label}

--- a/src/WithholdParker.tsx
+++ b/src/WithholdParker.tsx
@@ -8,7 +8,7 @@ import silentOathImage from "./Silent Oath.png";
 import { BackButton } from "./BackButton";
 import styles from "./WithholdParker.module.css";
 import { ShopButton } from "./ShopButton";
-import { getShopButtonStyle } from "./shopButtonStyles";
+import { getShopButtonStyle, sortShopButtons } from "./shopButtonStyles";
 
 type WithholdShop = {
   key: string;
@@ -63,6 +63,8 @@ export function WithholdParker({
     },
   ];
 
+  const sortedShops = sortShopButtons(shops);
+
   return (
     <div
       className={styles.wrapper}
@@ -80,7 +82,7 @@ export function WithholdParker({
         </div>
 
         <div className={styles.buttonGrid}>
-          {shops.map((shop) => (
+          {sortedShops.map((shop) => (
             <ShopButton
               key={shop.key}
               label={shop.label}

--- a/src/shopButtonStyles.ts
+++ b/src/shopButtonStyles.ts
@@ -3,10 +3,23 @@ export type ShopButtonStyle = {
   color?: string;
 };
 
+type ColorRule = {
+  name: string;
+  matcher: (color: string) => boolean;
+};
+
 const defaultStyle: ShopButtonStyle = {
   backgroundColor: "rgba(30, 41, 59, 0.82)",
   color: "#f8fafc",
 };
+
+const colorRules: ColorRule[] = [
+  { name: "white", matcher: (color) => color.includes("255, 255, 255") },
+  { name: "red", matcher: (color) => color.includes("220, 38, 38") },
+  { name: "yellow", matcher: (color) => color.includes("250, 204, 21") },
+  { name: "green", matcher: (color) => color.includes("34, 197, 94") },
+  { name: "blue", matcher: (color) => color.includes("37, 99, 235") },
+];
 
 const styleMap: Record<string, ShopButtonStyle> = {
   "auction house": { backgroundColor: "rgba(138, 253, 244, 0.712)" },
@@ -78,6 +91,16 @@ function normalizeLabel(label: string) {
   return label.replace(/’/g, "'").trim().toLowerCase();
 }
 
+function getColorRank(backgroundColor?: string) {
+  if (!backgroundColor) {
+    return colorRules.length;
+  }
+  const matchIndex = colorRules.findIndex((rule) =>
+    rule.matcher(backgroundColor)
+  );
+  return matchIndex === -1 ? colorRules.length : matchIndex;
+}
+
 export function getShopButtonStyle(label: string): ShopButtonStyle {
   const normalized = normalizeLabel(label);
   return styleMap[normalized] ?? defaultStyle;
@@ -85,4 +108,21 @@ export function getShopButtonStyle(label: string): ShopButtonStyle {
 
 export function getDefaultShopButtonStyle(): ShopButtonStyle {
   return defaultStyle;
+}
+
+export function sortShopButtons<T extends { label: string; backgroundColor?: string }>(
+  buttons: T[]
+): T[] {
+  return [...buttons].sort((a, b) => {
+    const colorRankA = getColorRank(
+      a.backgroundColor ?? getShopButtonStyle(a.label).backgroundColor
+    );
+    const colorRankB = getColorRank(
+      b.backgroundColor ?? getShopButtonStyle(b.label).backgroundColor
+    );
+    if (colorRankA !== colorRankB) {
+      return colorRankA - colorRankB;
+    }
+    return normalizeLabel(a.label).localeCompare(normalizeLabel(b.label));
+  });
 }


### PR DESCRIPTION
### Motivation
- Stop the drifting/floating motion on shop buttons for a steadier UI and to honor the recent request to remove float behavior. 
- Ensure shop lists are presented consistently by grouping buttons by color priority (white, red, yellow, green, blue) and alphabetizing within groups for predictable navigation. 

### Description
- Removed the floating animation and its runtime keyframe injection from `src/ShopButton.tsx` and dropped the `animation`/injection `useEffect` so buttons no longer float. 
- Added color-based sorting utilities to `src/shopButtonStyles.ts` (`colorRules`, `getColorRank`, `sortShopButtons`) and kept `getShopButtonStyle` to infer colors when a button has no explicit `backgroundColor`. 
- Wired sorting into the app by importing and using `sortShopButtons` in many sandbox components and portal lists (examples: `src/AnalepticHoltTeag.tsx`, `src/BallisticBellowsCaleb.tsx`, `src/BigHome.tsx`, `src/ButtingRams.tsx`, `src/ByfordDolphinRobertson.tsx`, `src/CalidrisFisk.tsx`, `src/Graveborn.tsx`, `src/HebronJoshua.tsx`, `src/JellyCity.tsx`, `src/MeanderMichael.tsx`, `src/MerricksMeadowHoward.tsx`, `src/OrbitingCity.tsx`, `src/SeymoursDriftMelanie.tsx`, `src/StrenuousPortal.tsx`, `src/WithholdParker.tsx`) so each shop grid maps over `sortedShops`. 
- Updated `src/Map.tsx` to use `sortShopButtons` for the global `EveryShop` list and to alphabetize the Sandbox Destinations menu (`sortedEveryShopButtons` and `sortedSandboxTowns`). 

### Testing
- Ran the development server with `npm start` and the app compiled and served successfully with ESLint/TypeScript warnings but no hard failures. 
- Executed a Playwright smoke script (headless Firefox) which navigated the UI and produced screenshots (`artifacts/strenuous-portal.png` and `artifacts/sandbox-destinations.png`) confirming UI screens render without floating buttons. 
- No unit tests were added; the primary automated checks were `npm start` and the Playwright screenshot script, both of which completed successfully (server started and screenshots captured).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fbac59e488329b6a508e93c7edd31)