### PR TITLE
Move ShopButton styles to CSS module and improve interactions

### DIFF
--- a/src/ShopButton.module.css
+++ b/src/ShopButton.module.css
@@ -1,0 +1,62 @@
+.button {
+  font-size: 1.5rem;
+  padding: 1.25rem 1.5rem;
+  border-radius: 18px;
+  border: 2px solid #fff;
+  box-shadow: 0 7px 12px rgba(0, 0, 0, 0.5);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  font-family: "Times New Roman", serif;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.85rem;
+  width: 100%;
+  max-width: 100%;
+  text-align: center;
+}
+
+.button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 16px rgba(0, 0, 0, 0.45);
+}
+
+.button:active {
+  transform: translateY(0);
+  box-shadow: 0 6px 10px rgba(0, 0, 0, 0.4);
+}
+
+.button:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.9);
+  outline-offset: 4px;
+}
+
+.buttonContent {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+}
+
+.buttonImage {
+  object-fit: contain;
+  border-radius: 14px;
+  border: 2px solid rgba(255, 255, 255, 0.6);
+  background-color: rgba(255, 255, 255, 0.85);
+  box-shadow: 4px 4px 8px rgba(0, 0, 0, 0.35);
+}
+
+.buttonLabel {
+  display: block;
+  font-weight: 700;
+  text-align: center;
+}
+
+.buttonDescription {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.45;
+  text-align: center;
+  max-width: 720px;
+}

--- a/src/ShopButton.tsx
+++ b/src/ShopButton.tsx
@@ -1,5 +1,7 @@
 import type { CSSProperties, ReactNode } from "react";
 
+import styles from "./ShopButton.module.css";
+
 export type ShopButtonProps = {
   label: string;
   onClick: () => void;
@@ -11,50 +13,9 @@ export type ShopButtonProps = {
 };
 
 const buttonStyles: Record<string, CSSProperties> = {
-  button: {
-    fontSize: "1.5rem",
-    padding: "1.25rem 1.5rem",
-    borderRadius: "18px",
-    border: "2px solid #ffffffff",
-    boxShadow: "0 7px 12px rgba(0, 0, 0, 0.5)",
-    cursor: "pointer",
-    transition: "transform 0.3s ease",
-    fontFamily: "'Times New Roman', serif",
-    display: "flex",
-    flexDirection: "column",
-    alignItems: "center",
-    gap: "0.85rem",
-    width: "100%",
-    maxWidth: "100%",
-    textAlign: "center",
-  },
-  buttonContent: {
-    display: "flex",
-    flexDirection: "column",
-    alignItems: "center",
-    gap: "0.5rem",
-    width: "100%",
-  },
   buttonImage: {
     width: "160px",
     height: "auto",
-    objectFit: "contain",
-    borderRadius: "14px",
-    border: "2px solid rgba(255, 255, 255, 0.6)",
-    backgroundColor: "rgba(255,255,255,0.85)",
-    boxShadow: "4 4px 8px rgba(0,0,0,0.35)",
-  },
-  buttonLabel: {
-    display: "block",
-    fontWeight: 700,
-    textAlign: "center",
-  },
-  buttonDescription: {
-    margin: 0,
-    fontSize: "0.95rem",
-    lineHeight: 1.45,
-    textAlign: "center",
-    maxWidth: "720px",
   },
 };
 
@@ -71,20 +32,25 @@ export function ShopButton({
     <button
       type="button"
       onClick={onClick}
+      className={styles.button}
       style={{
-        ...buttonStyles.button,
         animationDelay: delay,
         backgroundColor,
         color,
       }}
     >
       {imageSrc ? (
-        <div style={buttonStyles.buttonContent}>
-          <img src={imageSrc} alt={`${label} logo`} style={buttonStyles.buttonImage} />
-          <span style={buttonStyles.buttonLabel}>{label}</span>
+        <div className={styles.buttonContent}>
+          <img
+            src={imageSrc}
+            alt={`${label} logo`}
+            className={styles.buttonImage}
+            style={buttonStyles.buttonImage}
+          />
+          <span className={styles.buttonLabel}>{label}</span>
           {description ? (
             typeof description === "string" ? (
-              <p style={buttonStyles.buttonDescription}>{description}</p>
+              <p className={styles.buttonDescription}>{description}</p>
             ) : (
               description
             )


### PR DESCRIPTION
### Motivation
- Reduce inline style duplication and enable richer hover/focus/active interactions by moving layout and interaction styles into a CSS module.
- Preserve dynamic properties like `backgroundColor`, `color`, and `animationDelay` inline so buttons can remain data-driven.

### Description
- Added `src/ShopButton.module.css` containing button layout, hover/active/ focus-visible, content, image, label, and description styles.
- Updated `src/ShopButton.tsx` to import the CSS module and apply class names for layout and interactions while keeping `backgroundColor`, `color`, and `animationDelay` set inline.
- Reduced inline style object to only the image sizing and minimal inline properties, and corrected image box-shadow/border visuals in the CSS module.

### Testing
- Started the dev server with `npm start` which compiled the app successfully but emitted ESLint warnings (build succeeded with warnings). 
- Captured a visual regression snapshot by running a Playwright script which produced `artifacts/shop-button.png` successfully. 
- No unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69701d825940832987361fe4507cc204)