### PR TITLE
Preserve configured order for Sandbox destination buttons

### DIFF
--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -868,9 +868,7 @@ function SandboxMenu({
   onBack: () => void;
   onNavigate: (key: string) => void;
 }) {
-  const sortedSandboxTowns = [...sandboxTowns].sort((a, b) =>
-    a.name.localeCompare(b.name)
-  );
+  const orderedSandboxTowns = sandboxTowns;
 
   return (
     <div style={styles.wrapper}>
@@ -893,7 +891,7 @@ function SandboxMenu({
         </div>
       </div>
       <div style={styles.sandboxGrid}>
-        {sortedSandboxTowns.map((town) => (
+        {orderedSandboxTowns.map((town) => (
             <FloatingButton
               key={town.key}
               label={town.name}


### PR DESCRIPTION
### Motivation
- The Sandbox destinations menu should present buttons in the intentionally defined order in `sandboxTowns` rather than sorting them alphabetically.

### Description
- Remove alphabetical sorting and iterate the original `sandboxTowns` order in `src/Map.tsx` so the UI follows the configured sequence.

### Testing
- Started the dev server with `npm start`, the app compiled and served with lint warnings (no build failure).
- A Playwright check loaded the app and captured a screenshot of the Sandbox Destinations page successfully, producing an artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970291176ac832988b6c7e593e39955)