### PR TITLE
Replace Sleuth University with Pearl's Potions in Strenuous Portal; add N.M.E. to Calidris

### DIFF
--- a/src/CalidrisFisk.tsx
+++ b/src/CalidrisFisk.tsx
@@ -8,6 +8,7 @@ import robinsRopesImage from "./Robins Ropes.png";
 import bulletsBuffsBeyondImage from "./Bullets Buffs and Beyond.webp";
 import supremeSmithyImage from "./Supreme Smithy.png";
 import willsWeaponsImage from "./Wills Weapons.png";
+import nmeImage from "./N.M.E.png";
 import { BackButton } from "./BackButton";
 import styles from "./CalidrisFisk.module.css";
 import { ShopButton } from "./ShopButton";
@@ -81,6 +82,12 @@ export function CalidrisFisk({
       label: "Will's Weapons",
       image: willsWeaponsImage,
       onClick: () => onNavigate("WillsWeapons"),
+    },
+    {
+      key: "nme",
+      label: "N.M.E.",
+      image: nmeImage,
+      onClick: () => onNavigate("NME"),
     },
   ];
 

--- a/src/StrenuousPortal.tsx
+++ b/src/StrenuousPortal.tsx
@@ -22,7 +22,7 @@ import floralImage from "./Floral.webp";
 import golemWorkshopImage from "./Golem Work Shop.png";
 import jewelryGuildImage from "./Jewelry Guild.png";
 import nmeImage from "./N.M.E.png";
-import sleuthUniversityImage from "./Sleuth.webp";
+import pearlsPotionsImage from "./Pearls Potions.png";
 import fizzyTaleImage from "./FizzyTale.png";
 import goblinMarketImage from "./GoblinMarket.png";
 import { BackButton } from "./BackButton";
@@ -178,10 +178,10 @@ export function StrenuousPortal({
       onClick: () => onNavigate("NME"),
     },
     {
-      key: "sleuth-university",
-      label: "Sleuth University",
-      image: sleuthUniversityImage,
-      onClick: () => onNavigate("SleuthUniversity"),
+      key: "pearls-potions",
+      label: "Pearl's Potions",
+      image: pearlsPotionsImage,
+      onClick: () => onNavigate("PearlsPotions"),
     },
     {
       key: "fizzy-tales",


### PR DESCRIPTION
### Motivation
- Implement requested content updates: add Pearl's Potions to the Strenuous Portal, remove Sleuth University from that portal, and add N.M.E. to Calidris.

### Description
- Replaced the Sleuth University entry with `Pearl's Potions` in `src/StrenuousPortal.tsx` and imported `Pearls Potions.png` for the shop image.
- Added `N.M.E.` to the shops list in `src/CalidrisFisk.tsx` and imported `N.M.E.png` for the shop image.
- Changes update the navigation targets to `PearlsPotions` and `NME` respectively so the existing routing and shop components are reused.

### Testing
- Ran `npm run build` successfully (build completed; existing ESLint warnings unrelated to this change were reported). 
- Started the dev server with `npm start` and the app compiled (warnings only). 
- Captured a UI screenshot of the updated Strenuous Portal via an automated Playwright script, confirming the new `Pearl's Potions` entry is present. 
- Attempted an automated screenshot for Calidris but the browser container crashed when launching Chromium (SIGSEGV), so the Calidris UI verification could not be captured in that run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b623b45b083298644c5d757968d6b)