### PR TITLE
Sort Ye Old Home Depot items by price

### DIFF
--- a/src/YeOldHomeDepot.tsx
+++ b/src/YeOldHomeDepot.tsx
@@ -8,6 +8,21 @@ import sleuthBackground from "./Ye Old Home Depot.webp";
 
 type DisplayItem = YeOldHomeDepotItem & { finalPrice: number };
 
+function sortByPrice(a: DisplayItem, b: DisplayItem): number {
+  const aHasVariablePrice = Boolean(a.priceText);
+  const bHasVariablePrice = Boolean(b.priceText);
+
+  if (aHasVariablePrice !== bHasVariablePrice) {
+    return aHasVariablePrice ? 1 : -1;
+  }
+
+  if (a.finalPrice !== b.finalPrice) {
+    return a.finalPrice - b.finalPrice;
+  }
+
+  return a.name.localeCompare(b.name);
+}
+
 function calculateAdjustedPrice(item: Item, priceVariability: number): number {
   const variability = ((Math.random() * priceVariability) / 100) * item.price;
   const upOrDown = Math.random() < 0.5 ? -1 : 1;
@@ -30,7 +45,8 @@ export function YeOldHomeDepot({ onBack }: { onBack?: () => void }) {
           item.price > 0
             ? calculateAdjustedPrice(item, tribeYeOldHomeDepot.priceVariability)
             : 0,
-      })),
+      }))
+      .sort(sortByPrice),
     []
   );
 


### PR DESCRIPTION
### Motivation
- Improve the shop UX by presenting inventory in a predictable, price-ordered way so customers can easily find cheaper or more expensive items.
- Ensure items with non-fixed prices (services/rentals) do not interfere with numeric ordering and remain visible after fixed-price goods.

### Description
- Added a `sortByPrice` comparator that places fixed-price items before variable-price items, orders by `finalPrice` ascending, and uses `name` as a stable tie-breaker.
- Applied the comparator to the memoized `displayItems` array after computing `finalPrice` so adjusted/randomized pricing remains intact while presentation is ordered.
- Kept existing `calculateAdjustedPrice` and `formatPrice` behaviors unchanged.

### Testing
- Ran `npm run build` which completed successfully (the repo still contains unrelated ESLint warnings that existed before this change).
- Launched the dev server and executed a Playwright script to open the app and navigate to the Ye Old Home Depot view, and captured a screenshot to validate item ordering in the UI (screenshot produced successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c1c3703e4832992d002a952f11469)