### PR TITLE
Fix BellTier type mismatch in JellBell click handler

### DIFF
--- a/src/JellBell.tsx
+++ b/src/JellBell.tsx
@@ -19,6 +19,10 @@ import { SlimeStatBlock } from "./SlimeStatBlock";
 type DisplayItem = JellBellItem & { finalPrice: number };
 type BellTier = "3 Star Bell" | "4 Star Bell" | "5 Star Bell";
 
+function isBellTier(name: string): name is BellTier {
+  return name === "3 Star Bell" || name === "4 Star Bell" || name === "5 Star Bell";
+}
+
 function calculateAdjustedPrice(item: Item, priceVariability: number): number {
   const variability = ((Math.random() * priceVariability) / 100) * item.price;
   const upOrDown = Math.random() < 0.5 ? -1 : 1;
@@ -50,7 +54,12 @@ export function JellBell({ onBack }: { onBack?: () => void }) {
     return `${item.finalPrice.toLocaleString()} Gold`;
   };
 
-  const handleBellClick = (tier: BellTier) => {
+  const handleBellClick = (tierName: string) => {
+    if (!isBellTier(tierName)) {
+      return;
+    }
+
+    const tier = tierName;
     if (isSpinning) {
       return;
     }
@@ -198,8 +207,7 @@ export function JellBell({ onBack }: { onBack?: () => void }) {
         />
         <section className={styles.grid} aria-label="Available items">
           {displayItems.map((item, index) => {
-            const isBellTier =
-              item.name === "3 Star Bell" || item.name === "4 Star Bell" || item.name === "5 Star Bell";
+            const itemIsBellTier = isBellTier(item.name);
 
             return (
               <article
@@ -209,7 +217,7 @@ export function JellBell({ onBack }: { onBack?: () => void }) {
                 <h2 className={styles.cardTitle}>{item.name}</h2>
                 <p className={styles.description}>{item.description}</p>
                 <p className={styles.price}>{formatPrice(item)}</p>
-                {isBellTier && (
+                {itemIsBellTier && (
                   <button
                     className={styles.generateButton}
                     type="button"


### PR DESCRIPTION
### Motivation
- A TypeScript error occurred where `item.name` (a `string`) was passed to a handler expecting `BellTier`, producing `TS2345` for the `onClick` in `JellBell`.
- The intent is to allow wiring buttons from the item list (which provides `name` as `string`) to the existing bell-handling logic while preserving type safety.

### Description
- Added an `isBellTier` type guard function to narrow `string` values to the union type `BellTier` (`"3 Star Bell" | "4 Star Bell" | "5 Star Bell"`).
- Changed `handleBellClick` to accept a `string` parameter (`tierName: string`) and validate it with `isBellTier` before proceeding to use it as a `BellTier`.
- Replaced the inline boolean check in the render loop with `const itemIsBellTier = isBellTier(item.name)` and left the `onClick` calling `handleBellClick(item.name)` so narrowing happens inside the handler.
- All changes are contained in `src/JellBell.tsx`.

### Testing
- Ran `npm run build` and the build completed successfully after the fix (the build previously failed with the `TS2345` error before the type-guard changes).
- The build emits unrelated ESLint warnings in other files but completes and produces the production build artifacts as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994adb0e3808329b7623ee1b1cbadc1)