### PR TITLE
Adjust Jell Bell spin pacing and result panel placement

### DIFF
--- a/src/JellBell.module.css
+++ b/src/JellBell.module.css
@@ -182,7 +182,7 @@
 
 .resultPanel {
   width: 100%;
-  max-width: 1050px;
+  max-width: 780px;
   border-radius: 22px;
   border: 2px solid rgba(251, 191, 36, 0.7);
   padding: 1.2rem;
@@ -199,7 +199,7 @@
 .roulette {
   margin: 0;
   color: #bfdbfe;
-  animation: rouletteSpin 0.18s linear infinite;
+  animation: rouletteSpin 0.75s linear infinite;
 }
 
 @keyframes rouletteSpin {

--- a/src/JellBell.tsx
+++ b/src/JellBell.tsx
@@ -18,6 +18,7 @@ import { SlimeStatBlock } from "./SlimeStatBlock";
 
 type DisplayItem = JellBellItem & { finalPrice: number };
 type BellTier = "3 Star Bell" | "4 Star Bell" | "5 Star Bell";
+const SPIN_DURATION_MS = 2400;
 
 function isBellTier(name: string): name is BellTier {
   return name === "3 Star Bell" || name === "4 Star Bell" || name === "5 Star Bell";
@@ -76,7 +77,7 @@ export function JellBell({ onBack }: { onBack?: () => void }) {
         setGeneratedSlimes([]);
       }
       setIsSpinning(false);
-    }, 1100);
+    }, SPIN_DURATION_MS);
   };
 
   const renderResultPanel = () => {
@@ -205,6 +206,9 @@ export function JellBell({ onBack }: { onBack?: () => void }) {
           insults={tribeJellBell.insults}
           shopName={tribeJellBell.name}
         />
+
+        {renderResultPanel()}
+
         <section className={styles.grid} aria-label="Available items">
           {displayItems.map((item, index) => {
             const itemIsBellTier = isBellTier(item.name);
@@ -231,7 +235,6 @@ export function JellBell({ onBack }: { onBack?: () => void }) {
           })}
         </section>
 
-        {renderResultPanel()}
       </main>
     </div>
   );


### PR DESCRIPTION
### Motivation
- Make the Jell Bell generation feel slower and more dramatic by increasing the spin/delay duration. 
- Ensure generated results appear directly beneath the insult/dialogue box so the outcome is visually adjacent to the dialog. 
- Tweak result styling so the results panel matches the content column width for a cleaner layout.

### Description
- Added `SPIN_DURATION_MS = 2400` and used it for the spin timeout in `src/JellBell.tsx` to lengthen the generation delay instead of the previous hard-coded `1100ms` value. 
- Moved the `renderResultPanel()` call in `src/JellBell.tsx` to render immediately after the `InsultBox` so results appear under the insult/dialogue area and above the item grid. 
- Updated `src/JellBell.module.css` to reduce `.resultPanel` `max-width` from `1050px` to `780px` and slowed the `.roulette` animation from `0.18s` to `0.75s` so the textual spin indication feels longer.

### Testing
- Ran `npm run build` and the project built successfully (compiler emitted unrelated eslint warnings). 
- Launched the dev server with `npm start` and confirmed the app served and compiled. 
- Automated navigation and screenshot via Playwright to open the app and navigate to **Strenuous Portal → Jell Bell** and capture `artifacts/jellbell-results-layout.png`, confirming the new layout and longer spin behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994af3bde7c83299c67a505e08e057c)