### PR TITLE
Remove Jazz's Portable Potions from Big Home

### DIFF
--- a/src/BigHome.tsx
+++ b/src/BigHome.tsx
@@ -31,7 +31,6 @@ import blossomHotelImage from "./Blossom Hotel.png";
 import evansEnchantingEmporiumImage from "./Evan's Enchanting Emporium.png";
 import fairiesOfFloraImage from "./Floral.webp";
 import golemWorkshopImage from "./Golem Work Shop.png";
-import jazzPortablePotionsImage from "./Jazz's Portable Potions.png";
 import jewelryGuildImage from "./Jewelry Guild.png";
 import labyrinthineLibraryImage from "./Labyrinthine Labrary.png";
 import nmeImage from "./N.M.E.png";
@@ -227,12 +226,6 @@ export function BigHome({
       label: "Golem Workshop",
       image: golemWorkshopImage,
       onClick: () => onNavigate("GolemWorkshop"),
-    },
-    {
-      key: "jazz-portable-potions",
-      label: "Jazz's Portable Potions",
-      image: jazzPortablePotionsImage,
-      onClick: () => onNavigate("JazzPortablePotions"),
     },
     {
       key: "labyrinthine-library",


### PR DESCRIPTION
### Motivation
- Remove the "Jazz's Portable Potions" tile from the Big Home shop list so it no longer appears in that view.

### Description
- Deleted the `Jazz's Portable Potions` image import and removed its shop entry in `src/BigHome.tsx` so the shop is no longer included in the `Big Home` shop array.

### Testing
- Ran `npm run build` which completed successfully and launched the app with `npm start`, and captured a Playwright screenshot to verify the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e845fed688329b68c097690ce478a)