### PR TITLE
Remove Hug Cartel and Golem Workshop from Big Home

### DIFF
--- a/src/BigHome.tsx
+++ b/src/BigHome.tsx
@@ -20,7 +20,6 @@ import pearlsPotionsImage from "./Pearls Potions.png";
 import provisionsParadiseImage from "./Provisions Paradise.png";
 import piggyBankImage from "./Piggy Bank.png";
 import yeOldDonkeyImage from "./Ye Old Donkey.png";
-import hugImage from "./Hug.webp";
 import iconicDragonicImage from "./Iconic Dragonic.png";
 import jellBellImage from "./Jell.webp";
 import monsterMakerImage from "./Monster.webp";
@@ -30,7 +29,6 @@ import valhallaMartImage from "./Valhalla Mart.png";
 import blossomHotelImage from "./Blossom Hotel.png";
 import evansEnchantingEmporiumImage from "./Evan's Enchanting Emporium.png";
 import fairiesOfFloraImage from "./Floral.webp";
-import golemWorkshopImage from "./Golem Work Shop.png";
 import jazzPortablePotionsImage from "./Jazz's Portable Potions.png";
 import jewelryGuildImage from "./Jewelry Guild.png";
 import labyrinthineLibraryImage from "./Labyrinthine Labrary.png";
@@ -163,12 +161,6 @@ export function BigHome({
       onClick: () => onNavigate("YeOldDonkey"),
     },
     {
-      key: "hug-cartel",
-      label: "Hug Cartel",
-      image: hugImage,
-      onClick: () => onNavigate("HugInfo"),
-    },
-    {
       key: "iconic-dragonic",
       label: "Iconic Dragonic",
       image: iconicDragonicImage,
@@ -221,12 +213,6 @@ export function BigHome({
       label: "Fairies of Flora",
       image: fairiesOfFloraImage,
       onClick: () => onNavigate("FairiesOfFlora"),
-    },
-    {
-      key: "golem-workshop",
-      label: "Golem Workshop",
-      image: golemWorkshopImage,
-      onClick: () => onNavigate("GolemWorkshop"),
     },
     {
       key: "jazz-portable-potions",


### PR DESCRIPTION
### Motivation
- Remove the `Hug Cartel` and `Golem Workshop` entries from the Big Home UI and clean up their now-unused image imports.

### Description
- Deleted the `hug-cartel` and `golem-workshop` shop objects from the `shops` array and removed the corresponding `Hug.webp` and `Golem Work Shop.png` imports in `src/BigHome.tsx`.

### Testing
- Ran `npm run build` which completed successfully (production build created) with pre-existing ESLint warnings unrelated to this change; a Playwright-based screenshot attempt failed because Chromium crashed in this environment (SIGSEGV / `TargetClosedError`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e8606ba9c8329aa7b44607b4b4667)