### PR TITLE
Remove Jazz's Portable Potions from Big Home

### DIFF
--- a/src/BigHome.tsx
+++ b/src/BigHome.tsx
@@ -29,7 +29,6 @@ import valhallaMartImage from "./Valhalla Mart.png";
 import blossomHotelImage from "./Blossom Hotel.png";
 import evansEnchantingEmporiumImage from "./Evan's Enchanting Emporium.png";
 import fairiesOfFloraImage from "./Floral.webp";
-import jazzPortablePotionsImage from "./Jazz's Portable Potions.png";
 import jewelryGuildImage from "./Jewelry Guild.png";
 import labyrinthineLibraryImage from "./Labyrinthine Labrary.png";
 import nmeImage from "./N.M.E.png";
@@ -213,12 +212,6 @@ export function BigHome({
       label: "Fairies of Flora",
       image: fairiesOfFloraImage,
       onClick: () => onNavigate("FairiesOfFlora"),
-    },
-    {
-      key: "jazz-portable-potions",
-      label: "Jazz's Portable Potions",
-      image: jazzPortablePotionsImage,
-      onClick: () => onNavigate("JazzPortablePotions"),
     },
     {
       key: "labyrinthine-library",


### PR DESCRIPTION
### Motivation
- Remove the `Jazz's Portable Potions` shop from the Big Home listing so it no longer appears as a selectable location in the Big Home UI.

### Description
- Deleted the `Jazz's Portable Potions` image import and removed the shop entry (key `jazz-portable-potions`) from `src/BigHome.tsx`.

### Testing
- Ran `npm run build` which completed successfully (only existing lint warnings reported).
- Executed an automated Playwright script against the running dev server that loaded Big Home and captured a screenshot to validate the entry is no longer present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e8a7423a08329ac63eb90285edbb1)