### PR TITLE
Add layered Jell Bell slime artwork preview

### DIFF
--- a/src/JellBell.module.css
+++ b/src/JellBell.module.css
@@ -240,6 +240,32 @@
   color: #bae6fd;
 }
 
+
+.slimeArt {
+  position: relative;
+  width: min(100%, 260px);
+  aspect-ratio: 1;
+  margin: 0 auto 0.9rem;
+  border-radius: 14px;
+  overflow: hidden;
+  background: rgba(15, 23, 42, 0.5);
+  border: 1px solid rgba(251, 191, 36, 0.35);
+}
+
+.slimeLayer {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.flavorOverlay {
+  position: absolute;
+  inset: 0;
+  mix-blend-mode: multiply;
+  pointer-events: none;
+}
 .statsGrid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/src/SlimeStatBlock.tsx
+++ b/src/SlimeStatBlock.tsx
@@ -1,13 +1,34 @@
 import { GeneratedSlime } from "./jellBellGenerator";
 import styles from "./JellBell.module.css";
+import {
+  accessoryLayerByType,
+  bodyLayerByType,
+  flavorColorByType,
+  temperamentLayerByType,
+} from "./slimeVisuals";
 
 export function SlimeStatBlock({ slime }: { slime: GeneratedSlime }) {
+  const bodyLayer = bodyLayerByType[slime.bodyType.label];
+  const temperamentLayer = temperamentLayerByType[slime.temperament.label];
+  const accessoryLayer = accessoryLayerByType[slime.accessory.label];
+  const flavorColor = flavorColorByType[slime.flavor.label] ?? "rgba(148, 163, 184, 0.4)";
+
   return (
     <article className={styles.statBlock}>
       <h3 className={styles.statTitle}>{slime.name}</h3>
       <p className={styles.statSubline}>
         {slime.size.label} Ooze (Companion), {slime.bodyType.label} body
       </p>
+      <div className={styles.slimeArt} aria-label={`${slime.name} layered art preview`}>
+        {bodyLayer && <img className={styles.slimeLayer} src={bodyLayer} alt={`${slime.bodyType.label} body`} />}
+        {temperamentLayer && (
+          <img className={styles.slimeLayer} src={temperamentLayer} alt={`${slime.temperament.label} temperament`} />
+        )}
+        <div className={styles.flavorOverlay} style={{ backgroundColor: flavorColor }} aria-hidden="true" />
+        {accessoryLayer && (
+          <img className={styles.slimeLayer} src={accessoryLayer} alt={`${slime.accessory.label} accessory`} />
+        )}
+      </div>
       <div className={styles.statsGrid}>
         <p>
           <strong>Armor Class:</strong> {slime.size.armorClass}

--- a/src/slimeVisuals.ts
+++ b/src/slimeVisuals.ts
@@ -1,0 +1,66 @@
+import bubbly from "./Jell Bell images/Bubbly.png";
+import chunky from "./Jell Bell images/Chunky.png";
+import jiggly from "./Jell Bell images/Jiggly.png";
+import liquidy from "./Jell Bell images/Liquidy.png";
+import rubbery from "./Jell Bell images/Rubbery.png";
+import slippery from "./Jell Bell images/Slippery.png";
+import sticky from "./Jell Bell images/Sticky.png";
+import bouncy from "./Jell Bell images/Bouncy.png";
+import slappy from "./Jell Bell images/Slappy.png";
+import zippy from "./Jell Bell images/Zippy.png";
+import hardy from "./Jell Bell images/Hardy.png";
+import smarty from "./Jell Bell images/Smarty.png";
+import jumpy from "./Jell Bell images/Jumpy.png";
+import happy from "./Jell Bell images/Happy.png";
+import cuteBow from "./Jell Bell images/Cute_Bow.png";
+import outfit from "./Jell Bell images/Outfit.png";
+import glitter from "./Jell Bell images/Glitter.png";
+import blanket from "./Jell Bell images/Blanket.png";
+import smallHat from "./Jell Bell images/Small_Hat.png";
+import bracelet from "./Jell Bell images/Bracelet.png";
+import slimePlush from "./Jell Bell images/Slime_Plush.png";
+
+export const bodyLayerByType: Record<string, string> = {
+  Liquidy: liquidy,
+  Bubbly: bubbly,
+  Jiggly: jiggly,
+  Rubbery: rubbery,
+  Sticky: sticky,
+  Bouncy: bouncy,
+  Slippery: slippery,
+  Chunky: chunky,
+};
+
+export const temperamentLayerByType: Record<string, string> = {
+  Slappy: slappy,
+  Zippy: zippy,
+  Hardy: hardy,
+  Smarty: smarty,
+  Jumpy: jumpy,
+  Happy: happy,
+};
+
+export const accessoryLayerByType: Record<string, string> = {
+  "Cute Bow": cuteBow,
+  "An Outfit": outfit,
+  Glitter: glitter,
+  "Cozy Blanket": blanket,
+  "Tiny Hat": smallHat,
+  "Friendship Bracelet": bracelet,
+  "Slime Plushie": slimePlush,
+};
+
+export const flavorColorByType: Record<string, string> = {
+  "Pineapple Slime": "rgba(250, 204, 21, 0.48)",
+  "Coconut Slime": "rgba(248, 250, 252, 0.45)",
+  "Mint Slime": "rgba(134, 239, 172, 0.46)",
+  "Cherry Slime": "rgba(248, 113, 113, 0.5)",
+  "Vanilla Slime": "rgba(253, 230, 138, 0.42)",
+  "Lemon Slime": "rgba(253, 224, 71, 0.52)",
+  "Grape Slime": "rgba(167, 139, 250, 0.5)",
+  "Durian Slime": "rgba(132, 204, 22, 0.46)",
+  "Lime Slime": "rgba(74, 222, 128, 0.5)",
+  "Plum Slime": "rgba(192, 132, 252, 0.5)",
+  "Orange Slime": "rgba(251, 146, 60, 0.52)",
+  "Banana Slime": "rgba(255, 255, 102, 0.5)",
+};


### PR DESCRIPTION
### Motivation
- The Jell Bell images were uploaded and the UI needs to compose them into a layered slime preview when generating slimes so the visual matches the selected traits.

### Description
- Add a new mapping module `src/slimeVisuals.ts` that maps body types, temperaments, accessories, and flavor -> tint color to the uploaded image assets.
- Update `src/SlimeStatBlock.tsx` to render layered artwork in the requested order: body + temperament image layers, then a flavor color overlay, then the accessory layer on top, with safe fallbacks if an asset is missing.
- Add CSS in `src/JellBell.module.css` to create the layered canvas (`.slimeArt`), absolute-stacked image layers (`.slimeLayer`), and a multiply-mode flavor overlay (`.flavorOverlay`).
- Keep existing textual stats intact so options without uploaded images still display their info.

### Testing
- Ran `npm run build` and the production build completed successfully (compiled with unrelated ESLint warnings). 
- Ran an automated Playwright browser check that opened the app, navigated to Every Shop → Jell Bell, clicked `Generate 3 Star Slime`, waited for the result, and captured a screenshot (`artifacts/jellbell-layered-slime.png`), confirming the layered preview rendered as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a08731fb9083298959f2f7a4e97203)