### PR TITLE
Add settlement-based inventory availability and context; propagate settlement type from Map

### DIFF
--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -116,6 +116,8 @@ import { ByfordDolphinRobertson } from "./ByfordDolphinRobertson";
 import { Graveborn } from "./Graveborn";
 import { StrenuousPortal } from "./StrenuousPortal";
 import strenuousPortalButtonImage from "./StrenuousPortalButton2.webp";
+import { SettlementProvider } from "./SettlementContext";
+import { SettlementType } from "./inventoryAvailability";
 
 // Remove stray whitespace/newlines from data URIs (defensive)
 function cleanDataUrl(s?: string) {
@@ -158,7 +160,9 @@ function useTextImage(text?: string) {
 
 type SandboxTown = {
   key: string;
+  routeKey: string;
   name: string;
+  settlementType: SettlementType;
   description: string;
   image: string;
 };
@@ -175,105 +179,135 @@ type ShopButton = {
 const sandboxTowns: SandboxTown[] = [
   {
     key: "withhold",
+    routeKey: "Withhold",
     name: "Withhold (Parker)",
+    settlementType: "Thorpe",
     image: sandboxWytheholdeImage,
     description:
       "Nestled between warm rolling hills and jagged, freezing mountains, Withhold grows famous home-grown food but struggles for medicine once winter comes. As they live in Wandering Titan territory, nearly everyone knows how to flee into the tight valley caves when danger looms, preserving the town's dwindling stories.",
   },
   {
     key: "butting-rams",
+    routeKey: "ButtingRams",
     name: "Butting Rams",
+    settlementType: "Hamlet",
     image: sandboxButtingRamsImage,
     description:
       "Barbarians here love fighting, feasting, and boasting about both. Their town is literally split between two enormous rams that butt heads, catapulting residents back and forth—thankfully the rams are fluffy enough to make the landings survivable before the traditional 15-minute free-for-all.",
   },
   {
     key: "meander",
+    routeKey: "Meander",
     name: "Meander (Michael)",
+    settlementType: "Thorpe",
     image: sandboxMeanderImage,
     description:
       "A cowboy's dream that never settles, Meander roams Wandering Titan territory after draining every Magitek Oil spot. Constant desert travel keeps crops from thriving, so the townsfolk trade for food while clinging to a strong moral compass they defend fiercely.",
   },
   {
     key: "calidris",
+    routeKey: "Calidris",
     name: "Calidris (Fisk)",
+    settlementType: "Hamlet",
     image: sandboxCalidrisImage,
     description:
       "Created as an artisans' paradise with no creative limits, Calidris thrived—until every living resident vanished overnight. Only the golems and robots remain, tirelessly working while ignoring their missing masters.",
   },
   {
     key: "merricks-meadow",
+    routeKey: "MerricksMeadow",
     name: "Merrick's Meadow (Howard)",
+    settlementType: "Village",
     image: sandboxMerricksGroveImage,
     description:
       "This humble village boomed after discovering rare herbs. Newcomers flock to Merrick's Meadow for its newfound fame, while longtime residents grumble about the crowds disturbing their once-tranquil home.",
   },
   {
     key: "ballistic-bellows",
+    routeKey: "BallisticBellows",
     name: "Ballistic Bellows (Caleb)",
+    settlementType: "Village",
     image: sandboxBallisticBellowsImage,
     description:
       "Punctual and industrious, every citizen can run a forge or clockwork device. Their advanced weapons self-destruct if reverse engineered, protecting the secrets behind their booming craft.",
   },
   {
     key: "byford-dolphin",
+    routeKey: "ByfordDolphin",
     name: "Byford Dolphin (Robertson)",
+    settlementType: "Village",
     image: sandboxByfordDolphinImage,
     description:
       "Wealth dictates status in Byford Dolphin. Legendary metals pulled from the sea fund the Clockwork King's construction projects, while the richest citizen holds the House of Blades contract—and the bill that comes with it.",
   },
   {
     key: "hebron",
+    routeKey: "Hebron",
     name: "Hebron (Joshua)",
+    settlementType: "Town",
     image: sandboxHebronImage,
     description:
       "After the Missing Millennium, Hebron secured a monopoly on Thunder Cores by salvaging and purchasing every relic they could find. Now it's a hub for minds devoted to unlocking the power behind these remnants.",
   },
   {
     key: "jelly-city",
+    routeKey: "JellyCity",
     name: "Jelly City",
+    settlementType: "Town",
     image: sandboxJellyCityImage,
     description:
       "Built vertically inside a Wandering Titan jellyfish, this flexible city produces medicine that keeps the Disciples of Mother battle-ready. Its secrets are hard to see, but unforgettable once witnessed.",
   },
   {
     key: "pop-n-faith",
+    routeKey: "Sandbox",
     name: "Pop-n Faith (Eli)",
+    settlementType: "City",
     image: sandboxPopNFaithImage,
     description:
       "Sorry, but there is no more Pop-n Faith. Your world deities are gone; now your planet is stuck between death and unlife.",
   },
   {
     key: "analeptic-holt",
+    routeKey: "AnalepticHolt",
     name: "Analeptic Holt (Teag)",
+    settlementType: "City",
     image: sandboxAnalepticHoltImage,
     description:
       "Hidden beneath an ancient jungle canopy, Hadozee gliders live among massive roots and high branches. They cherish harmony with their environment but stay guarded with outsiders to protect their traditions.",
   },
   {
     key: "seymours-drift",
+    routeKey: "SeymoursDrift",
     name: "Seymour's Drift (Melanie)",
+    settlementType: "City",
     image: sandboxSeymoursDriftImage,
     description:
       "A sprawling city on a giant drifting lily pad, Seymour's Drift follows the tides while serving its enigmatic leader, Audrey the Second. Residents bond over devotion, firearms, and an unyielding love of meat.",
   },
   {
     key: "graveborn",
+    routeKey: "Graveborn",
     name: "Graveborn",
+    settlementType: "City",
     image: sandboxGraveBornImage,
     description:
       "A sanctuary for the undead, founded before the 75-year war so vampires, zombies, skeletons, and even dream visages could live free. Left alone, the undead eventually wander toward this vibrant necropolis.",
   },
   {
     key: "orbiting-city",
+    routeKey: "OrbitingCity",
     name: "Orbiting City",
+    settlementType: "City",
     image: sandboxOrbitingCityImage,
     description:
       "Humanity pushed the impossible to reality, building a city that sails the sky thanks to alliances and generosity toward the Clockwork King. Its flight marks a new era of exploration and diplomacy.",
   },
   {
     key: "big-home",
+    routeKey: "BigHome",
     name: "Big Home",
+    settlementType: "Metropolis",
     image: sandboxBigHomeImage,
     description:
       "Orcs value family, honesty, and loyalty. After 'Mother' guided them to shun technology and guard the secrets of the Missing Millennium, their strength in numbers and conviction makes them formidable when provoked.",
@@ -282,9 +316,16 @@ const sandboxTowns: SandboxTown[] = [
 
 export function Map() {
   const [navigatedTo, setNavigatedTo] = useState<string>("");
-  const [navigationStack, setNavigationStack] = useState<string[]>([]);
-  const handleNavigate = (next: string) => {
+  const [, setNavigationStack] = useState<string[]>([]);
+  const [selectedSettlementType, setSelectedSettlementType] =
+    useState<SettlementType | undefined>(undefined);
+
+  const handleNavigate = (
+    next: string,
+    options?: { settlementType?: SettlementType }
+  ) => {
     setNavigationStack((stack) => [...stack, navigatedTo]);
+    setSelectedSettlementType(options?.settlementType);
     setNavigatedTo(next);
   };
   const handleBack = () => {
@@ -621,7 +662,8 @@ export function Map() {
 
   const sortedEveryShopButtons = sortShopButtons(everyShopButtons);
 
-  switch (navigatedTo) {
+  const currentView = (() => {
+    switch (navigatedTo) {
     case "goblins":
 
       return <Goblins onBack={handleBack} />;
@@ -842,7 +884,7 @@ export function Map() {
             />
             <FloatingButton
               label="Strenuous Portal"
-              onClick={() => handleNavigate("StrenuousPortal")}
+              onClick={() => handleNavigate("StrenuousPortal", { settlementType: "Town" })}
               delay="2.5s"
               backgroundColor="rgba(88, 28, 135, 0.9)"
               color="#f1f5f9"
@@ -858,7 +900,14 @@ export function Map() {
           </div>
         </div>
       );
-  }
+    }
+  })();
+
+  return (
+    <SettlementProvider settlementType={selectedSettlementType}>
+      {currentView}
+    </SettlementProvider>
+  );
 }
 
 function SandboxMenu({
@@ -866,7 +915,7 @@ function SandboxMenu({
   onNavigate,
 }: {
   onBack: () => void;
-  onNavigate: (key: string) => void;
+  onNavigate: (key: string, options?: { settlementType?: SettlementType }) => void;
 }) {
   const orderedSandboxTowns = sandboxTowns;
 
@@ -901,35 +950,7 @@ function SandboxMenu({
               color="#e2e8f0"
               delay="0s"
               onClick={() =>
-                town.key === "withhold"
-                  ? onNavigate("Withhold")
-                  : town.key === "hebron"
-                  ? onNavigate("Hebron")
-                  : town.key === "byford-dolphin"
-                  ? onNavigate("ByfordDolphin")
-                  : town.key === "ballistic-bellows"
-                  ? onNavigate("BallisticBellows")
-                  : town.key === "merricks-meadow"
-                  ? onNavigate("MerricksMeadow")
-                  : town.key === "calidris"
-                  ? onNavigate("Calidris")
-                  : town.key === "analeptic-holt"
-                  ? onNavigate("AnalepticHolt")
-                  : town.key === "orbiting-city"
-                  ? onNavigate("OrbitingCity")
-                  : town.key === "butting-rams"
-                  ? onNavigate("ButtingRams")
-                  : town.key === "jelly-city"
-                  ? onNavigate("JellyCity")
-                  : town.key === "meander"
-                  ? onNavigate("Meander")
-                  : town.key === "seymours-drift"
-                  ? onNavigate("SeymoursDrift")
-                  : town.key === "big-home"
-                  ? onNavigate("BigHome")
-                  : town.key === "graveborn"
-                  ? onNavigate("Graveborn")
-                  : onNavigate("Sandbox")
+                onNavigate(town.routeKey, { settlementType: town.settlementType })
               }
             />
           ))}

--- a/src/SettlementContext.tsx
+++ b/src/SettlementContext.tsx
@@ -1,0 +1,23 @@
+import { createContext, useContext } from "react";
+import type { ReactNode } from "react";
+import { SettlementType } from "./inventoryAvailability";
+
+const SettlementContext = createContext<SettlementType | undefined>(undefined);
+
+export function SettlementProvider({
+  settlementType,
+  children,
+}: {
+  settlementType?: SettlementType;
+  children: ReactNode;
+}) {
+  return (
+    <SettlementContext.Provider value={settlementType}>
+      {children}
+    </SettlementContext.Provider>
+  );
+}
+
+export function useSettlementType() {
+  return useContext(SettlementContext);
+}

--- a/src/ShopTemplate.tsx
+++ b/src/ShopTemplate.tsx
@@ -3,6 +3,8 @@ import defaultStyles from "./BookBombs.module.css";
 import { BackButton } from "./BackButton";
 import { InsultBox } from "./InsultBox";
 import { Item, Tribe } from "./types";
+import { useSettlementType } from "./SettlementContext";
+import { getAvailableItems } from "./inventoryAvailability";
 
 type DisplayItem = Item & { finalPrice: number };
 type ShopTemplateStyles = typeof defaultStyles;
@@ -26,14 +28,18 @@ export function ShopTemplate({
   onBack?: () => void;
   styles?: ShopTemplateStyles;
 }) {
+  const settlementType = useSettlementType();
+
   const displayItems: DisplayItem[] = useMemo(() => {
-    return tribe.items
+    const availableItems = getAvailableItems(tribe.items, settlementType);
+
+    return availableItems
       .map((item) => ({
         ...item,
         finalPrice: calculateAdjustedPrice(item, tribe.priceVariability),
       }))
       .sort((a, b) => a.finalPrice - b.finalPrice);
-  }, [tribe]);
+  }, [settlementType, tribe]);
 
   return (
     <div className={styles.app}>

--- a/src/YeOldDonkey.tsx
+++ b/src/YeOldDonkey.tsx
@@ -4,6 +4,8 @@ import { tribeYeOldDonkey } from "./tribeYeOldDonkey";
 import { BackButton } from "./BackButton";
 import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
+import { useSettlementType } from "./SettlementContext";
+import { getAvailableItems } from "./inventoryAvailability";
 import yeOldDonkeyBackground from "./Ye Old Donkey.png";
 
 type DisplayItem = Item & { finalPrice: number };
@@ -17,14 +19,16 @@ function calculateAdjustedPrice(item: Item, priceVariability: number): number {
 }
 
 export function YeOldDonkey({ onBack }: { onBack?: () => void }) {
+  const settlementType = useSettlementType();
+
   const displayItems: DisplayItem[] = useMemo(() => {
-    return tribeYeOldDonkey.items
+    return getAvailableItems(tribeYeOldDonkey.items, settlementType)
       .map((item) => ({
         ...item,
         finalPrice: calculateAdjustedPrice(item, tribeYeOldDonkey.priceVariability),
       }))
       .sort((a, b) => a.finalPrice - b.finalPrice);
-  }, []);
+  }, [settlementType]);
 
   return (
     <div className={styles.app}>

--- a/src/inventoryAvailability.ts
+++ b/src/inventoryAvailability.ts
@@ -1,0 +1,53 @@
+import { Item } from "./types";
+
+export type SettlementType =
+  | "Isolated Dwelling"
+  | "Thorpe"
+  | "Hamlet"
+  | "Village"
+  | "Town"
+  | "City"
+  | "Metropolis";
+
+export const settlementInventoryPercent: Record<SettlementType, number> = {
+  "Isolated Dwelling": 10,
+  Thorpe: 25,
+  Hamlet: 40,
+  Village: 55,
+  Town: 70,
+  City: 85,
+  Metropolis: 100,
+};
+
+export function getVisibleItemCount(totalItems: number, settlementType?: SettlementType): number {
+  if (totalItems <= 0) {
+    return 0;
+  }
+
+  if (!settlementType) {
+    return totalItems;
+  }
+
+  const percent = settlementInventoryPercent[settlementType];
+  const count = Math.floor((totalItems * percent) / 100);
+  return Math.max(1, count);
+}
+
+function shuffle<T>(items: T[]): T[] {
+  const copy = [...items];
+  for (let i = copy.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+
+  return copy;
+}
+
+export function getAvailableItems<T extends Item>(items: T[], settlementType?: SettlementType): T[] {
+  const count = getVisibleItemCount(items.length, settlementType);
+  if (count >= items.length) {
+    return [...items];
+  }
+
+  return shuffle(items).slice(0, count);
+}


### PR DESCRIPTION
### Motivation

- Introduce a mechanism to vary shop inventories by settlement size so towns/cities show different subsets of items.
- Provide a central context so shop components can read the current settlement type without prop-drilling from deep UI code.

### Description

- Add `SettlementContext` (`src/SettlementContext.tsx`) and `SettlementProvider` along with `useSettlementType` to expose the current `SettlementType` to descendant components.
- Add `inventoryAvailability` (`src/inventoryAvailability.ts`) which defines `SettlementType`, maps settlement types to inventory visibility percentages, and provides `getVisibleItemCount` and `getAvailableItems` to compute and sample available items for a shop.
- Update `Map` (`src/Map.tsx`) to store and propagate a selected `settlementType` when navigating; add `routeKey` and `settlementType` fields to `sandboxTowns` and change `handleNavigate` to accept an optional `settlementType` parameter and wrap the rendered view with `SettlementProvider`.
- Update shop rendering to respect the new availability rules by changing `ShopTemplate` (`src/ShopTemplate.tsx`) and `YeOldDonkey` (`src/YeOldDonkey.tsx`) to consume `useSettlementType` and use `getAvailableItems` when building the displayed item list.

### Testing

- Ran TypeScript type-check (`tsc --noEmit`) and local build (`yarn build`) which both completed successfully.
- No new automated unit tests were added for this feature; existing test suites were not modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a50876473883298564c7c893c68fc3)