### PR TITLE
Make shop inventories settlement-aware (add SettlementContext and inventory filtering)

### DIFF
--- a/src/ApplegarthGuild.tsx
+++ b/src/ApplegarthGuild.tsx
@@ -5,6 +5,8 @@ import { BackButton } from "./BackButton";
 import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import applegarthBackground from "./Applegarth.webp";
+import { useSettlementType } from "./SettlementContext";
+import { getAvailableItems } from "./inventoryAvailability";
 
 type GuildItem = Item & { priceLabel?: string };
 type DisplayItem = GuildItem & { finalPrice?: number };
@@ -18,8 +20,9 @@ function calculateAdjustedPrice(item: Item, priceVariability: number): number {
 }
 
 export function ApplegarthGuild({ onBack }: { onBack?: () => void }) {
+  const settlementType = useSettlementType();
   const displayItems: DisplayItem[] = useMemo(() => {
-    return tribeApplegarthGuild.items
+    return getAvailableItems(tribeApplegarthGuild.items, settlementType)
       .map((item) => {
         if (item.priceLabel) {
           return { ...item, finalPrice: undefined };
@@ -31,7 +34,7 @@ export function ApplegarthGuild({ onBack }: { onBack?: () => void }) {
         };
       })
       .sort((a, b) => (a.finalPrice ?? Number.MAX_SAFE_INTEGER) - (b.finalPrice ?? Number.MAX_SAFE_INTEGER));
-  }, []);
+  }, [settlementType]);
 
   return (
     <div className={styles.app}>

--- a/src/ArchivesGuild.tsx
+++ b/src/ArchivesGuild.tsx
@@ -5,6 +5,8 @@ import { BackButton } from "./BackButton";
 import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import archivesGuildBackground from "./Archives Guild.png";
+import { useSettlementType } from "./SettlementContext";
+import { getAvailableItems } from "./inventoryAvailability";
 
 type DisplayItem = Item & { finalPrice: number };
 
@@ -17,14 +19,15 @@ function calculateAdjustedPrice(item: Item, priceVariability: number): number {
 }
 
 export function ArchivesGuild({ onBack }: { onBack?: () => void }) {
+  const settlementType = useSettlementType();
   const displayItems: DisplayItem[] = useMemo(() => {
-    return tribeArchivesGuild.items
+    return getAvailableItems(tribeArchivesGuild.items, settlementType)
       .map((item) => ({
         ...item,
         finalPrice: calculateAdjustedPrice(item, tribeArchivesGuild.priceVariability),
       }))
       .sort((a, b) => a.finalPrice - b.finalPrice);
-  }, []);
+  }, [settlementType]);
 
   return (
     <div className={styles.app}>

--- a/src/Auction.tsx
+++ b/src/Auction.tsx
@@ -11,8 +11,17 @@ import { tribeAuctionHouse5 } from "./tribeAuctionHouse5";
 import { getNextItem } from "./getNextItem";
 import { getCookie } from "./cookies";
 import { BackButton } from "./BackButton";
+import { useSettlementType } from "./SettlementContext";
+import { getAvailableItems } from "./inventoryAvailability";
 
 const MAX_CLICKS = 3;
+
+function getFilteredTribes(tribes: Tribe[], settlementType?: import("./inventoryAvailability").SettlementType): Tribe[] {
+  return tribes.map((tribe) => ({
+    ...tribe,
+    items: getAvailableItems(tribe.items, settlementType),
+  }));
+}
 
 export function getIndices(tribes: Tribe[], oldList: number[] = []): number[] {
   return tribes.map((tribe, index) => getNextItem(tribe.items, oldList[index]));
@@ -33,7 +42,8 @@ function getInitialIndices(tribes: Tribe[]): number[] {
 }
 
 export function Auctions({ onBack }: { onBack?: () => void }) {
-  const tribes = [tribeAuctionHouse, tribeAuctionHouse2, tribeAuctionHouse3, tribeAuctionHouse4, tribeAuctionHouse5 ];
+  const settlementType = useSettlementType();
+  const tribes = getFilteredTribes([tribeAuctionHouse, tribeAuctionHouse2, tribeAuctionHouse3, tribeAuctionHouse4, tribeAuctionHouse5 ], settlementType);
   const [clicks, setClicks] = useState(getInitialClicks());
   const [indices, setIndices] = useState(getInitialIndices(tribes));
   const scrollToTop = () => {

--- a/src/AuntiePattysPies.tsx
+++ b/src/AuntiePattysPies.tsx
@@ -5,6 +5,8 @@ import { BackButton } from "./BackButton";
 import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import auntPattiePieBackground from "./Aunt Pattie Pie.png";
+import { useSettlementType } from "./SettlementContext";
+import { getAvailableItems } from "./inventoryAvailability";
 
 type DisplayItem = Item & { finalPrice: number };
 
@@ -18,14 +20,15 @@ function calculateAdjustedPrice(item: Item, priceVariability: number): number {
 }
 
 export function AuntiePattysPies({ onBack }: { onBack?: () => void }) {
+  const settlementType = useSettlementType();
   const displayItems: DisplayItem[] = useMemo(() => {
-    return tribeAuntiePattysPies.items
+    return getAvailableItems(tribeAuntiePattysPies.items, settlementType)
       .map((item) => ({
         ...item,
         finalPrice: calculateAdjustedPrice(item, tribeAuntiePattysPies.priceVariability),
       }))
       .sort((a, b) => a.finalPrice - b.finalPrice);
-  }, []);
+  }, [settlementType]);
 
   return (
     <div className={styles.app}>

--- a/src/Black.tsx
+++ b/src/Black.tsx
@@ -11,8 +11,17 @@ import { tribeBlackMarket5 } from "./tribeBlackMarket5";
 import { getNextItem } from "./getNextItem";
 import { getCookie } from "./cookies";
 import { BackButton } from "./BackButton";
+import { useSettlementType } from "./SettlementContext";
+import { getAvailableItems } from "./inventoryAvailability";
 
 const MAX_CLICKS = 2;
+
+function getFilteredTribes(tribes: Tribe[], settlementType?: import("./inventoryAvailability").SettlementType): Tribe[] {
+  return tribes.map((tribe) => ({
+    ...tribe,
+    items: getAvailableItems(tribe.items, settlementType),
+  }));
+}
 
 export function getIndices(tribes: Tribe[], oldList: number[] = []): number[] {
   return tribes.map((tribe, index) => getNextItem(tribe.items, oldList[index]));
@@ -33,7 +42,8 @@ function getInitialIndices(tribes: Tribe[]): number[] {
 }
 
 export function Blacks({ onBack }: { onBack?: () => void }) {
-  const tribes = [tribeBlackMarket, tribeBlackMarket2, tribeBlackMarket3, tribeBlackMarket4, tribeBlackMarket5];
+  const settlementType = useSettlementType();
+  const tribes = getFilteredTribes([tribeBlackMarket, tribeBlackMarket2, tribeBlackMarket3, tribeBlackMarket4, tribeBlackMarket5], settlementType);
 
   const [clicks, setClicks] = useState(getInitialClicks());
 

--- a/src/BlossomHotel.tsx
+++ b/src/BlossomHotel.tsx
@@ -5,6 +5,8 @@ import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import { BlossomHotelItem, tribeBlossomHotel } from "./tribeBlossomHotel";
 import blossomHotelBackground from "./Blossom Hotel.png";
+import { useSettlementType } from "./SettlementContext";
+import { getAvailableItems } from "./inventoryAvailability";
 
 type DisplayItem = BlossomHotelItem & { finalPrice: number };
 
@@ -22,16 +24,17 @@ function formatPrice(item: DisplayItem): string {
 }
 
 export function BlossomHotel({ onBack }: { onBack?: () => void }) {
+  const settlementType = useSettlementType();
   const displayItems: DisplayItem[] = useMemo(
     () =>
-      tribeBlossomHotel.items.map((item) => ({
+      getAvailableItems(tribeBlossomHotel.items, settlementType).map((item) => ({
         ...item,
         finalPrice:
           item.price > 0
             ? calculateAdjustedPrice(item, tribeBlossomHotel.priceVariability)
             : 0,
       })),
-    []
+    [settlementType]
   );
 
   return (

--- a/src/BookBombs.tsx
+++ b/src/BookBombs.tsx
@@ -5,6 +5,8 @@ import { BackButton } from "./BackButton";
 import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import bookBombBackground from "./Book Bomb.png";
+import { useSettlementType } from "./SettlementContext";
+import { getAvailableItems } from "./inventoryAvailability";
 
 type DisplayItem = Item & { finalPrice: number };
 
@@ -18,14 +20,15 @@ function calculateAdjustedPrice(item: Item, priceVariability: number): number {
 }
 
 export function BookBombs({ onBack }: { onBack?: () => void }) {
+  const settlementType = useSettlementType();
   const displayItems: DisplayItem[] = useMemo(() => {
-    return tribeBookBombs.items
+    return getAvailableItems(tribeBookBombs.items, settlementType)
       .map((item) => ({
         ...item,
         finalPrice: calculateAdjustedPrice(item, tribeBookBombs.priceVariability),
       }))
       .sort((a, b) => a.finalPrice - b.finalPrice);
-  }, []);
+  }, [settlementType]);
 
   return (
     <div className={styles.app}>

--- a/src/BulletsBuffsBeyond.tsx
+++ b/src/BulletsBuffsBeyond.tsx
@@ -5,6 +5,8 @@ import { BackButton } from "./BackButton";
 import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import bulletsBuffsBeyondBackground from "./Bullets Buffs and Beyond.webp";
+import { useSettlementType } from "./SettlementContext";
+import { getAvailableItems } from "./inventoryAvailability";
 
 type BulletsBuffsBeyondItem = Item & { priceLabel?: string };
 type DisplayItem = BulletsBuffsBeyondItem & { finalPrice?: number };
@@ -19,8 +21,9 @@ function calculateAdjustedPrice(item: Item, priceVariability: number): number {
 }
 
 export function BulletsBuffsBeyond({ onBack }: { onBack?: () => void }) {
+  const settlementType = useSettlementType();
   const displayItems: DisplayItem[] = useMemo(() => {
-    return tribeBulletsBuffsBeyond.items
+    return getAvailableItems(tribeBulletsBuffsBeyond.items, settlementType)
       .map((item) => {
         if ("priceLabel" in item && item.priceLabel) {
           return { ...item, finalPrice: undefined };
@@ -32,7 +35,7 @@ export function BulletsBuffsBeyond({ onBack }: { onBack?: () => void }) {
         };
       })
       .sort((a, b) => (a.finalPrice ?? Number.MAX_SAFE_INTEGER) - (b.finalPrice ?? Number.MAX_SAFE_INTEGER));
-  }, []);
+  }, [settlementType]);
 
   return (
     <div className={styles.app}>

--- a/src/ChangingChurch.tsx
+++ b/src/ChangingChurch.tsx
@@ -5,6 +5,8 @@ import { BackButton } from "./BackButton";
 import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import changingChurchBackground from "./Changing Church.png";
+import { useSettlementType } from "./SettlementContext";
+import { getAvailableItems } from "./inventoryAvailability";
 
 type DisplayItem = Item & { finalPrice: number };
 
@@ -18,14 +20,15 @@ function calculateAdjustedPrice(item: Item, priceVariability: number): number {
 }
 
 export function ChangingChurch({ onBack }: { onBack?: () => void }) {
+  const settlementType = useSettlementType();
   const displayItems: DisplayItem[] = useMemo(() => {
-    return tribeChangingChurch.items
+    return getAvailableItems(tribeChangingChurch.items, settlementType)
       .map((item) => ({
         ...item,
         finalPrice: calculateAdjustedPrice(item, tribeChangingChurch.priceVariability),
       }))
       .sort((a, b) => a.finalPrice - b.finalPrice);
-  }, []);
+  }, [settlementType]);
 
   return (
     <div className={styles.app}>

--- a/src/ComedyGold.tsx
+++ b/src/ComedyGold.tsx
@@ -5,6 +5,8 @@ import { BackButton } from "./BackButton";
 import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import comedyGoldBackground from "./Comedy Gold.png";
+import { useSettlementType } from "./SettlementContext";
+import { getAvailableItems } from "./inventoryAvailability";
 
 type ComedyGoldItem = Item & { priceLabel?: string };
 type DisplayItem = ComedyGoldItem & { finalPrice?: number };
@@ -19,8 +21,9 @@ function calculateAdjustedPrice(item: Item, priceVariability: number): number {
 }
 
 export function ComedyGold({ onBack }: { onBack?: () => void }) {
+  const settlementType = useSettlementType();
   const displayItems: DisplayItem[] = useMemo(() => {
-    return tribeComedyGold.items
+    return getAvailableItems(tribeComedyGold.items, settlementType)
       .map((item) => {
         if ("priceLabel" in item && item.priceLabel) {
           return { ...item, finalPrice: undefined };
@@ -32,7 +35,7 @@ export function ComedyGold({ onBack }: { onBack?: () => void }) {
         };
       })
       .sort((a, b) => (a.finalPrice ?? Number.MAX_SAFE_INTEGER) - (b.finalPrice ?? Number.MAX_SAFE_INTEGER));
-  }, []);
+  }, [settlementType]);
 
   return (
     <div className={styles.app}>

--- a/src/DungeonCrawlerGuild.tsx
+++ b/src/DungeonCrawlerGuild.tsx
@@ -5,6 +5,8 @@ import { BackButton } from "./BackButton";
 import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import dungeonCrawlerGuildBackground from "./Dungeon Crawler's Guild.png";
+import { useSettlementType } from "./SettlementContext";
+import { getAvailableItems } from "./inventoryAvailability";
 
 type DisplayItem = Item & { finalPrice: number };
 
@@ -18,14 +20,15 @@ function calculateAdjustedPrice(item: Item, priceVariability: number): number {
 }
 
 export function DungeonCrawlerGuild({ onBack }: { onBack?: () => void }) {
+  const settlementType = useSettlementType();
   const displayItems: DisplayItem[] = useMemo(() => {
-    return tribeDungeonCrawlerGuild.items
+    return getAvailableItems(tribeDungeonCrawlerGuild.items, settlementType)
       .map((item) => ({
         ...item,
         finalPrice: calculateAdjustedPrice(item, tribeDungeonCrawlerGuild.priceVariability),
       }))
       .sort((a, b) => a.finalPrice - b.finalPrice);
-  }, []);
+  }, [settlementType]);
 
   return (
     <div className={styles.app}>

--- a/src/EvansEnchantingEmporium.tsx
+++ b/src/EvansEnchantingEmporium.tsx
@@ -8,6 +8,8 @@ import {
   tribeEvansEnchantingEmporium,
 } from "./tribeEvansEnchantingEmporium";
 import evansEnchantingBackground from "./Evan's Enchanting Emporium.png";
+import { useSettlementType } from "./SettlementContext";
+import { getAvailableItems } from "./inventoryAvailability";
 
 type DisplayItem = EvansEnchantingItem & { finalPrice: number };
 
@@ -25,9 +27,10 @@ function formatPrice(item: DisplayItem): string {
 }
 
 export function EvansEnchantingEmporium({ onBack }: { onBack?: () => void }) {
+  const settlementType = useSettlementType();
   const displayItems: DisplayItem[] = useMemo(
     () =>
-      tribeEvansEnchantingEmporium.items.map((item) => ({
+      getAvailableItems(tribeEvansEnchantingEmporium.items, settlementType).map((item) => ({
         ...item,
         finalPrice:
           item.price > 0
@@ -37,7 +40,7 @@ export function EvansEnchantingEmporium({ onBack }: { onBack?: () => void }) {
               )
             : 0,
       })),
-    []
+    [settlementType]
   );
 
   return (

--- a/src/FairiesOfFlora.tsx
+++ b/src/FairiesOfFlora.tsx
@@ -5,6 +5,8 @@ import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import { FairiesOfFloraItem, tribeFairiesOfFlora } from "./tribeFairiesOfFlora";
 import floralBackground from "./Floral.webp";
+import { useSettlementType } from "./SettlementContext";
+import { getAvailableItems } from "./inventoryAvailability";
 
 type DisplayItem = FairiesOfFloraItem & { finalPrice: number };
 
@@ -22,16 +24,17 @@ function formatPrice(item: DisplayItem): string {
 }
 
 export function FairiesOfFlora({ onBack }: { onBack?: () => void }) {
+  const settlementType = useSettlementType();
   const displayItems: DisplayItem[] = useMemo(
     () =>
-      tribeFairiesOfFlora.items.map((item) => ({
+      getAvailableItems(tribeFairiesOfFlora.items, settlementType).map((item) => ({
         ...item,
         finalPrice:
           item.price > 0
             ? calculateAdjustedPrice(item, tribeFairiesOfFlora.priceVariability)
             : 0,
       })),
-    []
+    [settlementType]
   );
 
   return (

--- a/src/FindAFriend.tsx
+++ b/src/FindAFriend.tsx
@@ -5,6 +5,8 @@ import { BackButton } from "./BackButton";
 import { InsultBox } from "./InsultBox";
 import findAFriendBackground from "./Find a Friend.png";
 import { Item } from "./types";
+import { useSettlementType } from "./SettlementContext";
+import { getAvailableItems } from "./inventoryAvailability";
 
 type DisplayItem = Item & { finalPrice: number };
 
@@ -22,14 +24,15 @@ function formatPrice(value: number) {
 }
 
 export function FindAFriend({ onBack }: { onBack?: () => void }) {
+  const settlementType = useSettlementType();
   const displayItems: DisplayItem[] = useMemo(() => {
-    return tribeFindAFriend.items
+    return getAvailableItems(tribeFindAFriend.items, settlementType)
       .map((item) => ({
         ...item,
         finalPrice: calculateAdjustedPrice(item, tribeFindAFriend.priceVariability),
       }))
       .sort((a, b) => a.finalPrice - b.finalPrice);
-  }, []);
+  }, [settlementType]);
 
   return (
     <div className={styles.app}>

--- a/src/FizzyTales.tsx
+++ b/src/FizzyTales.tsx
@@ -5,6 +5,8 @@ import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import { FizzyTalesItem, tribeFizzyTales } from "./tribeFizzyTales";
 import fizzyTalesBackground from "./FizzyTale.png";
+import { useSettlementType } from "./SettlementContext";
+import { getAvailableItems } from "./inventoryAvailability";
 
 type DisplayItem = FizzyTalesItem & { finalPrice: number };
 
@@ -22,14 +24,15 @@ function formatPrice(item: DisplayItem): string {
 }
 
 export function FizzyTales({ onBack }: { onBack?: () => void }) {
+  const settlementType = useSettlementType();
   const displayItems: DisplayItem[] = useMemo(
     () =>
-      tribeFizzyTales.items.map((item) => ({
+      getAvailableItems(tribeFizzyTales.items, settlementType).map((item) => ({
         ...item,
         finalPrice:
           item.price > 0 ? calculateAdjustedPrice(item, tribeFizzyTales.priceVariability) : 0,
       })),
-    []
+    [settlementType]
   );
 
   return (

--- a/src/Goblins.tsx
+++ b/src/Goblins.tsx
@@ -13,8 +13,17 @@ import { tribe7 } from "./tribe7";
 import { getNextItem } from "./getNextItem";
 import { getCookie } from "./cookies";
 import { BackButton } from "./BackButton";
+import { useSettlementType } from "./SettlementContext";
+import { getAvailableItems } from "./inventoryAvailability";
 
 const MAX_CLICKS = 5;
+
+function getFilteredTribes(tribes: Tribe[], settlementType?: import("./inventoryAvailability").SettlementType): Tribe[] {
+  return tribes.map((tribe) => ({
+    ...tribe,
+    items: getAvailableItems(tribe.items, settlementType),
+  }));
+}
 
 export function getIndices(tribes: Tribe[], oldList: number[] = []): number[] {
   return tribes.map((tribe, index) => getNextItem(tribe.items, oldList[index]));
@@ -35,7 +44,8 @@ function getInitialIndices(tribes: Tribe[]): number[] {
 }
 
 export function Goblins({ onBack }: { onBack?: () => void }) {
-  const tribes = [tribe1, tribe2, tribe3, tribe4, tribe5, tribe6, tribe7];
+  const settlementType = useSettlementType();
+  const tribes = getFilteredTribes([tribe1, tribe2, tribe3, tribe4, tribe5, tribe6, tribe7], settlementType);
 
   const [clicks, setClicks] = useState(getInitialClicks());
 

--- a/src/GolemWorkshop.tsx
+++ b/src/GolemWorkshop.tsx
@@ -5,6 +5,8 @@ import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import { GolemWorkshopItem, tribeGolemWorkshop } from "./tribeGolemWorkshop";
 import golemWorkshopBackground from "./Golem Work Shop.png";
+import { useSettlementType } from "./SettlementContext";
+import { getAvailableItems } from "./inventoryAvailability";
 
 type DisplayItem = GolemWorkshopItem & { finalPrice: number };
 
@@ -22,16 +24,17 @@ function formatPrice(item: DisplayItem): string {
 }
 
 export function GolemWorkshop({ onBack }: { onBack?: () => void }) {
+  const settlementType = useSettlementType();
   const displayItems: DisplayItem[] = useMemo(
     () =>
-      tribeGolemWorkshop.items.map((item) => ({
+      getAvailableItems(tribeGolemWorkshop.items, settlementType).map((item) => ({
         ...item,
         finalPrice:
           item.price > 0
             ? calculateAdjustedPrice(item, tribeGolemWorkshop.priceVariability)
             : 0,
       })),
-    []
+    [settlementType]
   );
 
   return (

--- a/src/IconicDragonic.tsx
+++ b/src/IconicDragonic.tsx
@@ -5,6 +5,8 @@ import { BackButton } from "./BackButton";
 import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import dragonicBackground from "./Iconic Dragonic.png";
+import { useSettlementType } from "./SettlementContext";
+import { getAvailableItems } from "./inventoryAvailability";
 
 type DisplayItem = Item & { finalPrice: number };
 
@@ -18,14 +20,15 @@ function calculateAdjustedPrice(item: Item, priceVariability: number): number {
 }
 
 export function IconicDragonic({ onBack }: { onBack?: () => void }) {
+  const settlementType = useSettlementType();
   const displayItems: DisplayItem[] = useMemo(() => {
-    return tribeIconicDragonic.items
+    return getAvailableItems(tribeIconicDragonic.items, settlementType)
       .map((item) => ({
         ...item,
         finalPrice: calculateAdjustedPrice(item, tribeIconicDragonic.priceVariability),
       }))
       .sort((a, b) => a.finalPrice - b.finalPrice);
-  }, []);
+  }, [settlementType]);
 
   return (
     <div className={styles.app}>

--- a/src/JellBell.tsx
+++ b/src/JellBell.tsx
@@ -15,6 +15,8 @@ import {
   slimeTemperamentOptions,
 } from "./jellBellGenerator";
 import { SlimeStatBlock } from "./SlimeStatBlock";
+import { useSettlementType } from "./SettlementContext";
+import { getAvailableItems } from "./inventoryAvailability";
 
 type DisplayItem = JellBellItem & { finalPrice: number };
 type BellTier = "3 Star Bell" | "4 Star Bell" | "5 Star Bell";
@@ -33,12 +35,13 @@ function calculateAdjustedPrice(item: Item, priceVariability: number): number {
 }
 
 export function JellBell({ onBack }: { onBack?: () => void }) {
+  const settlementType = useSettlementType();
   const [selectedTier, setSelectedTier] = useState<BellTier | null>(null);
   const [isSpinning, setIsSpinning] = useState(false);
   const [generatedSlimes, setGeneratedSlimes] = useState<GeneratedSlime[]>([]);
 
   const displayItems: DisplayItem[] = useMemo(() => {
-    return tribeJellBell.items
+    return getAvailableItems(tribeJellBell.items, settlementType)
       .map((item) => ({
         ...item,
         finalPrice:
@@ -47,7 +50,7 @@ export function JellBell({ onBack }: { onBack?: () => void }) {
             : 0,
       }))
       .sort((a, b) => a.finalPrice - b.finalPrice || a.name.localeCompare(b.name));
-  }, []);
+  }, [settlementType]);
 
   const formatPrice = (item: DisplayItem) => {
     if (item.priceText) return item.priceText;

--- a/src/JewelryGuild.tsx
+++ b/src/JewelryGuild.tsx
@@ -5,6 +5,8 @@ import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import { JewelryGuildItem, tribeJewelryGuild } from "./tribeJewelryGuild";
 import jewelryGuildBackground from "./Jewelry Guild.png";
+import { useSettlementType } from "./SettlementContext";
+import { getAvailableItems } from "./inventoryAvailability";
 
 type DisplayItem = JewelryGuildItem & { finalPrice: number };
 
@@ -22,16 +24,17 @@ function formatPrice(item: DisplayItem): string {
 }
 
 export function JewelryGuild({ onBack }: { onBack?: () => void }) {
+  const settlementType = useSettlementType();
   const displayItems: DisplayItem[] = useMemo(
     () =>
-      tribeJewelryGuild.items.map((item) => ({
+      getAvailableItems(tribeJewelryGuild.items, settlementType).map((item) => ({
         ...item,
         finalPrice:
           item.price > 0
             ? calculateAdjustedPrice(item, tribeJewelryGuild.priceVariability)
             : 0,
       })),
-    []
+    [settlementType]
   );
 
   return (

--- a/src/LabyrinthineLibrary.tsx
+++ b/src/LabyrinthineLibrary.tsx
@@ -8,6 +8,8 @@ import {
   tribeLabyrinthineLibrary,
 } from "./tribeLabyrinthineLibrary";
 import labyrinthineLibraryBackground from "./Labyrinthine Labrary.png";
+import { useSettlementType } from "./SettlementContext";
+import { getAvailableItems } from "./inventoryAvailability";
 
 type DisplayItem = LabyrinthineLibraryItem & { finalPrice: number };
 
@@ -25,9 +27,10 @@ function formatPrice(item: DisplayItem): string {
 }
 
 export function LabyrinthineLibrary({ onBack }: { onBack?: () => void }) {
+  const settlementType = useSettlementType();
   const displayItems: DisplayItem[] = useMemo(
     () =>
-      tribeLabyrinthineLibrary.items.map((item) => ({
+      getAvailableItems(tribeLabyrinthineLibrary.items, settlementType).map((item) => ({
         ...item,
         finalPrice:
           item.price > 0
@@ -37,7 +40,7 @@ export function LabyrinthineLibrary({ onBack }: { onBack?: () => void }) {
               )
             : 0,
       })),
-    []
+    [settlementType]
   );
 
   return (

--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -116,6 +116,8 @@ import { ByfordDolphinRobertson } from "./ByfordDolphinRobertson";
 import { Graveborn } from "./Graveborn";
 import { StrenuousPortal } from "./StrenuousPortal";
 import strenuousPortalButtonImage from "./StrenuousPortalButton2.webp";
+import { SettlementProvider } from "./SettlementContext";
+import { SettlementType } from "./inventoryAvailability";
 
 // Remove stray whitespace/newlines from data URIs (defensive)
 function cleanDataUrl(s?: string) {
@@ -158,7 +160,9 @@ function useTextImage(text?: string) {
 
 type SandboxTown = {
   key: string;
+  routeKey: string;
   name: string;
+  settlementType: SettlementType;
   description: string;
   image: string;
 };
@@ -175,105 +179,135 @@ type ShopButton = {
 const sandboxTowns: SandboxTown[] = [
   {
     key: "withhold",
+    routeKey: "Withhold",
     name: "Withhold (Parker)",
+    settlementType: "Thorpe",
     image: sandboxWytheholdeImage,
     description:
       "Nestled between warm rolling hills and jagged, freezing mountains, Withhold grows famous home-grown food but struggles for medicine once winter comes. As they live in Wandering Titan territory, nearly everyone knows how to flee into the tight valley caves when danger looms, preserving the town's dwindling stories.",
   },
   {
     key: "butting-rams",
+    routeKey: "ButtingRams",
     name: "Butting Rams",
+    settlementType: "Hamlet",
     image: sandboxButtingRamsImage,
     description:
       "Barbarians here love fighting, feasting, and boasting about both. Their town is literally split between two enormous rams that butt heads, catapulting residents back and forth—thankfully the rams are fluffy enough to make the landings survivable before the traditional 15-minute free-for-all.",
   },
   {
     key: "meander",
+    routeKey: "Meander",
     name: "Meander (Michael)",
+    settlementType: "Thorpe",
     image: sandboxMeanderImage,
     description:
       "A cowboy's dream that never settles, Meander roams Wandering Titan territory after draining every Magitek Oil spot. Constant desert travel keeps crops from thriving, so the townsfolk trade for food while clinging to a strong moral compass they defend fiercely.",
   },
   {
     key: "calidris",
+    routeKey: "Calidris",
     name: "Calidris (Fisk)",
+    settlementType: "Hamlet",
     image: sandboxCalidrisImage,
     description:
       "Created as an artisans' paradise with no creative limits, Calidris thrived—until every living resident vanished overnight. Only the golems and robots remain, tirelessly working while ignoring their missing masters.",
   },
   {
     key: "merricks-meadow",
+    routeKey: "MerricksMeadow",
     name: "Merrick's Meadow (Howard)",
+    settlementType: "Village",
     image: sandboxMerricksGroveImage,
     description:
       "This humble village boomed after discovering rare herbs. Newcomers flock to Merrick's Meadow for its newfound fame, while longtime residents grumble about the crowds disturbing their once-tranquil home.",
   },
   {
     key: "ballistic-bellows",
+    routeKey: "BallisticBellows",
     name: "Ballistic Bellows (Caleb)",
+    settlementType: "Village",
     image: sandboxBallisticBellowsImage,
     description:
       "Punctual and industrious, every citizen can run a forge or clockwork device. Their advanced weapons self-destruct if reverse engineered, protecting the secrets behind their booming craft.",
   },
   {
     key: "byford-dolphin",
+    routeKey: "ByfordDolphin",
     name: "Byford Dolphin (Robertson)",
+    settlementType: "Village",
     image: sandboxByfordDolphinImage,
     description:
       "Wealth dictates status in Byford Dolphin. Legendary metals pulled from the sea fund the Clockwork King's construction projects, while the richest citizen holds the House of Blades contract—and the bill that comes with it.",
   },
   {
     key: "hebron",
+    routeKey: "Hebron",
     name: "Hebron (Joshua)",
+    settlementType: "Town",
     image: sandboxHebronImage,
     description:
       "After the Missing Millennium, Hebron secured a monopoly on Thunder Cores by salvaging and purchasing every relic they could find. Now it's a hub for minds devoted to unlocking the power behind these remnants.",
   },
   {
     key: "jelly-city",
+    routeKey: "JellyCity",
     name: "Jelly City",
+    settlementType: "Town",
     image: sandboxJellyCityImage,
     description:
       "Built vertically inside a Wandering Titan jellyfish, this flexible city produces medicine that keeps the Disciples of Mother battle-ready. Its secrets are hard to see, but unforgettable once witnessed.",
   },
   {
     key: "pop-n-faith",
+    routeKey: "Sandbox",
     name: "Pop-n Faith (Eli)",
+    settlementType: "City",
     image: sandboxPopNFaithImage,
     description:
       "Sorry, but there is no more Pop-n Faith. Your world deities are gone; now your planet is stuck between death and unlife.",
   },
   {
     key: "analeptic-holt",
+    routeKey: "AnalepticHolt",
     name: "Analeptic Holt (Teag)",
+    settlementType: "City",
     image: sandboxAnalepticHoltImage,
     description:
       "Hidden beneath an ancient jungle canopy, Hadozee gliders live among massive roots and high branches. They cherish harmony with their environment but stay guarded with outsiders to protect their traditions.",
   },
   {
     key: "seymours-drift",
+    routeKey: "SeymoursDrift",
     name: "Seymour's Drift (Melanie)",
+    settlementType: "City",
     image: sandboxSeymoursDriftImage,
     description:
       "A sprawling city on a giant drifting lily pad, Seymour's Drift follows the tides while serving its enigmatic leader, Audrey the Second. Residents bond over devotion, firearms, and an unyielding love of meat.",
   },
   {
     key: "graveborn",
+    routeKey: "Graveborn",
     name: "Graveborn",
+    settlementType: "City",
     image: sandboxGraveBornImage,
     description:
       "A sanctuary for the undead, founded before the 75-year war so vampires, zombies, skeletons, and even dream visages could live free. Left alone, the undead eventually wander toward this vibrant necropolis.",
   },
   {
     key: "orbiting-city",
+    routeKey: "OrbitingCity",
     name: "Orbiting City",
+    settlementType: "City",
     image: sandboxOrbitingCityImage,
     description:
       "Humanity pushed the impossible to reality, building a city that sails the sky thanks to alliances and generosity toward the Clockwork King. Its flight marks a new era of exploration and diplomacy.",
   },
   {
     key: "big-home",
+    routeKey: "BigHome",
     name: "Big Home",
+    settlementType: "Metropolis",
     image: sandboxBigHomeImage,
     description:
       "Orcs value family, honesty, and loyalty. After 'Mother' guided them to shun technology and guard the secrets of the Missing Millennium, their strength in numbers and conviction makes them formidable when provoked.",
@@ -282,9 +316,16 @@ const sandboxTowns: SandboxTown[] = [
 
 export function Map() {
   const [navigatedTo, setNavigatedTo] = useState<string>("");
-  const [navigationStack, setNavigationStack] = useState<string[]>([]);
-  const handleNavigate = (next: string) => {
+  const [, setNavigationStack] = useState<string[]>([]);
+  const [selectedSettlementType, setSelectedSettlementType] =
+    useState<SettlementType | undefined>(undefined);
+
+  const handleNavigate = (
+    next: string,
+    options?: { settlementType?: SettlementType }
+  ) => {
     setNavigationStack((stack) => [...stack, navigatedTo]);
+    setSelectedSettlementType(options?.settlementType);
     setNavigatedTo(next);
   };
   const handleBack = () => {
@@ -621,7 +662,8 @@ export function Map() {
 
   const sortedEveryShopButtons = sortShopButtons(everyShopButtons);
 
-  switch (navigatedTo) {
+  const currentView = (() => {
+    switch (navigatedTo) {
     case "goblins":
 
       return <Goblins onBack={handleBack} />;
@@ -842,7 +884,7 @@ export function Map() {
             />
             <FloatingButton
               label="Strenuous Portal"
-              onClick={() => handleNavigate("StrenuousPortal")}
+              onClick={() => handleNavigate("StrenuousPortal", { settlementType: "Town" })}
               delay="2.5s"
               backgroundColor="rgba(88, 28, 135, 0.9)"
               color="#f1f5f9"
@@ -858,7 +900,14 @@ export function Map() {
           </div>
         </div>
       );
-  }
+    }
+  })();
+
+  return (
+    <SettlementProvider settlementType={selectedSettlementType}>
+      {currentView}
+    </SettlementProvider>
+  );
 }
 
 function SandboxMenu({
@@ -866,7 +915,7 @@ function SandboxMenu({
   onNavigate,
 }: {
   onBack: () => void;
-  onNavigate: (key: string) => void;
+  onNavigate: (key: string, options?: { settlementType?: SettlementType }) => void;
 }) {
   const orderedSandboxTowns = sandboxTowns;
 
@@ -901,35 +950,7 @@ function SandboxMenu({
               color="#e2e8f0"
               delay="0s"
               onClick={() =>
-                town.key === "withhold"
-                  ? onNavigate("Withhold")
-                  : town.key === "hebron"
-                  ? onNavigate("Hebron")
-                  : town.key === "byford-dolphin"
-                  ? onNavigate("ByfordDolphin")
-                  : town.key === "ballistic-bellows"
-                  ? onNavigate("BallisticBellows")
-                  : town.key === "merricks-meadow"
-                  ? onNavigate("MerricksMeadow")
-                  : town.key === "calidris"
-                  ? onNavigate("Calidris")
-                  : town.key === "analeptic-holt"
-                  ? onNavigate("AnalepticHolt")
-                  : town.key === "orbiting-city"
-                  ? onNavigate("OrbitingCity")
-                  : town.key === "butting-rams"
-                  ? onNavigate("ButtingRams")
-                  : town.key === "jelly-city"
-                  ? onNavigate("JellyCity")
-                  : town.key === "meander"
-                  ? onNavigate("Meander")
-                  : town.key === "seymours-drift"
-                  ? onNavigate("SeymoursDrift")
-                  : town.key === "big-home"
-                  ? onNavigate("BigHome")
-                  : town.key === "graveborn"
-                  ? onNavigate("Graveborn")
-                  : onNavigate("Sandbox")
+                onNavigate(town.routeKey, { settlementType: town.settlementType })
               }
             />
           ))}

--- a/src/MichaelsMount.tsx
+++ b/src/MichaelsMount.tsx
@@ -5,6 +5,8 @@ import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import { MichaelsMountItem, tribeMichaelsMount } from "./tribeMichaelsMount";
 import mountsBackground from "./Mounts.webp";
+import { useSettlementType } from "./SettlementContext";
+import { getAvailableItems } from "./inventoryAvailability";
 
 type DisplayItem = MichaelsMountItem & { finalPrice: number };
 
@@ -17,8 +19,9 @@ function calculateAdjustedPrice(item: Item, priceVariability: number): number {
 }
 
 export function MichaelsMount({ onBack }: { onBack?: () => void }) {
+  const settlementType = useSettlementType();
   const displayItems: DisplayItem[] = useMemo(() => {
-    return tribeMichaelsMount.items
+    return getAvailableItems(tribeMichaelsMount.items, settlementType)
       .map((item) => ({
         ...item,
         finalPrice:
@@ -27,7 +30,7 @@ export function MichaelsMount({ onBack }: { onBack?: () => void }) {
             : 0,
       }))
       .sort((a, b) => a.finalPrice - b.finalPrice || a.name.localeCompare(b.name));
-  }, []);
+  }, [settlementType]);
 
   const formatPrice = (item: DisplayItem) => {
     if (item.priceText) return item.priceText;

--- a/src/MonsterMaker.tsx
+++ b/src/MonsterMaker.tsx
@@ -5,6 +5,8 @@ import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import { MonsterMakerItem, tribeMonsterMaker } from "./tribeMonsterMaker";
 import monsterBackground from "./Monster.webp";
+import { useSettlementType } from "./SettlementContext";
+import { getAvailableItems } from "./inventoryAvailability";
 
 type DisplayItem = MonsterMakerItem & { finalPrice: number };
 
@@ -26,6 +28,7 @@ const cardPalettes = [
 ];
 
 export function MonsterMaker({ onBack }: { onBack?: () => void }) {
+  const settlementType = useSettlementType();
   const groupedItems = useMemo(() => {
     const categoryOrder = [
       "Type of Elemental",
@@ -38,7 +41,7 @@ export function MonsterMaker({ onBack }: { onBack?: () => void }) {
     const categoryMap: Record<string, DisplayItem[]> = {};
     const seenOrder: string[] = [];
 
-    tribeMonsterMaker.items.forEach((item: MonsterMakerItem) => {
+    getAvailableItems(tribeMonsterMaker.items, settlementType).forEach((item: MonsterMakerItem) => {
       const category = item.category || "Other";
       if (!categoryMap[category]) {
         categoryMap[category] = [];
@@ -65,7 +68,7 @@ export function MonsterMaker({ onBack }: { onBack?: () => void }) {
         (a, b) => a.finalPrice - b.finalPrice || a.name.localeCompare(b.name)
       ),
     }));
-  }, []);
+  }, [settlementType]);
 
   const formatPrice = (item: DisplayItem) => {
     if (item.priceText) return item.priceText;

--- a/src/NME.tsx
+++ b/src/NME.tsx
@@ -5,6 +5,8 @@ import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import { NMEItem, tribeNME } from "./tribeNME";
 import nmeBackground from "./N.M.E.png";
+import { useSettlementType } from "./SettlementContext";
+import { getAvailableItems } from "./inventoryAvailability";
 
 type DisplayItem = NMEItem & { finalPrice: number };
 
@@ -22,16 +24,17 @@ function formatPrice(item: DisplayItem): string {
 }
 
 export function NME({ onBack }: { onBack?: () => void }) {
+  const settlementType = useSettlementType();
   const displayItems: DisplayItem[] = useMemo(
     () =>
-      tribeNME.items.map((item) => ({
+      getAvailableItems(tribeNME.items, settlementType).map((item) => ({
         ...item,
         finalPrice:
           item.price > 0
             ? calculateAdjustedPrice(item, tribeNME.priceVariability)
             : 0,
       })),
-    []
+    [settlementType]
   );
 
   return (

--- a/src/NecromancyInsuranceCompany.tsx
+++ b/src/NecromancyInsuranceCompany.tsx
@@ -5,6 +5,8 @@ import { BackButton } from "./BackButton";
 import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import necromancyInsuranceBackground from "./NecromanyInsuranceCo-ezgif.com-webp-to-png-converter.png";
+import { useSettlementType } from "./SettlementContext";
+import { getAvailableItems } from "./inventoryAvailability";
 
 type DisplayItem = Item & { finalPrice: number };
 
@@ -18,14 +20,15 @@ function calculateAdjustedPrice(item: Item, priceVariability: number): number {
 }
 
 export function NecromancyInsuranceCompany({ onBack }: { onBack?: () => void }) {
+  const settlementType = useSettlementType();
   const displayItems: DisplayItem[] = useMemo(() => {
-    return tribeNecromancyInsuranceCompany.items
+    return getAvailableItems(tribeNecromancyInsuranceCompany.items, settlementType)
       .map((item) => ({
         ...item,
         finalPrice: calculateAdjustedPrice(item, tribeNecromancyInsuranceCompany.priceVariability),
       }))
       .sort((a, b) => a.finalPrice - b.finalPrice);
-  }, []);
+  }, [settlementType]);
 
   return (
     <div className={styles.app}>

--- a/src/PawsClawsMaws.tsx
+++ b/src/PawsClawsMaws.tsx
@@ -5,6 +5,8 @@ import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import { PawsClawsMawsItem, tribePawsClawsMaws } from "./tribePawsClawsMaws";
 import pawsClawsMawsBackground from "./Paws, Claws, & Maws.png";
+import { useSettlementType } from "./SettlementContext";
+import { getAvailableItems } from "./inventoryAvailability";
 
 type DisplayItem = PawsClawsMawsItem & { finalPrice: number };
 
@@ -25,8 +27,9 @@ const cardPalettes = [
 ];
 
 export function PawsClawsMaws({ onBack }: { onBack?: () => void }) {
+  const settlementType = useSettlementType();
   const displayItems: DisplayItem[] = useMemo(() => {
-    return tribePawsClawsMaws.items
+    return getAvailableItems(tribePawsClawsMaws.items, settlementType)
       .map((item) => ({
         ...item,
         finalPrice:
@@ -35,7 +38,7 @@ export function PawsClawsMaws({ onBack }: { onBack?: () => void }) {
             : 0,
       }))
       .sort((a, b) => a.finalPrice - b.finalPrice || a.name.localeCompare(b.name));
-  }, []);
+  }, [settlementType]);
 
   const formatPrice = (item: DisplayItem) => {
     if (item.priceText) return item.priceText;

--- a/src/PearlsPotions.tsx
+++ b/src/PearlsPotions.tsx
@@ -5,6 +5,8 @@ import { BackButton } from "./BackButton";
 import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import pearlsPotionsBackground from "./Pearls Potions.png";
+import { useSettlementType } from "./SettlementContext";
+import { getAvailableItems } from "./inventoryAvailability";
 
 type DisplayItem = Item & { finalPrice: number };
 
@@ -17,14 +19,15 @@ function calculateAdjustedPrice(item: Item, priceVariability: number): number {
 }
 
 export function PearlsPotions({ onBack }: { onBack?: () => void }) {
+  const settlementType = useSettlementType();
   const displayItems: DisplayItem[] = useMemo(() => {
-    return tribePearlsPotions.items
+    return getAvailableItems(tribePearlsPotions.items, settlementType)
       .map((item) => ({
         ...item,
         finalPrice: calculateAdjustedPrice(item, tribePearlsPotions.priceVariability),
       }))
       .sort((a, b) => a.finalPrice - b.finalPrice);
-  }, []);
+  }, [settlementType]);
 
   return (
     <div className={styles.app}>

--- a/src/PiggyBank.tsx
+++ b/src/PiggyBank.tsx
@@ -4,6 +4,8 @@ import { BackButton } from "./BackButton";
 import { InsultBox } from "./InsultBox";
 import piggyBankBackground from "./Piggy Bank.png";
 import { PiggyBankItem, tribePiggyBank } from "./tribePiggyBank";
+import { useSettlementType } from "./SettlementContext";
+import { getAvailableItems } from "./inventoryAvailability";
 
 type DisplayItem = PiggyBankItem & { finalPrice?: number; displayPrice: string };
 
@@ -16,8 +18,9 @@ function calculateAdjustedPrice(item: PiggyBankItem, priceVariability: number): 
 }
 
 export function PiggyBank({ onBack }: { onBack?: () => void }) {
+  const settlementType = useSettlementType();
   const displayItems: DisplayItem[] = useMemo(() => {
-    return tribePiggyBank.items.map((item) => {
+    return getAvailableItems(tribePiggyBank.items, settlementType).map((item) => {
       if (item.priceLabel) {
         return { ...item, displayPrice: item.priceLabel };
       }
@@ -29,7 +32,7 @@ export function PiggyBank({ onBack }: { onBack?: () => void }) {
         displayPrice: `${finalPrice.toLocaleString()} Gold`,
       };
     });
-  }, []);
+  }, [settlementType]);
 
   return (
     <div className={styles.app}>

--- a/src/RunestoneRelay.tsx
+++ b/src/RunestoneRelay.tsx
@@ -5,6 +5,8 @@ import { BackButton } from "./BackButton";
 import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import runestoneRelayBackground from "./Runestone Relay.png";
+import { useSettlementType } from "./SettlementContext";
+import { getAvailableItems } from "./inventoryAvailability";
 
 type DisplayItem = Item & { finalPrice: number };
 
@@ -17,8 +19,9 @@ function calculateAdjustedPrice(item: Item, priceVariability: number): number {
 }
 
 export function RunestoneRelay({ onBack }: { onBack?: () => void }) {
+  const settlementType = useSettlementType();
   const displayItems: DisplayItem[] = useMemo(() => {
-    return tribeRunestoneRelay.items
+    return getAvailableItems(tribeRunestoneRelay.items, settlementType)
       .map((item) => ({
         ...item,
         finalPrice: calculateAdjustedPrice(
@@ -27,7 +30,7 @@ export function RunestoneRelay({ onBack }: { onBack?: () => void }) {
         ),
       }))
       .sort((a, b) => a.finalPrice - b.finalPrice);
-  }, []);
+  }, [settlementType]);
 
   return (
     <div className={styles.app}>

--- a/src/SettlementContext.tsx
+++ b/src/SettlementContext.tsx
@@ -1,0 +1,23 @@
+import { createContext, useContext } from "react";
+import type { ReactNode } from "react";
+import { SettlementType } from "./inventoryAvailability";
+
+const SettlementContext = createContext<SettlementType | undefined>(undefined);
+
+export function SettlementProvider({
+  settlementType,
+  children,
+}: {
+  settlementType?: SettlementType;
+  children: ReactNode;
+}) {
+  return (
+    <SettlementContext.Provider value={settlementType}>
+      {children}
+    </SettlementContext.Provider>
+  );
+}
+
+export function useSettlementType() {
+  return useContext(SettlementContext);
+}

--- a/src/ShopTemplate.tsx
+++ b/src/ShopTemplate.tsx
@@ -3,6 +3,8 @@ import defaultStyles from "./BookBombs.module.css";
 import { BackButton } from "./BackButton";
 import { InsultBox } from "./InsultBox";
 import { Item, Tribe } from "./types";
+import { useSettlementType } from "./SettlementContext";
+import { getAvailableItems } from "./inventoryAvailability";
 
 type DisplayItem = Item & { finalPrice: number };
 type ShopTemplateStyles = typeof defaultStyles;
@@ -26,14 +28,18 @@ export function ShopTemplate({
   onBack?: () => void;
   styles?: ShopTemplateStyles;
 }) {
+  const settlementType = useSettlementType();
+
   const displayItems: DisplayItem[] = useMemo(() => {
-    return tribe.items
+    const availableItems = getAvailableItems(tribe.items, settlementType);
+
+    return availableItems
       .map((item) => ({
         ...item,
         finalPrice: calculateAdjustedPrice(item, tribe.priceVariability),
       }))
       .sort((a, b) => a.finalPrice - b.finalPrice);
-  }, [tribe]);
+  }, [settlementType, tribe]);
 
   return (
     <div className={styles.app}>

--- a/src/SleuthUniversity.tsx
+++ b/src/SleuthUniversity.tsx
@@ -8,6 +8,8 @@ import {
   tribeSleuthUniversity,
 } from "./tribeSleuthUniversity";
 import sleuthBackground from "./Sleuth.webp";
+import { useSettlementType } from "./SettlementContext";
+import { getAvailableItems } from "./inventoryAvailability";
 
 type DisplayItem = SleuthUniversityItem & { finalPrice: number };
 
@@ -25,16 +27,17 @@ function formatPrice(item: DisplayItem): string {
 }
 
 export function SleuthUniversity({ onBack }: { onBack?: () => void }) {
+  const settlementType = useSettlementType();
   const displayItems: DisplayItem[] = useMemo(
     () =>
-      tribeSleuthUniversity.items.map((item) => ({
+      getAvailableItems(tribeSleuthUniversity.items, settlementType).map((item) => ({
         ...item,
         finalPrice:
           item.price > 0
             ? calculateAdjustedPrice(item, tribeSleuthUniversity.priceVariability)
             : 0,
       })),
-    []
+    [settlementType]
   );
 
   return (

--- a/src/ValhallaMart.tsx
+++ b/src/ValhallaMart.tsx
@@ -5,6 +5,8 @@ import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import { ValhallaMartItem, tribeValhallaMart } from "./tribeValhallaMart";
 import valhallaBackground from "./Valhalla Mart.png";
+import { useSettlementType } from "./SettlementContext";
+import { getAvailableItems } from "./inventoryAvailability";
 
 type DisplayItem = ValhallaMartItem & { finalPrice: number };
 
@@ -17,8 +19,9 @@ function calculateAdjustedPrice(item: Item, priceVariability: number): number {
 }
 
 export function ValhallaMart({ onBack }: { onBack?: () => void }) {
+  const settlementType = useSettlementType();
   const displayItems: DisplayItem[] = useMemo(() => {
-    return tribeValhallaMart.items
+    return getAvailableItems(tribeValhallaMart.items, settlementType)
       .map((item) => ({
         ...item,
         finalPrice:
@@ -27,7 +30,7 @@ export function ValhallaMart({ onBack }: { onBack?: () => void }) {
             : 0,
       }))
       .sort((a, b) => a.finalPrice - b.finalPrice || a.name.localeCompare(b.name));
-  }, []);
+  }, [settlementType]);
 
   const formatPrice = (item: DisplayItem) => {
     if (item.priceText) return item.priceText;

--- a/src/YeOldDonkey.tsx
+++ b/src/YeOldDonkey.tsx
@@ -4,6 +4,8 @@ import { tribeYeOldDonkey } from "./tribeYeOldDonkey";
 import { BackButton } from "./BackButton";
 import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
+import { useSettlementType } from "./SettlementContext";
+import { getAvailableItems } from "./inventoryAvailability";
 import yeOldDonkeyBackground from "./Ye Old Donkey.png";
 
 type DisplayItem = Item & { finalPrice: number };
@@ -17,14 +19,16 @@ function calculateAdjustedPrice(item: Item, priceVariability: number): number {
 }
 
 export function YeOldDonkey({ onBack }: { onBack?: () => void }) {
+  const settlementType = useSettlementType();
+
   const displayItems: DisplayItem[] = useMemo(() => {
-    return tribeYeOldDonkey.items
+    return getAvailableItems(tribeYeOldDonkey.items, settlementType)
       .map((item) => ({
         ...item,
         finalPrice: calculateAdjustedPrice(item, tribeYeOldDonkey.priceVariability),
       }))
       .sort((a, b) => a.finalPrice - b.finalPrice);
-  }, []);
+  }, [settlementType]);
 
   return (
     <div className={styles.app}>

--- a/src/YeOldHomeDepot.tsx
+++ b/src/YeOldHomeDepot.tsx
@@ -5,6 +5,8 @@ import { InsultBox } from "./InsultBox";
 import { Item } from "./types";
 import { YeOldHomeDepotItem, tribeYeOldHomeDepot } from "./tribeYeOldHomeDepot";
 import sleuthBackground from "./Ye Old Home Depot.webp";
+import { useSettlementType } from "./SettlementContext";
+import { getAvailableItems } from "./inventoryAvailability";
 
 type DisplayItem = YeOldHomeDepotItem & { finalPrice: number };
 
@@ -37,9 +39,10 @@ function formatPrice(item: DisplayItem): string {
 }
 
 export function YeOldHomeDepot({ onBack }: { onBack?: () => void }) {
+  const settlementType = useSettlementType();
   const displayItems: DisplayItem[] = useMemo(
     () =>
-      tribeYeOldHomeDepot.items.map((item) => ({
+      getAvailableItems(tribeYeOldHomeDepot.items, settlementType).map((item) => ({
         ...item,
         finalPrice:
           item.price > 0
@@ -47,7 +50,7 @@ export function YeOldHomeDepot({ onBack }: { onBack?: () => void }) {
             : 0,
       }))
       .sort(sortByPrice),
-    []
+    [settlementType]
   );
 
   return (

--- a/src/inventoryAvailability.ts
+++ b/src/inventoryAvailability.ts
@@ -1,0 +1,53 @@
+import { Item } from "./types";
+
+export type SettlementType =
+  | "Isolated Dwelling"
+  | "Thorpe"
+  | "Hamlet"
+  | "Village"
+  | "Town"
+  | "City"
+  | "Metropolis";
+
+export const settlementInventoryPercent: Record<SettlementType, number> = {
+  "Isolated Dwelling": 10,
+  Thorpe: 25,
+  Hamlet: 40,
+  Village: 55,
+  Town: 70,
+  City: 85,
+  Metropolis: 100,
+};
+
+export function getVisibleItemCount(totalItems: number, settlementType?: SettlementType): number {
+  if (totalItems <= 0) {
+    return 0;
+  }
+
+  if (!settlementType) {
+    return totalItems;
+  }
+
+  const percent = settlementInventoryPercent[settlementType];
+  const count = Math.floor((totalItems * percent) / 100);
+  return Math.max(1, count);
+}
+
+function shuffle<T>(items: T[]): T[] {
+  const copy = [...items];
+  for (let i = copy.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+
+  return copy;
+}
+
+export function getAvailableItems<T extends Item>(items: T[], settlementType?: SettlementType): T[] {
+  const count = getVisibleItemCount(items.length, settlementType);
+  if (count >= items.length) {
+    return [...items];
+  }
+
+  return shuffle(items).slice(0, count);
+}


### PR DESCRIPTION
### Motivation

- Allow shops to show a subset of their inventory depending on the settlement type so sandbox towns/portals can simulate different market sizes.
- Propagate the selected settlement type from the map/sandbox navigation so views can adjust available items dynamically.

### Description

- Add `inventoryAvailability.ts` which defines `SettlementType`, availability percentages, and `getAvailableItems` to pick a randomized visible subset of items based on settlement size.
- Add `SettlementContext.tsx` that exposes `useSettlementType` and `SettlementProvider` for components to read the currently-selected settlement type.
- Wire most shop components and templates to import `useSettlementType` and `getAvailableItems`, filter their `tribe.items` through `getAvailableItems`, and add `settlementType` to `useMemo` dependencies so items update when the settlement changes.  `ShopTemplate` and a number of shop files were updated accordingly.
- Update list-based pages (`Auction`, `Black`, `Goblins`) with a small `getFilteredTribes` helper to filter each tribe's `items` by settlement type and ensure indices/clicks logic uses the filtered lists.
- Update `Map.tsx` to surface `settlementType` when navigating from the Sandbox and wrap the rendered view with `SettlementProvider` so child views can access the selected settlement type.

### Testing

- Ran TypeScript type-check with `tsc --noEmit` and the codebase type-checks successfully.
- Built the app using the project build command (`npm run build`) and the build completed without errors.
- Ran the test suite (`npm test`) and existing tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a50876473883298564c7c893c68fc3)