### PR TITLE
Fix settlement type persistence when navigating shops

### DIFF
--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -325,7 +325,9 @@ export function Map() {
     options?: { settlementType?: SettlementType }
   ) => {
     setNavigationStack((stack) => [...stack, navigatedTo]);
-    setSelectedSettlementType(options?.settlementType);
+    if (options && Object.prototype.hasOwnProperty.call(options, "settlementType")) {
+      setSelectedSettlementType(options.settlementType);
+    }
     setNavigatedTo(next);
   };
   const handleBack = () => {
@@ -876,7 +878,7 @@ export function Map() {
           <div style={styles.buttonContainer}>
             <FloatingButton
               label="Sandbox"
-              onClick={() => handleNavigate("Sandbox")}
+              onClick={() => handleNavigate("Sandbox", { settlementType: undefined })}
               delay="1.5s"
               backgroundColor="rgba(15, 23, 42, 0.85)"
               color="#e2e8f0"
@@ -892,7 +894,7 @@ export function Map() {
             />
             <FloatingButton
               label="Every Shop"
-              onClick={() => handleNavigate("EveryShop")}
+              onClick={() => handleNavigate("EveryShop", { settlementType: undefined })}
               delay="3s"
               backgroundColor="rgba(30, 64, 175, 0.9)"
               color="#e2e8f0"


### PR DESCRIPTION
### Motivation
- Navigating to top-level views without navigation options kept the previously selected `settlementType` in context, which unintentionally filtered shop inventories by an old town rank.

### Description
- Change `handleNavigate` in `src/Map.tsx` to only call `setSelectedSettlementType` when `options` explicitly contains a `settlementType` property, and update the top-level `Sandbox` and `EveryShop` buttons to call `handleNavigate` with `{ settlementType: undefined }` so those views clear any previously set settlement type.

### Testing
- Ran `npm run build` and the production build completed successfully (there are unrelated lint warnings in other files).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5140784f48329baeb69dc2a67ca6f)