### PR TITLE
Use settlement size limits consistently for Goblin, Black, and Auction markets

### DIFF
--- a/src/Auction.tsx
+++ b/src/Auction.tsx
@@ -12,16 +12,9 @@ import { getNextItem } from "./getNextItem";
 import { getCookie } from "./cookies";
 import { BackButton } from "./BackButton";
 import { useSettlementType } from "./SettlementContext";
-import { getAvailableItems } from "./inventoryAvailability";
+import { filterMarketTribesBySettlement } from "./marketInventory";
 
 const MAX_CLICKS = 3;
-
-function getFilteredTribes(tribes: Tribe[], settlementType?: import("./inventoryAvailability").SettlementType): Tribe[] {
-  return tribes.map((tribe) => ({
-    ...tribe,
-    items: getAvailableItems(tribe.items, settlementType),
-  }));
-}
 
 export function getIndices(tribes: Tribe[], oldList: number[] = []): number[] {
   return tribes.map((tribe, index) => getNextItem(tribe.items, oldList[index]));
@@ -43,7 +36,7 @@ function getInitialIndices(tribes: Tribe[]): number[] {
 
 export function Auctions({ onBack }: { onBack?: () => void }) {
   const settlementType = useSettlementType();
-  const tribes = getFilteredTribes([tribeAuctionHouse, tribeAuctionHouse2, tribeAuctionHouse3, tribeAuctionHouse4, tribeAuctionHouse5 ], settlementType);
+  const tribes = filterMarketTribesBySettlement([tribeAuctionHouse, tribeAuctionHouse2, tribeAuctionHouse3, tribeAuctionHouse4, tribeAuctionHouse5 ], settlementType);
   const [clicks, setClicks] = useState(getInitialClicks());
   const [indices, setIndices] = useState(getInitialIndices(tribes));
   const scrollToTop = () => {

--- a/src/Black.tsx
+++ b/src/Black.tsx
@@ -12,16 +12,9 @@ import { getNextItem } from "./getNextItem";
 import { getCookie } from "./cookies";
 import { BackButton } from "./BackButton";
 import { useSettlementType } from "./SettlementContext";
-import { getAvailableItems } from "./inventoryAvailability";
+import { filterMarketTribesBySettlement } from "./marketInventory";
 
 const MAX_CLICKS = 2;
-
-function getFilteredTribes(tribes: Tribe[], settlementType?: import("./inventoryAvailability").SettlementType): Tribe[] {
-  return tribes.map((tribe) => ({
-    ...tribe,
-    items: getAvailableItems(tribe.items, settlementType),
-  }));
-}
 
 export function getIndices(tribes: Tribe[], oldList: number[] = []): number[] {
   return tribes.map((tribe, index) => getNextItem(tribe.items, oldList[index]));
@@ -43,7 +36,7 @@ function getInitialIndices(tribes: Tribe[]): number[] {
 
 export function Blacks({ onBack }: { onBack?: () => void }) {
   const settlementType = useSettlementType();
-  const tribes = getFilteredTribes([tribeBlackMarket, tribeBlackMarket2, tribeBlackMarket3, tribeBlackMarket4, tribeBlackMarket5], settlementType);
+  const tribes = filterMarketTribesBySettlement([tribeBlackMarket, tribeBlackMarket2, tribeBlackMarket3, tribeBlackMarket4, tribeBlackMarket5], settlementType);
 
   const [clicks, setClicks] = useState(getInitialClicks());
 

--- a/src/Goblins.tsx
+++ b/src/Goblins.tsx
@@ -14,16 +14,9 @@ import { getNextItem } from "./getNextItem";
 import { getCookie } from "./cookies";
 import { BackButton } from "./BackButton";
 import { useSettlementType } from "./SettlementContext";
-import { getAvailableItems } from "./inventoryAvailability";
+import { filterMarketTribesBySettlement } from "./marketInventory";
 
 const MAX_CLICKS = 5;
-
-function getFilteredTribes(tribes: Tribe[], settlementType?: import("./inventoryAvailability").SettlementType): Tribe[] {
-  return tribes.map((tribe) => ({
-    ...tribe,
-    items: getAvailableItems(tribe.items, settlementType),
-  }));
-}
 
 export function getIndices(tribes: Tribe[], oldList: number[] = []): number[] {
   return tribes.map((tribe, index) => getNextItem(tribe.items, oldList[index]));
@@ -45,7 +38,7 @@ function getInitialIndices(tribes: Tribe[]): number[] {
 
 export function Goblins({ onBack }: { onBack?: () => void }) {
   const settlementType = useSettlementType();
-  const tribes = getFilteredTribes([tribe1, tribe2, tribe3, tribe4, tribe5, tribe6, tribe7], settlementType);
+  const tribes = filterMarketTribesBySettlement([tribe1, tribe2, tribe3, tribe4, tribe5, tribe6, tribe7], settlementType);
 
   const [clicks, setClicks] = useState(getInitialClicks());
 

--- a/src/marketInventory.test.ts
+++ b/src/marketInventory.test.ts
@@ -1,0 +1,32 @@
+import { filterMarketTribesBySettlement } from "./marketInventory";
+import { Tribe } from "./types";
+
+const baseTribe: Tribe = {
+  name: "Test Vendor",
+  percentAngry: 0,
+  insults: [],
+  priceVariability: 0,
+  items: [
+    { name: "Item 1", description: "", price: 100 },
+    { name: "Item 2", description: "", price: 200 },
+    { name: "Item 3", description: "", price: 300 },
+    { name: "Item 4", description: "", price: 400 },
+    { name: "Item 5", description: "", price: 500 },
+  ],
+};
+
+describe("filterMarketTribesBySettlement", () => {
+  it("limits items by settlement size for market tribes", () => {
+    const [thorpe] = filterMarketTribesBySettlement([baseTribe], "Thorpe");
+    const [metropolis] = filterMarketTribesBySettlement([baseTribe], "Metropolis");
+
+    expect(thorpe.items).toHaveLength(1);
+    expect(metropolis.items).toHaveLength(5);
+  });
+
+  it("keeps all items when settlement size is not provided", () => {
+    const [allItems] = filterMarketTribesBySettlement([baseTribe]);
+
+    expect(allItems.items).toHaveLength(5);
+  });
+});

--- a/src/marketInventory.ts
+++ b/src/marketInventory.ts
@@ -1,0 +1,12 @@
+import { getAvailableItems, SettlementType } from "./inventoryAvailability";
+import { Tribe } from "./types";
+
+export function filterMarketTribesBySettlement(
+  tribes: Tribe[],
+  settlementType?: SettlementType
+): Tribe[] {
+  return tribes.map((tribe) => ({
+    ...tribe,
+    items: getAvailableItems(tribe.items, settlementType),
+  }));
+}


### PR DESCRIPTION
### Motivation
- Make the Goblin Market, Black Market, and Auction House honor the same settlement-size based item visibility rules so market item lists reflect the size of the current location.

### Description
- Added a shared helper `filterMarketTribesBySettlement` in `src/marketInventory.ts` that applies `getAvailableItems` to each tribe's `items` based on a `SettlementType`.
- Replaced duplicated per-file filtering logic with `filterMarketTribesBySettlement` in `src/Goblins.tsx`, `src/Black.tsx`, and `src/Auction.tsx` so those three markets use location size to limit visible items.
- Added unit tests in `src/marketInventory.test.ts` covering small-settlement limiting and the no-settlement (full list) case.

### Testing
- Ran the new unit tests with `npm test -- --watchAll=false src/marketInventory.test.ts` and they passed. ✅
- Ran the full test suite with `npm test -- --watchAll=false`; the suite failed but the failure is due to existing unrelated test/environment issues in `src/App.test.tsx` (jsdom `canvas` API not available and a heading text mismatch) and not due to the market changes. ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a52725c18083298b43293894eafbf5)