### PR TITLE
Remove settlement-size inventory limits from Goblin, Black, and Auction markets

### DIFF
--- a/src/Auction.tsx
+++ b/src/Auction.tsx
@@ -11,15 +11,14 @@ import { tribeAuctionHouse5 } from "./tribeAuctionHouse5";
 import { getNextItem } from "./getNextItem";
 import { getCookie } from "./cookies";
 import { BackButton } from "./BackButton";
-import { useSettlementType } from "./SettlementContext";
 import { getAvailableItems } from "./inventoryAvailability";
 
 const MAX_CLICKS = 3;
 
-function getFilteredTribes(tribes: Tribe[], settlementType?: import("./inventoryAvailability").SettlementType): Tribe[] {
+function getFilteredTribes(tribes: Tribe[]): Tribe[] {
   return tribes.map((tribe) => ({
     ...tribe,
-    items: getAvailableItems(tribe.items, settlementType),
+    items: getAvailableItems(tribe.items),
   }));
 }
 
@@ -42,8 +41,7 @@ function getInitialIndices(tribes: Tribe[]): number[] {
 }
 
 export function Auctions({ onBack }: { onBack?: () => void }) {
-  const settlementType = useSettlementType();
-  const tribes = getFilteredTribes([tribeAuctionHouse, tribeAuctionHouse2, tribeAuctionHouse3, tribeAuctionHouse4, tribeAuctionHouse5 ], settlementType);
+  const tribes = getFilteredTribes([tribeAuctionHouse, tribeAuctionHouse2, tribeAuctionHouse3, tribeAuctionHouse4, tribeAuctionHouse5 ]);
   const [clicks, setClicks] = useState(getInitialClicks());
   const [indices, setIndices] = useState(getInitialIndices(tribes));
   const scrollToTop = () => {

--- a/src/Black.tsx
+++ b/src/Black.tsx
@@ -11,15 +11,14 @@ import { tribeBlackMarket5 } from "./tribeBlackMarket5";
 import { getNextItem } from "./getNextItem";
 import { getCookie } from "./cookies";
 import { BackButton } from "./BackButton";
-import { useSettlementType } from "./SettlementContext";
 import { getAvailableItems } from "./inventoryAvailability";
 
 const MAX_CLICKS = 2;
 
-function getFilteredTribes(tribes: Tribe[], settlementType?: import("./inventoryAvailability").SettlementType): Tribe[] {
+function getFilteredTribes(tribes: Tribe[]): Tribe[] {
   return tribes.map((tribe) => ({
     ...tribe,
-    items: getAvailableItems(tribe.items, settlementType),
+    items: getAvailableItems(tribe.items),
   }));
 }
 
@@ -42,8 +41,7 @@ function getInitialIndices(tribes: Tribe[]): number[] {
 }
 
 export function Blacks({ onBack }: { onBack?: () => void }) {
-  const settlementType = useSettlementType();
-  const tribes = getFilteredTribes([tribeBlackMarket, tribeBlackMarket2, tribeBlackMarket3, tribeBlackMarket4, tribeBlackMarket5], settlementType);
+  const tribes = getFilteredTribes([tribeBlackMarket, tribeBlackMarket2, tribeBlackMarket3, tribeBlackMarket4, tribeBlackMarket5]);
 
   const [clicks, setClicks] = useState(getInitialClicks());
 

--- a/src/Goblins.tsx
+++ b/src/Goblins.tsx
@@ -13,15 +13,14 @@ import { tribe7 } from "./tribe7";
 import { getNextItem } from "./getNextItem";
 import { getCookie } from "./cookies";
 import { BackButton } from "./BackButton";
-import { useSettlementType } from "./SettlementContext";
 import { getAvailableItems } from "./inventoryAvailability";
 
 const MAX_CLICKS = 5;
 
-function getFilteredTribes(tribes: Tribe[], settlementType?: import("./inventoryAvailability").SettlementType): Tribe[] {
+function getFilteredTribes(tribes: Tribe[]): Tribe[] {
   return tribes.map((tribe) => ({
     ...tribe,
-    items: getAvailableItems(tribe.items, settlementType),
+    items: getAvailableItems(tribe.items),
   }));
 }
 
@@ -44,8 +43,7 @@ function getInitialIndices(tribes: Tribe[]): number[] {
 }
 
 export function Goblins({ onBack }: { onBack?: () => void }) {
-  const settlementType = useSettlementType();
-  const tribes = getFilteredTribes([tribe1, tribe2, tribe3, tribe4, tribe5, tribe6, tribe7], settlementType);
+  const tribes = getFilteredTribes([tribe1, tribe2, tribe3, tribe4, tribe5, tribe6, tribe7]);
 
   const [clicks, setClicks] = useState(getInitialClicks());
 


### PR DESCRIPTION
### Motivation

- Make Goblin Market, Black Market, and Auction House inventories independent of the settlement size so those shops always show the full available item sets.

### Description

- Removed `useSettlementType` import and settlement-type parameter from the market flows in `src/Goblins.tsx`, `src/Black.tsx`, and `src/Auction.tsx` so markets no longer consult the location size when preparing items.
- Changed `getFilteredTribes` signature to `getFilteredTribes(tribes: Tribe[])` and call `getAvailableItems(tribe.items)` (no settlement argument) in each of the three files.
- Updated the three market components to construct `tribes` without passing a `settlementType` argument at the call site.
- Files changed: `src/Goblins.tsx`, `src/Black.tsx`, `src/Auction.tsx`.

### Testing

- Ran `npm run build`, which completed successfully (build emitted minor ESLint warnings but succeeded).
- Ran `npm test -- --watchAll=false`, which failed due to existing test environment issues (jsdom `canvas.getContext` not implemented and an outdated App test expectation) that are unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5284178388329ad22dbd22291ebd2)