### PR TITLE
Fix Jell Bell slime art visibility on mobile

### DIFF
--- a/src/JellBell.module.css
+++ b/src/JellBell.module.css
@@ -243,13 +243,21 @@
 
 .slimeArt {
   position: relative;
-  width: min(100%, 260px);
-  aspect-ratio: 1;
+  width: 100%;
+  max-width: 260px;
+  height: 260px;
   margin: 0 auto 0.9rem;
   border-radius: 14px;
   overflow: hidden;
   background: rgba(15, 23, 42, 0.5);
   border: 1px solid rgba(251, 191, 36, 0.35);
+}
+
+@supports (aspect-ratio: 1 / 1) {
+  .slimeArt {
+    height: auto;
+    aspect-ratio: 1 / 1;
+  }
 }
 
 .slimeLayer {
@@ -306,6 +314,10 @@
 @media (max-width: 900px) {
   .dualResult {
     grid-template-columns: 1fr;
+  }
+
+  .slimeArt {
+    height: 220px;
   }
 
   .statsGrid,


### PR DESCRIPTION
### Motivation
- Mobile browsers can collapse containers that rely solely on `aspect-ratio`, causing the layered slime images to render with zero height and not appear, so the preview needs a reliable fallback for smaller or older browsers.

### Description
- Update `src/JellBell.module.css` to give `.slimeArt` an explicit fallback size (`width: 100%; max-width: 260px; height: 260px;`), add `@supports (aspect-ratio: 1 / 1)` to preserve the modern square layout when supported, and reduce the height to `220px` under the existing `@media (max-width: 900px)` breakpoint.

### Testing
- Ran `npm run build` successfully and validated the change in a mobile viewport with Playwright by navigating to Every Shop → Jell Bell and generating a 3 Star slime, confirming the layered slime imagery renders as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1e7e526608329be5af27ccd9b4c6f)