### PR TITLE
Set requested sandbox towns to Metropolis inventory tier

### DIFF
--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -181,7 +181,7 @@ const sandboxTowns: SandboxTown[] = [
     key: "withhold",
     routeKey: "Withhold",
     name: "Withhold (Parker)",
-    settlementType: "Thorpe",
+    settlementType: "Metropolis",
     image: sandboxWytheholdeImage,
     description:
       "Nestled between warm rolling hills and jagged, freezing mountains, Withhold grows famous home-grown food but struggles for medicine once winter comes. As they live in Wandering Titan territory, nearly everyone knows how to flee into the tight valley caves when danger looms, preserving the town's dwindling stories.",
@@ -190,7 +190,7 @@ const sandboxTowns: SandboxTown[] = [
     key: "butting-rams",
     routeKey: "ButtingRams",
     name: "Butting Rams",
-    settlementType: "Hamlet",
+    settlementType: "Metropolis",
     image: sandboxButtingRamsImage,
     description:
       "Barbarians here love fighting, feasting, and boasting about both. Their town is literally split between two enormous rams that butt heads, catapulting residents back and forth—thankfully the rams are fluffy enough to make the landings survivable before the traditional 15-minute free-for-all.",
@@ -199,7 +199,7 @@ const sandboxTowns: SandboxTown[] = [
     key: "meander",
     routeKey: "Meander",
     name: "Meander (Michael)",
-    settlementType: "Thorpe",
+    settlementType: "Metropolis",
     image: sandboxMeanderImage,
     description:
       "A cowboy's dream that never settles, Meander roams Wandering Titan territory after draining every Magitek Oil spot. Constant desert travel keeps crops from thriving, so the townsfolk trade for food while clinging to a strong moral compass they defend fiercely.",
@@ -208,7 +208,7 @@ const sandboxTowns: SandboxTown[] = [
     key: "calidris",
     routeKey: "Calidris",
     name: "Calidris (Fisk)",
-    settlementType: "Hamlet",
+    settlementType: "Metropolis",
     image: sandboxCalidrisImage,
     description:
       "Created as an artisans' paradise with no creative limits, Calidris thrived—until every living resident vanished overnight. Only the golems and robots remain, tirelessly working while ignoring their missing masters.",
@@ -217,7 +217,7 @@ const sandboxTowns: SandboxTown[] = [
     key: "merricks-meadow",
     routeKey: "MerricksMeadow",
     name: "Merrick's Meadow (Howard)",
-    settlementType: "Village",
+    settlementType: "Metropolis",
     image: sandboxMerricksGroveImage,
     description:
       "This humble village boomed after discovering rare herbs. Newcomers flock to Merrick's Meadow for its newfound fame, while longtime residents grumble about the crowds disturbing their once-tranquil home.",
@@ -226,7 +226,7 @@ const sandboxTowns: SandboxTown[] = [
     key: "ballistic-bellows",
     routeKey: "BallisticBellows",
     name: "Ballistic Bellows (Caleb)",
-    settlementType: "Village",
+    settlementType: "Metropolis",
     image: sandboxBallisticBellowsImage,
     description:
       "Punctual and industrious, every citizen can run a forge or clockwork device. Their advanced weapons self-destruct if reverse engineered, protecting the secrets behind their booming craft.",
@@ -235,7 +235,7 @@ const sandboxTowns: SandboxTown[] = [
     key: "byford-dolphin",
     routeKey: "ByfordDolphin",
     name: "Byford Dolphin (Robertson)",
-    settlementType: "Village",
+    settlementType: "Metropolis",
     image: sandboxByfordDolphinImage,
     description:
       "Wealth dictates status in Byford Dolphin. Legendary metals pulled from the sea fund the Clockwork King's construction projects, while the richest citizen holds the House of Blades contract—and the bill that comes with it.",
@@ -244,7 +244,7 @@ const sandboxTowns: SandboxTown[] = [
     key: "hebron",
     routeKey: "Hebron",
     name: "Hebron (Joshua)",
-    settlementType: "Town",
+    settlementType: "Metropolis",
     image: sandboxHebronImage,
     description:
       "After the Missing Millennium, Hebron secured a monopoly on Thunder Cores by salvaging and purchasing every relic they could find. Now it's a hub for minds devoted to unlocking the power behind these remnants.",
@@ -253,7 +253,7 @@ const sandboxTowns: SandboxTown[] = [
     key: "jelly-city",
     routeKey: "JellyCity",
     name: "Jelly City",
-    settlementType: "Town",
+    settlementType: "Metropolis",
     image: sandboxJellyCityImage,
     description:
       "Built vertically inside a Wandering Titan jellyfish, this flexible city produces medicine that keeps the Disciples of Mother battle-ready. Its secrets are hard to see, but unforgettable once witnessed.",
@@ -262,7 +262,7 @@ const sandboxTowns: SandboxTown[] = [
     key: "pop-n-faith",
     routeKey: "Sandbox",
     name: "Pop-n Faith (Eli)",
-    settlementType: "City",
+    settlementType: "Metropolis",
     image: sandboxPopNFaithImage,
     description:
       "Sorry, but there is no more Pop-n Faith. Your world deities are gone; now your planet is stuck between death and unlife.",
@@ -271,7 +271,7 @@ const sandboxTowns: SandboxTown[] = [
     key: "analeptic-holt",
     routeKey: "AnalepticHolt",
     name: "Analeptic Holt (Teag)",
-    settlementType: "City",
+    settlementType: "Metropolis",
     image: sandboxAnalepticHoltImage,
     description:
       "Hidden beneath an ancient jungle canopy, Hadozee gliders live among massive roots and high branches. They cherish harmony with their environment but stay guarded with outsiders to protect their traditions.",
@@ -280,7 +280,7 @@ const sandboxTowns: SandboxTown[] = [
     key: "seymours-drift",
     routeKey: "SeymoursDrift",
     name: "Seymour's Drift (Melanie)",
-    settlementType: "City",
+    settlementType: "Metropolis",
     image: sandboxSeymoursDriftImage,
     description:
       "A sprawling city on a giant drifting lily pad, Seymour's Drift follows the tides while serving its enigmatic leader, Audrey the Second. Residents bond over devotion, firearms, and an unyielding love of meat.",
@@ -289,7 +289,7 @@ const sandboxTowns: SandboxTown[] = [
     key: "graveborn",
     routeKey: "Graveborn",
     name: "Graveborn",
-    settlementType: "City",
+    settlementType: "Metropolis",
     image: sandboxGraveBornImage,
     description:
       "A sanctuary for the undead, founded before the 75-year war so vampires, zombies, skeletons, and even dream visages could live free. Left alone, the undead eventually wander toward this vibrant necropolis.",
@@ -298,7 +298,7 @@ const sandboxTowns: SandboxTown[] = [
     key: "orbiting-city",
     routeKey: "OrbitingCity",
     name: "Orbiting City",
-    settlementType: "City",
+    settlementType: "Metropolis",
     image: sandboxOrbitingCityImage,
     description:
       "Humanity pushed the impossible to reality, building a city that sails the sky thanks to alliances and generosity toward the Clockwork King. Its flight marks a new era of exploration and diplomacy.",


### PR DESCRIPTION
### Motivation
- Make the listed sandbox towns use the highest inventory tier so their shops supply Metropolis-level inventories when selected.

### Description
- Updated `settlementType` to `"Metropolis"` for the selected sandbox towns in `src/Map.tsx` so shop inventory selection uses the Metropolis tier.
- The towns changed are: Withhold (Parker), Butting Rams, Meander (Michael), Calidris (Fisk), Merrick's Meadow (Howard), Ballistic Bellows (Caleb), Byford Dolphin (Robertson), Hebron (Joshua), Jelly City, Pop-n Faith (Eli), Analeptic Holt (Teag), Seymour's Drift (Melanie), Graveborn, and Orbiting City.
- No other files, assets, or shop lists were modified.

### Testing
- Ran `npm run build` and produced a successful production build (the build completed with pre-existing ESLint warnings unrelated to this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b22d48d7ac8329a18e9361ac9905af)