### PR TITLE
Use StrenuousTrue assets for portal button and add map/news panels

### DIFF
--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -115,7 +115,7 @@ import { JellyCity } from "./JellyCity";
 import { ByfordDolphinRobertson } from "./ByfordDolphinRobertson";
 import { Graveborn } from "./Graveborn";
 import { StrenuousPortal } from "./StrenuousPortal";
-import strenuousPortalButtonImage from "./StrenuousPortalButton2.webp";
+import strenuousPortalButtonImage from "./StrenuousTrue.webp";
 import { SettlementProvider } from "./SettlementContext";
 import { SettlementType } from "./inventoryAvailability";
 

--- a/src/StrenuousPortal.module.css
+++ b/src/StrenuousPortal.module.css
@@ -70,6 +70,20 @@
   width: 100%;
   gap: 1.25rem;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  padding: 1.25rem;
+  border-radius: 20px;
+  background-image: linear-gradient(rgba(15, 23, 42, 0.75), rgba(15, 23, 42, 0.75)), url("./StrenuousTrue.webp");
+  background-size: cover;
+  background-position: center;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+}
+
+.featureImage {
+  width: 100%;
+  max-width: 900px;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.35);
 }
 
 .shopButton {

--- a/src/StrenuousPortal.tsx
+++ b/src/StrenuousPortal.tsx
@@ -1,5 +1,6 @@
-import backgroundImage from "./StrenuousPortalButton2.webp";
-import applegarthImage from "./Applegarth.webp";
+import backgroundImage from "./StrenuousTrue.webp";
+import strenuousMapImage from "./StrenuousMap.webp";
+import strenuousNewsImage from "./StrenuousNews.png";
 import archivesGuildImage from "./Archives Guild.png";
 import bookBombsImage from "./Book Bomb.png";
 import bulletsBuffsBeyondImage from "./Bullets Buffs and Beyond.webp";
@@ -215,6 +216,12 @@ export function StrenuousPortal({
           </p>
         </div>
 
+        <img
+          className={styles.featureImage}
+          src={strenuousMapImage}
+          alt="Map view of the Strenuous Portal"
+        />
+
         <div className={styles.buttonGrid}>
           {sortedShops.map((shop) => (
             <ShopButton
@@ -226,6 +233,12 @@ export function StrenuousPortal({
             />
           ))}
         </div>
+
+        <img
+          className={styles.featureImage}
+          src={strenuousNewsImage}
+          alt="Latest Strenuous Portal news"
+        />
 
         <p className={styles.footer}>
           Only time will tell if you will ever get back home.


### PR DESCRIPTION
### Motivation
- Refresh the Strenuous Portal visuals by switching the portal button art and page background to the new `StrenuousTrue.webp` asset. 
- Surface additional contextual artwork by showing a map and a news panel for the Strenuous Portal area above and below the shop buttons.

### Description
- Replaced the main menu Strenuous Portal button image import in `src/Map.tsx` to use `StrenuousTrue.webp` instead of the previous asset. 
- Updated `src/StrenuousPortal.tsx` to set the page background to `StrenuousTrue.webp`, added imports for `StrenuousMap.webp` and `StrenuousNews.png`, and inserted corresponding `<img>` elements (map below the title block and news below the shop buttons). 
- Adjusted `src/StrenuousPortal.module.css` to style the `.buttonGrid` with a background treatment that uses `StrenuousTrue.webp` and added a `.featureImage` rule for the inserted map/news images. 
- Removed an unused `Applegarth.webp` import from `src/StrenuousPortal.tsx` as part of cleanup.

### Testing
- Ran `npm run build`, which completed successfully and produced an optimized production build; unrelated `eslint` warnings remain in other files but did not block the build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb644116c88329a4bac36a8b5cd043)