### PR TITLE
Remove box styling behind shop button images

### DIFF
--- a/src/ShopButton.module.css
+++ b/src/ShopButton.module.css
@@ -42,9 +42,9 @@
 .buttonImage {
   object-fit: contain;
   border-radius: 14px;
-  border: 2px solid rgba(255, 255, 255, 0.6);
-  background-color: rgba(255, 255, 255, 0.85);
-  box-shadow: 4px 4px 8px rgba(0, 0, 0, 0.35);
+  border: none;
+  background-color: transparent;
+  box-shadow: none;
 }
 
 .buttonLabel {


### PR DESCRIPTION
### Motivation
- Remove the boxed visual treatment behind shop button images to match the requested UI change and produce a cleaner, image-first button appearance.

### Description
- Updated `src/ShopButton.module.css` to set `.buttonImage` `border: none`, `background-color: transparent`, and `box-shadow: none`, removing the white box, border, and shadow behind images used by `ShopButton`.

### Testing
- Ran `npm run build` and the production build completed successfully; existing unrelated ESLint warnings were reported but the build passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb66be9c04832998470a9248ec78b2)