### PR TITLE
Remove background box from Strenuous portal menu buttons

### DIFF
--- a/src/StrenuousPortal.module.css
+++ b/src/StrenuousPortal.module.css
@@ -70,12 +70,6 @@
   width: 100%;
   gap: 1.25rem;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  padding: 1.25rem;
-  border-radius: 20px;
-  background-image: linear-gradient(rgba(15, 23, 42, 0.75), rgba(15, 23, 42, 0.75)), url("./StrenuousTrue.webp");
-  background-size: cover;
-  background-position: center;
-  border: 1px solid rgba(255, 255, 255, 0.18);
 }
 
 .featureImage {


### PR DESCRIPTION
### Motivation
- The boxed panel behind the Strenuous Portal shop buttons (provided by the `.buttonGrid` container styles) visually masked the background and needed to be removed to let the underlying artwork show through.

### Description
- Removed the `padding`, `border-radius`, `background-image`, `background-size`, `background-position`, and `border` properties from `.buttonGrid` in `src/StrenuousPortal.module.css`, while preserving the grid layout and spacing so shop buttons remain unchanged.

### Testing
- Ran `npm run build` and the production build completed successfully; existing unrelated ESLint warnings remain but the build passes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb686ee9508329b2bc6cbf971236fc)