### PR TITLE
Add selectable TV show filtering to project_nonsense_player.py

### DIFF
--- a/src/Project Nonsense/project_nonsense_player.py
+++ b/src/Project Nonsense/project_nonsense_player.py
@@ -30,6 +30,27 @@ REPEAT_HISTORY = 294
 # Wait this many seconds after a clip ends before starting the next one
 DELAY_BETWEEN_CLIPS = .5
 
+# Show folders that can be included in TV playback
+SHOW_OPTIONS = [
+    "Arcane",
+    "Azumanga Daioh",
+    "Batman: Brave n Bold",
+    "Bluey",
+    "Delicious in Dungeon",
+    "Epithet Erased",
+    "Gwain Saga Episodes",
+    "Huanted Hotel",
+    "Kid Cosmic",
+    "Kirby: Right Back At Ya!",
+    "Murder Drones",
+    "Owl House",
+    "Phineas and Ferb",
+    "The Amazing Digital Circus",
+    "Win or Lose",
+    "Youtube",
+    "Zombie Land Saga",
+]
+
 
 # =====================
 # VLC FINDER
@@ -113,7 +134,78 @@ def get_videos(folder):
     return videos
 
 
-tv_videos = get_videos(TV_FOLDER)
+def choose_tv_shows():
+    """
+    Ask the user which show folders should be included.
+    Return only the chosen show names from SHOW_OPTIONS.
+    """
+    print("\nChoose which TV shows to include before playback starts.")
+    print("Type one or more numbers separated by commas (example: 1,4,9).")
+    print("Type 'all' to include every show option.\n")
+
+    for index, show_name in enumerate(SHOW_OPTIONS, start=1):
+        print(f"{index}. {show_name}")
+
+    while True:
+        raw_choice = input("\nWhich shows should run? ").strip()
+        lowered = raw_choice.lower()
+
+        if lowered == "all":
+            return SHOW_OPTIONS[:]
+
+        selected_indexes = []
+        valid = True
+
+        for piece in raw_choice.split(","):
+            item = piece.strip()
+            if not item.isdigit():
+                valid = False
+                break
+
+            number = int(item)
+            if number < 1 or number > len(SHOW_OPTIONS):
+                valid = False
+                break
+
+            selected_indexes.append(number - 1)
+
+        if not valid or not selected_indexes:
+            print("Invalid choice. Enter numbers like 1,3,5 or type 'all'.")
+            continue
+
+        # Preserve order while removing duplicates
+        unique_indexes = list(dict.fromkeys(selected_indexes))
+        return [SHOW_OPTIONS[i] for i in unique_indexes]
+
+
+def get_tv_videos_from_selected_shows(selected_shows):
+    """
+    Load TV videos from only the show folders selected by the user.
+    """
+    videos = []
+    missing_folders = []
+
+    for show_name in selected_shows:
+        show_folder = os.path.join(TV_FOLDER, show_name)
+        if os.path.isdir(show_folder):
+            videos.extend(get_videos(show_folder))
+        else:
+            missing_folders.append(show_folder)
+
+    if missing_folders:
+        print("\nThese selected show folders were not found:")
+        for folder in missing_folders:
+            print("-", folder)
+
+    return videos
+
+
+selected_tv_shows = choose_tv_shows()
+print("\nSelected shows:")
+for show in selected_tv_shows:
+    print("-", show)
+
+tv_videos = get_tv_videos_from_selected_shows(selected_tv_shows)
 movie_videos = get_videos(MOVIE_FOLDER)
 
 # Show how many videos were found


### PR DESCRIPTION
### Motivation
- Provide an interactive way to limit TV playback to only the user-selected show folders from a fixed list instead of scanning the entire TV folder.
- Keep the change contained to the existing script without adding new Python files and preserve movie playback behavior.

### Description
- Added a `SHOW_OPTIONS` list containing the requested show names to enumerate possible TV folders.
- Implemented `choose_tv_shows()` which prompts the user at startup with a multiple-choice interface accepting comma-separated indexes or `all`, validates input, and deduplicates selections.
- Implemented `get_tv_videos_from_selected_shows()` which loads videos only from the selected show subfolders and prints missing-folder warnings for any chosen but absent paths.
- Replaced the original broad `tv_videos = get_videos(TV_FOLDER)` with the selected-show flow that prints chosen shows and builds `tv_videos` only from those folders while leaving movie handling unchanged.

### Testing
- Ran `python3 -m py_compile 'src/Project Nonsense/project_nonsense_player.py'` which completed successfully with no syntax errors.
- Verified repository status and created a commit for the change (`git commit` succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1c824e90c83299d536cd42b967516)