### PR TITLE
Add ReadySetBet page and Every Shop button (Horse racing)

### DIFF
--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -116,6 +116,8 @@ import { ByfordDolphinRobertson } from "./ByfordDolphinRobertson";
 import { Graveborn } from "./Graveborn";
 import { StrenuousPortal } from "./StrenuousPortal";
 import strenuousPortalButtonImage from "./StrenuousTrue.webp";
+import { ReadySetBet } from "./ReadySetBet";
+import readySetBetTrackImage from "./ReadySetBet/ReadySetBetRaceTrack.jpg";
 import { SettlementProvider } from "./SettlementContext";
 import { SettlementType } from "./inventoryAvailability";
 
@@ -660,6 +662,13 @@ export function Map() {
       backgroundColor: "rgba(255, 255, 255, 0.9)",
       imageSrc: yeOldHomeDepotImage,
     },
+    {
+      key: "ReadySetBet",
+      label: "Horse racing",
+      delay: "50s",
+      backgroundColor: "rgba(250, 204, 21, 0.9)",
+      imageSrc: readySetBetTrackImage,
+    },
   ];
 
   const sortedEveryShopButtons = sortShopButtons(everyShopButtons);
@@ -707,6 +716,8 @@ export function Map() {
       return <FizzyTales onBack={handleBack} />;
     case "YeOldHomeDepot":
       return <YeOldHomeDepot onBack={handleBack} />;
+    case "ReadySetBet":
+      return <ReadySetBet onBack={handleBack} />;
     case "PiggyBank":
       return <PiggyBank onBack={handleBack} />;
     case "NavigationGuild":

--- a/src/ReadySetBet.tsx
+++ b/src/ReadySetBet.tsx
@@ -1,0 +1,19 @@
+import { BackButton } from "./BackButton";
+import raceTrackImage from "./ReadySetBet/ReadySetBetRaceTrack.jpg";
+
+export function ReadySetBet({ onBack }: { onBack?: () => void }) {
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        position: "relative",
+        backgroundImage: `url(${raceTrackImage})`,
+        backgroundSize: "cover",
+        backgroundPosition: "center",
+        backgroundRepeat: "no-repeat",
+      }}
+    >
+      <BackButton onClick={onBack} />
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Add a new horse-racing destination to the map so users can open the ReadySetBet view from the "Every Shop" menu. 
- Wire the new destination into the existing navigation flow so it behaves like other shop pages. 

### Description
- Import the `ReadySetBet` component and track image in `src/Map.tsx` via `import { ReadySetBet } from "./ReadySetBet"` and `import readySetBetTrackImage from "./ReadySetBet/ReadySetBetRaceTrack.jpg"`.
- Append a new `everyShopButtons` entry with `key: "ReadySetBet"`, `label: "Horse racing"`, `imageSrc: readySetBetTrackImage`, `delay: "50s"`, and a yellow background color to match nearby entries.
- Add a `case "ReadySetBet": return <ReadySetBet onBack={handleBack} />;` to the `switch (navigatedTo)` so navigation resolves to the new page.
- Add a new routed page component at `src/ReadySetBet.tsx` that displays the racetrack background and includes the `BackButton` to return to the map.

### Testing
- Ran the production build with `npm run build`, which completed successfully (build succeeded, compiled with unrelated ESLint warnings). 
- Verified the app compiles and the new files are included in the build output (no runtime build errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c71c9c645c8329bc80d62165d57fc3)