### PR TITLE
Refactor ReadySetBet to use typed racer asset catalog

### DIFF
--- a/src/ReadySetBet.tsx
+++ b/src/ReadySetBet.tsx
@@ -1,76 +1,20 @@
 import { useMemo, useState } from "react";
 import { BackButton } from "./BackButton";
 import raceTrackImage from "./ReadySetBet/ReadySetBetRaceTrack.jpg";
-
-import horse1 from "./ReadySetBet/H-Horse 1.webp";
-import horse2 from "./ReadySetBet/H-Horse 2.png";
-import horse3 from "./ReadySetBet/H-Horse 3.png";
-import horse4 from "./ReadySetBet/H-Horse 4.png";
-import horse5 from "./ReadySetBet/H-Horse 5.png";
-import horse6 from "./ReadySetBet/H-Horse 6.png";
-import horse9 from "./ReadySetBet/H-Horse 9.png";
-
-import peopleAlex from "./ReadySetBet/P-Alex.webp";
-import peopleGoldship from "./ReadySetBet/P-goldship.webp";
-import peopleHornet from "./ReadySetBet/P-Hornet.webp";
-import peopleKnight from "./ReadySetBet/P-Knight.webp";
-import peopleShadow from "./ReadySetBet/P-Shadow.webp";
-import peopleSonic from "./ReadySetBet/P-Sonic.gif";
-import peopleSoldier from "./ReadySetBet/P-Soldier.png";
-import peopleSteve from "./ReadySetBet/P-Steve.png";
-import peopleSurge from "./ReadySetBet/P-Surge.png";
-
-import uniqueHorse8 from "./ReadySetBet/U-Horse 8.png";
-import uniqueUnicorn7 from "./ReadySetBet/U-Unicorn 7.png";
+import { readySetBetAssets, type ReadySetBetRacer } from "./ReadySetBet/assets";
 
 type RacerMode = "horse" | "people" | "unique";
 
-type RacerAsset = {
-  fileName: string;
-  src: string;
+const RACERS_BY_MODE: Record<RacerMode, ReadySetBetRacer[]> = {
+  horse: readySetBetAssets.horses,
+  people: readySetBetAssets.people,
+  unique: readySetBetAssets.unique,
 };
-
-const RACERS_BY_MODE: Record<RacerMode, RacerAsset[]> = {
-  horse: [
-    { fileName: "H-Horse 1.webp", src: horse1 },
-    { fileName: "H-Horse 2.png", src: horse2 },
-    { fileName: "H-Horse 3.png", src: horse3 },
-    { fileName: "H-Horse 4.png", src: horse4 },
-    { fileName: "H-Horse 5.png", src: horse5 },
-    { fileName: "H-Horse 6.png", src: horse6 },
-    { fileName: "H-Horse 9.png", src: horse9 },
-  ],
-  people: [
-    { fileName: "P-Alex.webp", src: peopleAlex },
-    { fileName: "P-goldship.webp", src: peopleGoldship },
-    { fileName: "P-Hornet.webp", src: peopleHornet },
-    { fileName: "P-Knight.webp", src: peopleKnight },
-    { fileName: "P-Shadow.webp", src: peopleShadow },
-    { fileName: "P-Sonic.gif", src: peopleSonic },
-    { fileName: "P-Soldier.png", src: peopleSoldier },
-    { fileName: "P-Steve.png", src: peopleSteve },
-    { fileName: "P-Surge.png", src: peopleSurge },
-  ],
-  unique: [
-    { fileName: "U-Horse 8.png", src: uniqueHorse8 },
-    { fileName: "U-Unicorn 7.png", src: uniqueUnicorn7 },
-  ],
-};
-
-function toDisplayLabel(fileName: string): string {
-  const strippedPrefix = fileName.replace(/^[A-Z]-/, "");
-  return strippedPrefix.replace(/\.[^.]+$/, "");
-}
 
 export function ReadySetBet({ onBack }: { onBack?: () => void }) {
   const [mode, setMode] = useState<RacerMode>("horse");
 
-  const racers = useMemo(() => {
-    return RACERS_BY_MODE[mode].map((racer) => ({
-      ...racer,
-      displayName: toDisplayLabel(racer.fileName),
-    }));
-  }, [mode]);
+  const racers = useMemo(() => RACERS_BY_MODE[mode], [mode]);
 
   return (
     <div
@@ -147,7 +91,7 @@ export function ReadySetBet({ onBack }: { onBack?: () => void }) {
         >
           {racers.map((racer) => (
             <article
-              key={racer.fileName}
+              key={racer.id}
               style={{
                 backgroundColor: "rgba(255, 255, 255, 0.95)",
                 color: "#111827",
@@ -161,17 +105,15 @@ export function ReadySetBet({ onBack }: { onBack?: () => void }) {
               }}
             >
               <img
-                src={racer.src}
-                alt={racer.displayName}
+                src={racer.image}
+                alt={racer.name}
                 style={{
                   width: "100%",
                   height: "140px",
                   objectFit: "contain",
                 }}
               />
-              <strong style={{ textAlign: "center", fontSize: "0.95rem" }}>
-                {racer.displayName}
-              </strong>
+              <strong style={{ textAlign: "center", fontSize: "0.95rem" }}>{racer.name}</strong>
             </article>
           ))}
         </section>

--- a/src/ReadySetBet/assets.ts
+++ b/src/ReadySetBet/assets.ts
@@ -1,0 +1,60 @@
+import horse1 from "./H-Horse 1.webp";
+import horse2 from "./H-Horse 2.png";
+import horse3 from "./H-Horse 3.png";
+import horse4 from "./H-Horse 4.png";
+import horse5 from "./H-Horse 5.png";
+import horse6 from "./H-Horse 6.png";
+import horse9 from "./H-Horse 9.png";
+
+import peopleAlex from "./P-Alex.webp";
+import peopleGoldship from "./P-goldship.webp";
+import peopleHornet from "./P-Hornet.webp";
+import peopleKnight from "./P-Knight.webp";
+import peopleShadow from "./P-Shadow.webp";
+import peopleSonic from "./P-Sonic.gif";
+import peopleSoldier from "./P-Soldier.png";
+import peopleSteve from "./P-Steve.png";
+import peopleSurge from "./P-Surge.png";
+
+import uniqueHorse8 from "./U-Horse 8.png";
+import uniqueUnicorn7 from "./U-Unicorn 7.png";
+
+export type ReadySetBetRacer = {
+  id: string;
+  name: string;
+  image: string;
+};
+
+// Validation note:
+// - Keep only H-* files in `horses`, P-* files in `people`, and U-* files in `unique`.
+// - If you add a new image, preserve this prefix convention so filtering stays predictable.
+export const readySetBetAssets: {
+  horses: ReadySetBetRacer[];
+  people: ReadySetBetRacer[];
+  unique: ReadySetBetRacer[];
+} = {
+  horses: [
+    { id: "H-Horse 1", name: "Horse 1", image: horse1 },
+    { id: "H-Horse 2", name: "Horse 2", image: horse2 },
+    { id: "H-Horse 3", name: "Horse 3", image: horse3 },
+    { id: "H-Horse 4", name: "Horse 4", image: horse4 },
+    { id: "H-Horse 5", name: "Horse 5", image: horse5 },
+    { id: "H-Horse 6", name: "Horse 6", image: horse6 },
+    { id: "H-Horse 9", name: "Horse 9", image: horse9 },
+  ],
+  people: [
+    { id: "P-Alex", name: "Alex", image: peopleAlex },
+    { id: "P-goldship", name: "goldship", image: peopleGoldship },
+    { id: "P-Hornet", name: "Hornet", image: peopleHornet },
+    { id: "P-Knight", name: "Knight", image: peopleKnight },
+    { id: "P-Shadow", name: "Shadow", image: peopleShadow },
+    { id: "P-Sonic", name: "Sonic", image: peopleSonic },
+    { id: "P-Soldier", name: "Soldier", image: peopleSoldier },
+    { id: "P-Steve", name: "Steve", image: peopleSteve },
+    { id: "P-Surge", name: "Surge", image: peopleSurge },
+  ],
+  unique: [
+    { id: "U-Horse 8", name: "Horse 8", image: uniqueHorse8 },
+    { id: "U-Unicorn 7", name: "Unicorn 7", image: uniqueUnicorn7 },
+  ],
+};


### PR DESCRIPTION
### Motivation
- Centralize Ready Set Bet image imports into a single typed catalog to simplify maintenance and reduce repeated per-image imports in the component.
- Enforce a predictable naming convention so assets can be reliably grouped by category (`H-*`, `P-*`, `U-*`).
- Simplify `ReadySetBet` component logic by consuming a single source of truth for racer data.

### Description
- Added `src/ReadySetBet/assets.ts` which defines `ReadySetBetRacer` and exports `readySetBetAssets` with `horses`, `people`, and `unique` arrays of `{ id, name, image }` entries.
- All image imports are placed at the top of `assets.ts` and the file includes validation comments instructing contributors to keep `H-*` files in `horses`, `P-*` files in `people`, and `U-*` files in `unique`.
- Updated `src/ReadySetBet.tsx` to import `readySetBetAssets` and to render racers using `racer.id`, `racer.name`, and `racer.image` instead of inline image imports and `toDisplayLabel` logic.
- Preserved existing UI behavior (mode tabs and grid rendering) while switching to the typed catalog.

### Testing
- Ran `npm run build`, which initially surfaced an `import/first` ESLint error in the new asset file that was corrected, and a subsequent `npm run build` completed successfully.
- The build completed with unrelated ESLint warnings in other files but produced a working production build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c720a971648329a811b8ce2f04ef13)