### PR TITLE
Ready Set Bet: lane-based name tag colors and tighter racer images

### DIFF
--- a/src/ReadySetBet.tsx
+++ b/src/ReadySetBet.tsx
@@ -18,6 +18,17 @@ const TRACK_COLUMN_POSITIONS = [
   10, 15.5, 21, 26.5, 32, 37.5, 43, 48.5, 54, 59.5, 65, 70.5, 76, 81.5, 87, 92.5,
 ] as const;
 const TRACK_LANE_TOP_POSITIONS = [21.5, 29, 35.8, 43, 50, 57, 64, 71, 78] as const;
+const NAME_TAG_COLOR_BY_LANE_LABEL: Record<(typeof LANE_LABELS)[number], string> = {
+  "2/3": "#2563eb",
+  "4": "#2563eb",
+  "5": "#facc15",
+  "6": "#ec4899",
+  "7": "#ec4899",
+  "8": "#111827",
+  "9": "#facc15",
+  "10": "#2563eb",
+  "11/12": "#2563eb",
+};
 
 // PSEUDOCODE: Keep map-button metadata here so Map.tsx only consumes exported config.
 export const readySetBetMapButton = {
@@ -328,6 +339,9 @@ export function ReadySetBet({ onBack }: { onBack?: () => void }) {
               const safePosition = Math.max(0, Math.min(FINISH_SPACE, positions[index]));
               const topOffset = TRACK_LANE_TOP_POSITIONS[index] ?? 50;
               const markerLeft = TRACK_COLUMN_POSITIONS[safePosition] ?? TRACK_COLUMN_POSITIONS[0];
+              const laneLabel = LANE_LABELS[index];
+              const nameTagColor = NAME_TAG_COLOR_BY_LANE_LABEL[laneLabel] ?? "#1e293b";
+              const hasDarkTag = nameTagColor === "#111827";
 
               return (
                 <div
@@ -350,22 +364,27 @@ export function ReadySetBet({ onBack }: { onBack?: () => void }) {
                     style={{
                       width: "52px",
                       height: "52px",
-                      objectFit: "contain",
+                      objectFit: "cover",
                       filter: "drop-shadow(0 2px 3px rgba(0,0,0,0.65))",
+                      borderRadius: "999px",
+                      backgroundColor: "transparent",
                     }}
                   />
                   <div
                     style={{
-                      backgroundColor: "rgba(15, 23, 42, 0.85)",
-                      border: "1px solid rgba(255,255,255,0.55)",
+                      backgroundColor: nameTagColor,
+                      border: hasDarkTag
+                        ? "1px solid rgba(148, 163, 184, 0.8)"
+                        : "1px solid rgba(255,255,255,0.6)",
                       borderRadius: "10px",
                       padding: "0.2rem 0.45rem",
                       lineHeight: 1.2,
                       maxWidth: "180px",
+                      color: hasDarkTag || nameTagColor === "#2563eb" ? "#f8fafc" : "#111827",
                     }}
                   >
                     <div style={{ fontSize: "0.74rem", opacity: 0.85 }}>
-                      Lane {lane} ({LANE_LABELS[index]})
+                      Lane {lane} ({laneLabel})
                     </div>
                     <div style={{ fontSize: "0.78rem", fontWeight: 700 }}>{racer.name}</div>
                     <div style={{ fontSize: "0.72rem", opacity: 0.85 }}>
@@ -407,7 +426,9 @@ export function ReadySetBet({ onBack }: { onBack?: () => void }) {
                 style={{
                   width: "100%",
                   height: "140px",
-                  objectFit: "contain",
+                  objectFit: "cover",
+                  borderRadius: "8px",
+                  backgroundColor: "transparent",
                 }}
               />
               <strong style={{ textAlign: "center", fontSize: "0.95rem" }}>{racer.name}</strong>


### PR DESCRIPTION
### Motivation
- Provide lane-aware visual cues on the Ready Set Bet race markers so name tags change color by lane for faster identification during races.
- Reduce the visible empty gray/letterbox space around racer images so avatars feel tighter and more visually consistent with circular/rounded name tags.

### Description
- Added a `NAME_TAG_COLOR_BY_LANE_LABEL` mapping and wired it into the live race marker name tag styles in `src/ReadySetBet.tsx`, using hex colors for each lane label (blue for `2/3`, `4`, `10`, `11/12`; gold for `5` and `9`; pink for `6` and `7`; black for `8`).
- Lookups use the existing `LANE_LABELS` array and apply `backgroundColor`, an appropriate border style, and readable text color to each tag.
- Tightened racer images by changing `objectFit` from `contain` to `cover`, adding `borderRadius` and removing background padding to reduce empty gray space for both moving race icons and racer cards.
- All changes are confined to `src/ReadySetBet.tsx` and are implemented inline with the existing styling approach.

### Testing
- Ran the production build with `npm run build`, which completed successfully and produced the optimized build artifacts.
- The build emitted unrelated ESLint warnings in other files but no build-time errors occurred; the Ready Set Bet changes render without build failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c821f5e9d48329b1e5c65bbf31b429)