### PR TITLE
Fix Ready Set Bet racer image cropping and blur

### DIFF
--- a/src/ReadySetBet.tsx
+++ b/src/ReadySetBet.tsx
@@ -364,9 +364,9 @@ export function ReadySetBet({ onBack }: { onBack?: () => void }) {
                     style={{
                       width: "52px",
                       height: "52px",
-                      objectFit: "cover",
+                      objectFit: "contain",
                       filter: "drop-shadow(0 2px 3px rgba(0,0,0,0.65))",
-                      borderRadius: "999px",
+                      imageRendering: "auto",
                       backgroundColor: "transparent",
                     }}
                   />
@@ -426,7 +426,8 @@ export function ReadySetBet({ onBack }: { onBack?: () => void }) {
                 style={{
                   width: "100%",
                   height: "140px",
-                  objectFit: "cover",
+                  objectFit: "contain",
+                  imageRendering: "auto",
                   borderRadius: "8px",
                   backgroundColor: "transparent",
                 }}


### PR DESCRIPTION
### Motivation
- Racer artwork was being cropped and appearing blurry when scaled because `object-fit: cover` and a circular crop were applied to racer images in the Ready Set Bet UI.

### Description
- In `src/ReadySetBet.tsx` changed racer image styles on the race track and in the racer preview cards from `objectFit: "cover"` to `objectFit: "contain"`, added `imageRendering: "auto"`, and removed the circular `borderRadius: 999px` so full artwork is visible and renders more cleanly.

### Testing
- Ran `npm run build` which completed successfully (production build created; unrelated ESLint warnings remain in other files).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c82439b3cc83298c5053d841babf47)