### PR TITLE
Mirror selected Ready-set-bet racers

### DIFF
--- a/src/ReadySetBet.tsx
+++ b/src/ReadySetBet.tsx
@@ -29,6 +29,18 @@ const NAME_TAG_COLOR_BY_LANE_LABEL: Record<(typeof LANE_LABELS)[number], string>
   "10": "#2563eb",
   "11/12": "#2563eb",
 };
+const MIRRORED_RACER_IDS = new Set([
+  "H-Horse 1",
+  "H-Horse 2",
+  "H-Horse 3",
+  "H-Horse 4",
+  "H-Horse 5",
+  "H-Horse 9",
+  "P-Alex",
+  "P-Hornet",
+  "P-Soldier",
+  "P-Surge",
+]);
 
 // PSEUDOCODE: Keep map-button metadata here so Map.tsx only consumes exported config.
 export const readySetBetMapButton = {
@@ -342,6 +354,7 @@ export function ReadySetBet({ onBack }: { onBack?: () => void }) {
               const laneLabel = LANE_LABELS[index];
               const nameTagColor = NAME_TAG_COLOR_BY_LANE_LABEL[laneLabel] ?? "#1e293b";
               const hasDarkTag = nameTagColor === "#111827";
+              const isMirrored = MIRRORED_RACER_IDS.has(racer.id);
 
               return (
                 <div
@@ -365,6 +378,7 @@ export function ReadySetBet({ onBack }: { onBack?: () => void }) {
                       width: "52px",
                       height: "52px",
                       objectFit: "contain",
+                      transform: isMirrored ? "scaleX(-1)" : "none",
                       filter: "drop-shadow(0 2px 3px rgba(0,0,0,0.65))",
                       imageRendering: "auto",
                       backgroundColor: "transparent",
@@ -405,21 +419,24 @@ export function ReadySetBet({ onBack }: { onBack?: () => void }) {
             gap: "0.75rem",
           }}
         >
-          {racers.map((racer) => (
-            <article
-              key={racer.id}
-              style={{
-                backgroundColor: "rgba(255, 255, 255, 0.95)",
-                color: "#111827",
-                borderRadius: "12px",
-                padding: "0.75rem",
-                display: "flex",
-                flexDirection: "column",
-                alignItems: "center",
-                gap: "0.5rem",
-                minHeight: "220px",
-              }}
-            >
+          {racers.map((racer) => {
+            const isMirrored = MIRRORED_RACER_IDS.has(racer.id);
+
+            return (
+              <article
+                key={racer.id}
+                style={{
+                  backgroundColor: "rgba(255, 255, 255, 0.95)",
+                  color: "#111827",
+                  borderRadius: "12px",
+                  padding: "0.75rem",
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                  gap: "0.5rem",
+                  minHeight: "220px",
+                }}
+              >
               <img
                 src={racer.image}
                 alt={racer.name}
@@ -427,14 +444,16 @@ export function ReadySetBet({ onBack }: { onBack?: () => void }) {
                   width: "100%",
                   height: "140px",
                   objectFit: "contain",
+                  transform: isMirrored ? "scaleX(-1)" : "none",
                   imageRendering: "auto",
                   borderRadius: "8px",
                   backgroundColor: "transparent",
                 }}
               />
               <strong style={{ textAlign: "center", fontSize: "0.95rem" }}>{racer.name}</strong>
-            </article>
-          ))}
+              </article>
+            );
+          })}
         </section>
       </main>
     </div>


### PR DESCRIPTION
### Motivation

- Certain racer sprites (horses and people) were facing the wrong direction on the track, so they need to be flipped horizontally while remaining upright. 
- Make the visual orientation consistent between the live race board and the racer selector cards.

### Description

- Added a `MIRRORED_RACER_IDS` set in `src/ReadySetBet.tsx` containing the requested IDs: `H-Horse 1`, `H-Horse 2`, `H-Horse 3`, `H-Horse 4`, `H-Horse 5`, `H-Horse 9`, `P-Alex`, `P-Hornet`, `P-Soldier`, and `P-Surge`.
- Applied a horizontal flip via CSS transform `scaleX(-1)` to racer images rendered on the moving race board when the racer id is in `MIRRORED_RACER_IDS`.
- Applied the same `scaleX(-1)` rule to the racer cards in the selector grid so the selected racers show the same orientation everywhere.
- All changes were made in `src/ReadySetBet.tsx` and are conditional on the racer `id` so other assets are unaffected.

### Testing

- Ran the production build with `npm run build` and the build completed successfully.
- The build output includes pre-existing ESLint warnings in unrelated files, but no errors were introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8256edcbc8329acd60875f6a105b3)