### PR TITLE
Adjust ReadySetBet nametag positioning behavior

### DIFF
--- a/src/ReadySetBet.tsx
+++ b/src/ReadySetBet.tsx
@@ -349,6 +349,7 @@ export function ReadySetBet({ onBack }: { onBack?: () => void }) {
             />
             {raceSlots.map(({ lane, racer }, index) => {
               const safePosition = Math.max(0, Math.min(FINISH_SPACE, positions[index]));
+              const hasReachedHalfway = safePosition >= FINISH_SPACE / 2;
               const topOffset = TRACK_LANE_TOP_POSITIONS[index] ?? 50;
               const markerLeft = TRACK_COLUMN_POSITIONS[safePosition] ?? TRACK_COLUMN_POSITIONS[0];
               const laneLabel = LANE_LABELS[index];
@@ -365,9 +366,6 @@ export function ReadySetBet({ onBack }: { onBack?: () => void }) {
                     left: `${markerLeft}%`,
                     transform: "translate(-50%, -50%)",
                     transition: "left 0.45s ease-out",
-                    display: "flex",
-                    alignItems: "center",
-                    gap: "0.35rem",
                     zIndex: 2,
                   }}
                 >
@@ -386,6 +384,11 @@ export function ReadySetBet({ onBack }: { onBack?: () => void }) {
                   />
                   <div
                     style={{
+                      position: "absolute",
+                      top: "50%",
+                      left: hasReachedHalfway ? "auto" : "calc(100% + 8px)",
+                      right: hasReachedHalfway ? "calc(100% + 8px)" : "auto",
+                      transform: "translateY(-50%)",
                       backgroundColor: nameTagColor,
                       border: hasDarkTag
                         ? "1px solid rgba(148, 163, 184, 0.8)"
@@ -394,6 +397,7 @@ export function ReadySetBet({ onBack }: { onBack?: () => void }) {
                       padding: "0.2rem 0.45rem",
                       lineHeight: 1.2,
                       maxWidth: "180px",
+                      whiteSpace: "nowrap",
                       color: hasDarkTag || nameTagColor === "#2563eb" ? "#f8fafc" : "#111827",
                     }}
                   >


### PR DESCRIPTION
### Motivation
- Prevent nametags from shifting racer images and track placement while keeping nametags visually following each racer, and switch tag side at the race midpoint so tags appear ahead early and trail after halfway. 

### Description
- Compute `hasReachedHalfway` from the racer's `positions[index]` against `FINISH_SPACE / 2` and use it to decide tag side. 
- Decoupled the nametag layout from the marker by making the tag `position: absolute` inside the racer container and removing the inline `flex` spacing that previously moved the icon. 
- Place the tag to the left or right using `left: calc(100% + 8px)` / `right: calc(100% + 8px)` depending on `hasReachedHalfway`, and added `whiteSpace: 'nowrap'` to avoid wrapping. 

### Testing
- Ran `npm run build`, which completed successfully and produced a production build; there are pre-existing ESLint warnings in unrelated files but the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8292cb92c8329a35d48141acaed16)