### PR TITLE
Mirror requested Ready Set Bet racers by ID

### DIFF
--- a/src/ReadySetBet.tsx
+++ b/src/ReadySetBet.tsx
@@ -36,28 +36,23 @@ const MIRRORED_RACER_IDS = new Set([
   "H-Horse 4",
   "H-Horse 5",
   "H-Horse 9",
+  "H-Cinnamon",
+  "H-Grace",
+  "H-Midnight",
+  "H-Prince",
   "P-Alex",
   "P-Hornet",
+  "P-Kinger",
+  "P-MasterChief",
+  "P-Monoco",
+  "P-PikminTrio",
   "P-Soldier",
   "P-Surge",
-]);
-const MIRRORED_RACER_NAMES = new Set([
-  "Alex",
-  "Hornet",
-  "Soldier",
-  "Surge",
-  "Cinnamon Grace",
-  "Midnight Prince",
-  "Kingger",
-  "Master Chief",
-  "Mike Monoco",
-  "Pikmin Trio",
-  "Teto",
-  "Vicent Van gogh",
+  "P-Teto",
+  "P-VincentvanGogh",
 ]);
 
-const shouldMirrorRacer = (racer: ReadySetBetRacer) =>
-  MIRRORED_RACER_IDS.has(racer.id) || MIRRORED_RACER_NAMES.has(racer.name);
+const shouldMirrorRacer = (racer: ReadySetBetRacer) => MIRRORED_RACER_IDS.has(racer.id);
 
 // PSEUDOCODE: Keep map-button metadata here so Map.tsx only consumes exported config.
 export const readySetBetMapButton = {


### PR DESCRIPTION
### Motivation
- Users requested flipping specific racers so they face the other direction without the images becoming upside down. 
- Matching by racer `id` is more robust than using display `name` text because it avoids spelling/capitalization mismatches.

### Description
- Added the requested horse IDs to the mirrored set in `src/ReadySetBet.tsx`: `H-Cinnamon`, `H-Grace`, `H-Midnight`, and `H-Prince` alongside the existing `H-Horse 1/2/3/4/5/9` entries. 
- Added the requested people IDs to the mirrored set in `src/ReadySetBet.tsx`: `P-Alex`, `P-Hornet`, `P-Kinger`, `P-MasterChief`, `P-Monoco`, `P-PikminTrio`, `P-Soldier`, `P-Surge`, `P-Teto`, and `P-VincentvanGogh`.
- Removed the `MIRRORED_RACER_NAMES` string-based set and changed `shouldMirrorRacer` to check only `MIRRORED_RACER_IDS` so mirroring is applied by racer `id`.

### Testing
- Ran `npm run build` and the production build completed successfully (build succeeded with unrelated lint warnings in other files).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8325564408329948bd6703adba690)