### PR TITLE
Fix Ready Set Bet racer marker anchoring

### DIFF
--- a/src/ReadySetBet.tsx
+++ b/src/ReadySetBet.tsx
@@ -536,6 +536,8 @@ export function ReadySetBet({ onBack }: { onBack?: () => void }) {
                     transform: "translate(-50%, -50%)",
                     transition: "left 0.45s ease-out",
                     zIndex: 2,
+                    width: "52px",
+                    height: "52px",
                   }}
                 >
                   <img


### PR DESCRIPTION
### Motivation
- Ensure racer position is anchored to the sprite hitbox so the name tag’s rendered size no longer shifts where racers appear in Ready, Set, Bet.

### Description
- Add fixed `width: "52px"` and `height: "52px"` to the in-race racer marker wrapper in `src/ReadySetBet.tsx` so placement is based on the sprite bounds rather than the name-tag dimensions.

### Testing
- Ran `npm run build` which completed successfully (build passed; unrelated ESLint warnings remain).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c83567eb1883299316ec26b4ecd658)