### PR TITLE
Add standard betting UI and settlement logic; add BettingEngine spec

### DIFF
--- a/src/ReadySetBet.tsx
+++ b/src/ReadySetBet.tsx
@@ -36,6 +36,7 @@ const MODE_LABEL_BY_VALUE: Record<RacerMode, string> = {
 const LANE_LABELS = ["2/3", "4", "5", "6", "7", "8", "9", "10", "11/12"] as const;
 const BONUS_MOVES_BY_LANE = [3, 3, 2, 1, 0, 1, 2, 3, 3] as const;
 const FINISH_SPACE = 15;
+const RED_LINE_SPACE = 8;
 const TRACK_COLUMN_POSITIONS = [
   10, 15.5, 21, 26.5, 32, 37.5, 43, 48.5, 54, 59.5, 65, 70.5, 76, 81.5, 87, 92.5,
 ] as const;
@@ -80,6 +81,45 @@ const MIRRORED_RACER_IDS = new Set([
 ]);
 
 const shouldMirrorRacer = (racer: ReadySetBetRacer) => MIRRORED_RACER_IDS.has(racer.id);
+
+type StandardBetType = "show" | "place" | "win";
+type StandardBetSpotIndex = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
+const STANDARD_MATRIX: Record<(typeof LANE_LABELS)[number], ReadonlyArray<readonly [number, number]>> = {
+  "2/3": [[4, 4], [4, 3], [5, 4], [5, 3], [7, 2], [8, 2], [9, 2]],
+  "4": [[3, 1], [3, 0], [4, 1], [4, 0], [5, 1], [6, 0], [7, 0]],
+  "5": [[2, 3], [2, 0], [2, 2], [3, 2], [4, 2], [4, 0], [5, 0]],
+  "6": [[1, 2], [1, 0], [2, 5], [2, 4], [3, 2], [3, 1], [3, 0]],
+  "7": [[1, 3], [1, 1], [2, 6], [2, 5], [3, 4], [3, 3], [3, 2]],
+  "8": [[1, 2], [1, 0], [2, 5], [2, 4], [3, 2], [3, 1], [3, 0]],
+  "9": [[2, 3], [2, 0], [2, 2], [3, 2], [4, 2], [4, 0], [5, 0]],
+  "10": [[3, 1], [3, 0], [4, 1], [4, 0], [5, 1], [6, 0], [7, 0]],
+  "11/12": [[4, 4], [4, 3], [5, 4], [5, 3], [7, 2], [8, 2], [9, 2]],
+};
+
+const SPOT_INDEXES_BY_BET_TYPE: Record<StandardBetType, StandardBetSpotIndex[]> = {
+  show: [0, 1],
+  place: [2, 3],
+  win: [4, 5, 6],
+};
+
+const PLAYER_TOKENS = [
+  { id: "token-2", value: 2 },
+  { id: "token-3a", value: 3 },
+  { id: "token-3b", value: 3 },
+  { id: "token-4", value: 4 },
+  { id: "token-5", value: 5 },
+] as const;
+
+interface PlacedStandardBet {
+  tokenId: string;
+  tokenValue: number;
+  laneLabel: (typeof LANE_LABELS)[number];
+  betType: StandardBetType;
+  spotIndex: StandardBetSpotIndex;
+  multiplier: number;
+  loss: number;
+}
 
 // PSEUDOCODE: Keep map-button metadata here so Map.tsx only consumes exported config.
 export const readySetBetMapButton = {
@@ -154,6 +194,16 @@ export function ReadySetBet({ onBack }: { onBack?: () => void }) {
   const [raceSlots, setRaceSlots] = useState<Array<{ lane: number; racer: ReadySetBetRacer }>>(() =>
     createRaceSlots(RACERS_BY_MODE.horse)
   );
+  const [bankroll, setBankroll] = useState(30);
+  const [placedBets, setPlacedBets] = useState<PlacedStandardBet[]>([]);
+  const [bettingOpen, setBettingOpen] = useState(true);
+  const [settlementSummary, setSettlementSummary] = useState<string | null>(null);
+  const [selectedTokenId, setSelectedTokenId] = useState<string>(PLAYER_TOKENS[0].id);
+  const [selectedLaneLabel, setSelectedLaneLabel] = useState<(typeof LANE_LABELS)[number]>(LANE_LABELS[0]);
+  const [selectedBetType, setSelectedBetType] = useState<StandardBetType>("win");
+  const [selectedSpotIndex, setSelectedSpotIndex] = useState<StandardBetSpotIndex>(4);
+  const betsRef = useRef<PlacedStandardBet[]>([]);
+  const hasSettledRef = useRef(false);
   // PSEUDOCODE: Convert two-dice total into lane index based on ready-set-bet odds layout.
   const horseIndexByDiceSum = (sum: number) => {
     if (sum <= 3) return 0;
@@ -182,8 +232,70 @@ export function ReadySetBet({ onBack }: { onBack?: () => void }) {
     setPositions(Array(9).fill(0));
     setWinnerLane(null);
     setLastRoll(null);
+    setPlacedBets([]);
+    setBettingOpen(true);
+    setSettlementSummary(null);
     streakRef.current = { laneIndex: null, count: 0 };
+    hasSettledRef.current = false;
   }, [stopRace]);
+
+  useEffect(() => {
+    betsRef.current = placedBets;
+  }, [placedBets]);
+
+  const settleRace = useCallback((finalPositions: number[]) => {
+    if (hasSettledRef.current) {
+      return;
+    }
+    hasSettledRef.current = true;
+    const laneByRank = finalPositions
+      .map((position, index) => ({ laneLabel: LANE_LABELS[index], position }))
+      .sort((a, b) => b.position - a.position);
+
+    const rankGroups: Array<Array<(typeof LANE_LABELS)[number]>> = [];
+    laneByRank.forEach((entry) => {
+      const lastGroup = rankGroups[rankGroups.length - 1];
+      if (!lastGroup) {
+        rankGroups.push([entry.laneLabel]);
+        return;
+      }
+      const representative = laneByRank.find((item) => item.laneLabel === lastGroup[0]);
+      if (representative?.position === entry.position) {
+        lastGroup.push(entry.laneLabel);
+      } else {
+        rankGroups.push([entry.laneLabel]);
+      }
+    });
+
+    const winSet = new Set(rankGroups[0] ?? []);
+    const placeSet = new Set([...(rankGroups[0] ?? []), ...(rankGroups[1] ?? [])]);
+    const showSet = new Set(
+      rankGroups[1] && rankGroups[1].length >= 2
+        ? [...(rankGroups[0] ?? []), ...(rankGroups[1] ?? [])]
+        : [...(rankGroups[0] ?? []), ...(rankGroups[1] ?? []), ...(rankGroups[2] ?? [])]
+    );
+
+    const isWinningBet = (bet: PlacedStandardBet) => {
+      if (bet.betType === "win") return winSet.has(bet.laneLabel);
+      if (bet.betType === "place") return placeSet.has(bet.laneLabel);
+      return showSet.has(bet.laneLabel);
+    };
+
+    let winnings = 0;
+    let losses = 0;
+    betsRef.current.forEach((bet) => {
+      if (isWinningBet(bet)) {
+        winnings += bet.tokenValue * bet.multiplier;
+      } else {
+        losses += bet.loss;
+      }
+    });
+    const net = winnings - losses;
+    setBankroll((current) => Math.max(0, current + net));
+    setSettlementSummary(
+      `Settled ${betsRef.current.length} bet${betsRef.current.length === 1 ? "" : "s"}: +$${winnings} / -$${losses} (net ${net >= 0 ? "+" : ""}$${net}).`
+    );
+  }, []);
 
   // PSEUDOCODE: On interval, roll dice -> choose lane -> apply streak bonus -> move racer -> stop if someone finishes.
   const startRace = (intervalMs = 650) => {
@@ -220,8 +332,14 @@ export function ReadySetBet({ onBack }: { onBack?: () => void }) {
         nextPositions[laneIndex] = Math.min(FINISH_SPACE, nextPositions[laneIndex] + move);
 
         const finishIndex = nextPositions.findIndex((position) => position >= FINISH_SPACE);
+        const crossedRedLine = nextPositions.filter((position) => position >= RED_LINE_SPACE).length;
+        if (crossedRedLine >= 3) {
+          setBettingOpen(false);
+        }
         if (finishIndex !== -1) {
           setWinnerLane(finishIndex + 1);
+          setBettingOpen(false);
+          settleRace(nextPositions);
           stopRace();
         }
 
@@ -236,6 +354,13 @@ export function ReadySetBet({ onBack }: { onBack?: () => void }) {
     resetRace();
     setRaceSlots(createRaceSlots(racers, mode === "choose"));
   }, [createRaceSlots, mode, racers, resetRace]);
+
+  useEffect(() => {
+    const validSpots = SPOT_INDEXES_BY_BET_TYPE[selectedBetType];
+    if (!validSpots.includes(selectedSpotIndex)) {
+      setSelectedSpotIndex(validSpots[0]);
+    }
+  }, [selectedBetType, selectedSpotIndex]);
 
   const hasRacersAvailable = raceSlots.length > 0;
 
@@ -256,6 +381,45 @@ export function ReadySetBet({ onBack }: { onBack?: () => void }) {
       });
       return next;
     });
+  };
+
+  const placeStandardBet = () => {
+    if (!bettingOpen || !isRacing) {
+      return;
+    }
+    const token = PLAYER_TOKENS.find((entry) => entry.id === selectedTokenId);
+    if (!token) {
+      return;
+    }
+    const tokenUsed = placedBets.some((bet) => bet.tokenId === token.id);
+    if (tokenUsed) {
+      setSettlementSummary("That token is already placed this race.");
+      return;
+    }
+    const sameSpotTaken = placedBets.some(
+      (bet) =>
+        bet.laneLabel === selectedLaneLabel &&
+        bet.betType === selectedBetType &&
+        bet.spotIndex === selectedSpotIndex
+    );
+    if (sameSpotTaken) {
+      setSettlementSummary("That spot is already occupied by one of your bets.");
+      return;
+    }
+    const [multiplier, loss] = STANDARD_MATRIX[selectedLaneLabel][selectedSpotIndex];
+    setPlacedBets((current) => [
+      ...current,
+      {
+        tokenId: token.id,
+        tokenValue: token.value,
+        laneLabel: selectedLaneLabel,
+        betType: selectedBetType,
+        spotIndex: selectedSpotIndex,
+        multiplier,
+        loss,
+      },
+    ]);
+    setSettlementSummary(null);
   };
 
   return (
@@ -507,6 +671,108 @@ export function ReadySetBet({ onBack }: { onBack?: () => void }) {
               <strong>
                 Winner: Lane {winnerLane} ({raceSlots[winnerLane - 1]?.racer.name ?? "Unknown"})
               </strong>
+            )}
+          </div>
+
+          <div
+            style={{
+              marginBottom: "0.85rem",
+              padding: "0.75rem",
+              borderRadius: "12px",
+              backgroundColor: "rgba(15, 23, 42, 0.68)",
+              border: "1px solid rgba(255,255,255,0.24)",
+            }}
+          >
+            <h2 style={{ marginTop: 0, marginBottom: "0.45rem", fontSize: "1rem" }}>Betting</h2>
+            <p style={{ marginTop: 0, marginBottom: "0.5rem" }}>
+              Bankroll: <strong>${bankroll}</strong> · Betting:{" "}
+              <strong style={{ color: bettingOpen && isRacing ? "#86efac" : "#fca5a5" }}>
+                {bettingOpen && isRacing ? "OPEN" : "CLOSED"}
+              </strong>
+              {!isRacing && " (start a race to place bets)"}
+            </p>
+            <div style={{ display: "flex", flexWrap: "wrap", gap: "0.5rem", alignItems: "center" }}>
+              <label>
+                Token{" "}
+                <select value={selectedTokenId} onChange={(event) => setSelectedTokenId(event.target.value)}>
+                  {PLAYER_TOKENS.map((token) => {
+                    const tokenUsed = placedBets.some((bet) => bet.tokenId === token.id);
+                    return (
+                      <option key={token.id} value={token.id} disabled={tokenUsed}>
+                        {token.value} {tokenUsed ? "(used)" : ""}
+                      </option>
+                    );
+                  })}
+                </select>
+              </label>
+              <label>
+                Horse{" "}
+                <select
+                  value={selectedLaneLabel}
+                  onChange={(event) => setSelectedLaneLabel(event.target.value as (typeof LANE_LABELS)[number])}
+                >
+                  {LANE_LABELS.map((laneLabel) => (
+                    <option key={laneLabel} value={laneLabel}>
+                      {laneLabel}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                Bet{" "}
+                <select
+                  value={selectedBetType}
+                  onChange={(event) => setSelectedBetType(event.target.value as StandardBetType)}
+                >
+                  <option value="show">Show</option>
+                  <option value="place">Place</option>
+                  <option value="win">Win</option>
+                </select>
+              </label>
+              <label>
+                Spot{" "}
+                <select
+                  value={selectedSpotIndex}
+                  onChange={(event) => setSelectedSpotIndex(Number(event.target.value) as StandardBetSpotIndex)}
+                >
+                  {SPOT_INDEXES_BY_BET_TYPE[selectedBetType].map((index) => {
+                    const [multiplier, loss] = STANDARD_MATRIX[selectedLaneLabel][index];
+                    return (
+                      <option key={index} value={index}>
+                        #{index + 1} ({multiplier}x / -{loss})
+                      </option>
+                    );
+                  })}
+                </select>
+              </label>
+              <button
+                type="button"
+                onClick={placeStandardBet}
+                disabled={!isRacing || !bettingOpen}
+                style={{
+                  border: "1px solid #fff",
+                  backgroundColor: !isRacing || !bettingOpen ? "rgba(148,163,184,0.45)" : "#facc15",
+                  color: "#111827",
+                  borderRadius: "999px",
+                  padding: "0.4rem 0.85rem",
+                  fontWeight: 700,
+                  cursor: !isRacing || !bettingOpen ? "not-allowed" : "pointer",
+                }}
+              >
+                Place Bet
+              </button>
+            </div>
+            {settlementSummary && (
+              <p style={{ marginBottom: 0.15, color: "#fde68a", fontWeight: 700 }}>{settlementSummary}</p>
+            )}
+            {placedBets.length > 0 && (
+              <ul style={{ marginBottom: 0, paddingLeft: "1.1rem" }}>
+                {placedBets.map((bet) => (
+                  <li key={`${bet.tokenId}-${bet.laneLabel}-${bet.betType}-${bet.spotIndex}`}>
+                    ${bet.tokenValue} on {bet.betType.toUpperCase()} {bet.laneLabel} ({bet.multiplier}x / -{bet.loss})
+                  </li>
+                ))}
+              </ul>
             )}
           </div>
 

--- a/src/ReadySetBet/BettingEngineSpec.md
+++ b/src/ReadySetBet/BettingEngineSpec.md
@@ -1,0 +1,306 @@
+# Ready Set Bet — Betting Engine Implementation Spec
+
+This document translates the betting-only rules handoff into implementable data structures, validation rules, and resolution logic.
+
+## 1) Scope
+
+This spec covers:
+- Bet placement legality.
+- Betting window locking.
+- Win/loss evaluation for standard bets, color bets, prop bets, and exotic finish bets.
+- Payout/loss application, including bonus token behavior.
+- House betting variant occupancy exception.
+
+This spec does **not** provide complete canonical card databases for all Prop/VIP cards because the rulebook scan is incomplete for full card text.
+
+---
+
+## 2) Core domain model
+
+```ts
+type HorseLabel = "2/3" | "4" | "5" | "6" | "7" | "8" | "9" | "10" | "11/12";
+
+type BetCategory = "standard" | "color" | "special" | "prop" | "exotic";
+type StandardKind = "show" | "place" | "win";
+type ColorKind = "blueWins" | "orangeWins" | "redWins";
+type SpecialKind = "sevenFinishesFifthOrWorse";
+
+type Money = number; // integer dollars
+
+type BetTokenBaseValue = 2 | 3 | 4 | 5 | 6 | 7;
+
+interface BonusTokenRules {
+  /** extra loss charged on losing bets; null for value-2 negate token */
+  extraLossOnLose: number | null;
+  /** if true, losing spot penalty is ignored */
+  negatesSpotLoss: boolean;
+}
+
+interface BetToken {
+  id: string;
+  ownerPlayerId: string;
+  baseValue: BetTokenBaseValue;
+  isBonus: boolean;
+  bonusRules?: BonusTokenRules;
+}
+
+interface BetSpot {
+  id: string;
+  category: BetCategory;
+  multiplier: number;
+  spotLoss: number; // red-circle amount; 0 if none
+
+  horse?: HorseLabel;          // standard bets
+  standardKind?: StandardKind; // standard bets
+  colorKind?: ColorKind;       // color bets
+  specialKind?: SpecialKind;   // 7 finishes 5th+ bet
+
+  propCardId?: string;
+  exoticCardId?: string;
+}
+
+interface PlacedBet {
+  tokenId: string;
+  ownerPlayerId: string;
+  spotId: string;
+  timestampMs: number;
+  placedByHouseToken: boolean;
+}
+
+interface PlayerState {
+  id: string;
+  money: Money;
+  tokens: BetToken[];
+  faceUpVipIds: string[];
+}
+
+interface RaceResult {
+  /** final distance reached by each horse at race end */
+  finalDistanceByHorse: Record<HorseLabel, number>;
+  /** standings groups, highest distance first; ties grouped */
+  rankGroups: HorseLabel[][];
+}
+```
+
+---
+
+## 3) Board definition
+
+### 3.1 Standard grid spots
+
+For each horse row, define 7 spots in this order:
+`showLeft, showRight, placeLeft, placeRight, winLeft, winMid, winRight`.
+
+```ts
+type StandardRow = [
+  [multiplier: number, loss: number],
+  [multiplier: number, loss: number],
+  [multiplier: number, loss: number],
+  [multiplier: number, loss: number],
+  [multiplier: number, loss: number],
+  [multiplier: number, loss: number],
+  [multiplier: number, loss: number]
+];
+
+const STANDARD_MATRIX: Record<HorseLabel, StandardRow> = {
+  "2/3":  [[4,4],[4,3],[5,4],[5,3],[7,2],[8,2],[9,2]],
+  "4":    [[3,1],[3,0],[4,1],[4,0],[5,1],[6,0],[7,0]],
+  "5":    [[2,3],[2,0],[2,2],[3,2],[4,2],[4,0],[5,0]],
+  "6":    [[1,2],[1,0],[2,5],[2,4],[3,2],[3,1],[3,0]],
+  "7":    [[1,3],[1,1],[2,6],[2,5],[3,4],[3,3],[3,2]],
+  "8":    [[1,2],[1,0],[2,5],[2,4],[3,2],[3,1],[3,0]],
+  "9":    [[2,3],[2,0],[2,2],[3,2],[4,2],[4,0],[5,0]],
+  "10":   [[3,1],[3,0],[4,1],[4,0],[5,1],[6,0],[7,0]],
+  "11/12":[[4,4],[4,3],[5,4],[5,3],[7,2],[8,2],[9,2]],
+};
+```
+
+> Stored `loss` values are positive magnitudes; subtract them from money on loss.
+
+### 3.2 Color + special spots
+
+```ts
+const COLOR_AND_SPECIAL_SPOTS = {
+  blueWins: { multiplier: 5, loss: 1 },
+  orangeWins: { multiplier: 3, loss: 1 },
+  redWins: { multiplier: 2, loss: 1 },
+  sevenFinishesFifthOrWorse: {
+    multiplier: 4,
+    loss: null, // unresolved from parsed text; verify from component art
+  },
+} as const;
+```
+
+### 3.3 Exotic cards
+
+```ts
+const EXOTIC_DEFS = {
+  tightRace:    { multiplier: 6, loss: 2 },
+  lateStart:    { multiplier: 4, loss: 1 },
+  photoFinish:  { multiplier: 5, loss: 3 },
+  byANose:      { multiplier: 5, loss: 3 },
+  blowOut:      { multiplier: 4, loss: 2 },
+} as const;
+```
+
+---
+
+## 4) Betting window state machine
+
+```ts
+type BettingWindowState = "open" | "closed";
+
+interface BettingWindow {
+  state: BettingWindowState;
+  noMoreBetsCalled: boolean;
+  raceEnded: boolean;
+}
+```
+
+Close betting immediately when **either** occurs first:
+1. House calls “No more bets!” (triggered when third horse crosses red line).
+2. Any horse reaches finish space 15 (race ends immediately).
+
+All placement attempts while `state === "closed"` are invalid unless a VIP explicitly overrides timing.
+
+---
+
+## 5) Placement validation
+
+Given `(playerId, tokenId, spotId, timestamp)`:
+
+1. Validate window open (or VIP timing exception).
+2. Token must belong to player and be unused this race.
+3. Player cannot place more than one of their own tokens on same spot.
+4. If spot currently contains another normal-player token, reject unless:
+   - VIP allows piggyback/stacking for this token, or
+   - existing token is a House token (House tokens do not block).
+5. Prop card spot: only one token total unless VIP override.
+6. Exotic card rule: player may not place more than one of their own tokens on the same exotic card.
+7. Once placed, token cannot move/remove.
+
+---
+
+## 6) Finish classification (Win / Place / Show)
+
+Input: `rankGroups` ordered from first to last, where each group contains tied horses.
+
+Algorithm:
+1. `winSet = rankGroups[0]`.
+2. `placeSet = union(rankGroups[0], rankGroups[1] if exists)`.
+3. Show:
+   - If `rankGroups[1]` exists and has size >= 2 (tie for second), then
+     `showSet = union(rankGroups[0], rankGroups[1])` and no lower ranks show.
+   - Else
+     `showSet = union(rankGroups[0], rankGroups[1]?, rankGroups[2]?)`.
+
+This matches rulebook tie handling.
+
+---
+
+## 7) Side-bet evaluation rules
+
+### 7.1 Color winners
+- `blueWins` succeeds if any blue horse is in first-place tie group.
+- `orangeWins` succeeds if any orange horse is in first-place tie group.
+- `redWins` succeeds if any red horse is in first-place tie group.
+
+(Implement with a static mapping `HorseLabel -> Color` sourced from board art.)
+
+### 7.2 “7 finishes 5th or worse”
+- Count how many horses finish strictly ahead of horse `7`.
+- Bet wins if count >= 4.
+
+### 7.3 Prop cards
+Each prop card should compile into a predicate:
+
+```ts
+type PropPredicate = (result: RaceResult) => boolean;
+```
+
+Common semantics:
+- "A finishes ahead of B" means `distance(A) > distance(B)`.
+- If tied (`distance(A) === distance(B)`), prop loses.
+- "A ahead of all in set S" requires strict `>` against each member of `S`.
+
+### 7.4 Exotic cards
+Using `finalDistanceByHorse` and `rankGroups`:
+- **Tight Race**: every horse distance >= 6.
+- **Late Start**: at least 2 horses distance <= 3.
+- **Photo Finish**: distance gap between 2nd-place distance and 3rd-place distance <= 3.
+  - If tie for 2nd exists, 2nd and 3rd distances are equal -> qualifies.
+- **By a Nose**: gap between 1st-place distance and 2nd-place distance === 1.
+- **Blow Out**: gap between 1st-place distance and 2nd-place distance > 5.
+
+For ties, define rank distances by group index (`rankGroups[0]` first-place group, `rankGroups[1]` second-place group, etc.).
+
+---
+
+## 8) Payout/loss resolution
+
+Resolve in this order:
+1. Compute all bet outcomes (`won/lost`) from locked board state + race result.
+2. Credit all winnings.
+3. Charge all losses.
+4. Clamp money floor at 0 (no debt).
+
+Formulas:
+- Win payout: `token.baseValue * spot.multiplier`.
+- Standard loss: `spot.spotLoss`.
+- If spot has no red circle, `spotLoss = 0`.
+
+Bonus token loss extension:
+- If bonus token is value-2 negate type: losing cost ignores spot loss.
+- Otherwise losing cost is `spotLoss + bonus.extraLossOnLose`.
+
+If exact bonus extra-loss values are unknown from assets, keep them data-driven and injected from verified component references.
+
+---
+
+## 9) House variant rules
+
+If House participates:
+- House pre-places 6 house tokens on 6 different spots.
+- House tokens do not close spots for normal players.
+- House tokens resolve with same payout/loss formulas.
+- House starts with `$18` and no VIP cards.
+
+Implementation tip: model occupancy by token class:
+- `normalOccupant?: tokenId`
+- `houseOccupant?: tokenId`
+
+Normal placement checks only block on `normalOccupant` unless VIP override.
+
+---
+
+## 10) Recommended service boundaries
+
+```ts
+interface BettingPlacementService {
+  validatePlacement(input: PlacementAttempt, state: BettingState): PlacementValidation;
+  applyPlacement(input: PlacementAttempt, state: BettingState): BettingState;
+}
+
+interface BetOutcomeService {
+  classifyFinish(result: RaceResult): { winSet: Set<HorseLabel>; placeSet: Set<HorseLabel>; showSet: Set<HorseLabel> };
+  evaluateBet(placedBet: PlacedBet, state: BettingState, result: RaceResult): { won: boolean; payout: number; loss: number };
+}
+
+interface SettlementService {
+  settleRace(state: BettingState, result: RaceResult): SettlementSummary;
+}
+```
+
+Keep unresolved rulebook fields configurable in one schema file (prop deck text, full VIP deck text, special-spot missing loss, bonus-token loss table).
+
+---
+
+## 11) Known unresolved constants to verify from physical/asset references
+
+1. Complete text/database of all 28 Prop cards.
+2. Complete text/database of all 32 VIP cards.
+3. Bonus token extra-loss values for 3/4/5/6/7 tokens.
+4. Exact red-line track-space index.
+5. Exact red-circle loss on the “7 finishes 5th or worse” spot.
+
+Until verified, expose these as external config with strict runtime validation.


### PR DESCRIPTION
### Motivation
- Implement an in-component betting subsystem so players can place standard bets (show/place/win) during races and have payouts/losses resolved at race end.
- Introduce structured constants and types for standard bet spots, tokens, and placement validation to make betting logic deterministic and maintainable.
- Capture the full betting rules, edge cases, and service boundaries in a human-readable spec to guide future implementation work and verification.

### Description
- Added standard-bet types, the `STANDARD_MATRIX`, `SPOT_INDEXES_BY_BET_TYPE`, and `PLAYER_TOKENS` constants and related TypeScript types to represent spots, multipliers, and token values. 
- Introduced betting state to the component (`bankroll`, `placedBets`, `bettingOpen`, `settlementSummary`, selected token/spot state) and implemented `placeStandardBet` to validate and record bets. 
- Implemented race-settlement logic in `settleRace` that classifies win/place/show per the rulebook tie rules, computes winnings/losses, updates `bankroll`, and produces a settlement summary, and added betting window closing when three horses cross the red line or when a horse finishes. 
- Added a betting UI block to `ReadySetBet.tsx` (controls for token, horse, bet kind, spot, and a list of placed bets) and created `src/ReadySetBet/BettingEngineSpec.md` with a detailed specification covering placement rules, finish classification, exotic/prop rules, payout formulas, house rules, and recommended service boundaries.

### Testing
- No new automated unit tests were added for the betting engine in this PR. 
- Performed a TypeScript type-check with `tsc --noEmit` which completed successfully. 
- Built the application with `npm run build` to ensure the changes compile; the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c84161884883298e57e49b804bbce9)