### PR TITLE
Move Set Bankroll control next to Reset in race controls

### DIFF
--- a/src/ReadySetBet.tsx
+++ b/src/ReadySetBet.tsx
@@ -862,6 +862,33 @@ export function ReadySetBet({ onBack }: { onBack?: () => void }) {
             >
               Reset
             </button>
+            <label>
+              Starting bankroll{" "}
+              <input
+                type="number"
+                min={1}
+                value={investmentInput}
+                disabled={isRacing}
+                onChange={(event) => setInvestmentInput(event.target.value)}
+                style={{ width: "100px" }}
+              />
+            </label>
+            <button
+              type="button"
+              onClick={applyInvestment}
+              disabled={isRacing}
+              style={{
+                border: "1px solid #fff",
+                backgroundColor: isRacing ? "rgba(148,163,184,0.45)" : "#60a5fa",
+                color: "#111827",
+                borderRadius: "999px",
+                padding: "0.4rem 0.85rem",
+                fontWeight: 700,
+                cursor: isRacing ? "not-allowed" : "pointer",
+              }}
+            >
+              Set Bankroll
+            </button>
             <small style={{ opacity: 0.9 }}>
               {!hasSetInvestment
                 ? "Set bankroll first."
@@ -902,33 +929,6 @@ export function ReadySetBet({ onBack }: { onBack?: () => void }) {
               </strong>
             </p>
             <div style={{ display: "flex", flexWrap: "wrap", gap: "0.5rem", alignItems: "center", marginBottom: "0.65rem" }}>
-              <label>
-                Starting bankroll{" "}
-                <input
-                  type="number"
-                  min={1}
-                  value={investmentInput}
-                  disabled={isRacing}
-                  onChange={(event) => setInvestmentInput(event.target.value)}
-                  style={{ width: "100px" }}
-                />
-              </label>
-              <button
-                type="button"
-                onClick={applyInvestment}
-                disabled={isRacing}
-                style={{
-                  border: "1px solid #fff",
-                  backgroundColor: isRacing ? "rgba(148,163,184,0.45)" : "#60a5fa",
-                  color: "#111827",
-                  borderRadius: "999px",
-                  padding: "0.4rem 0.85rem",
-                  fontWeight: 700,
-                  cursor: isRacing ? "not-allowed" : "pointer",
-                }}
-              >
-                Set Bankroll
-              </button>
               <span style={{ fontSize: "0.9rem", opacity: 0.9 }}>
                 Click squares on the board image to toggle bets while open ({placedBets.length}/5 selected).
               </span>


### PR DESCRIPTION
### Motivation
- Players need to be able to set their starting bankroll before interacting with race/betting controls, so the bankroll controls should be available earlier in the UI.

### Description
- Moved the `Starting bankroll` input and `Set Bankroll` button from the betting board into the main race controls row immediately after the `Reset` button in `src/ReadySetBet.tsx`.
- Removed the duplicated bankroll controls from the betting board section and left only the board helper text in that section.
- No changes to betting logic or state handlers were introduced; the existing `investmentInput`, `applyInvestment`, and related state are reused.

### Testing
- Ran `npm run build` and the project built successfully (production build completed; unrelated ESLint warnings remain in other files).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c85044a15c8329aa80da00ce3c8c9b)