### PR TITLE
Fix Sandbox town buttons with images and center Sandbox header

### DIFF
--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -939,7 +939,7 @@ function SandboxMenu({
       <div style={styles.sandboxContent}>
         <div style={styles.sandboxHero}>
           <p style={styles.sandboxEyebrow}>Welcome to</p>
-          <h1 style={styles.title}>Sandbox</h1>
+          <h1 style={{ ...styles.title, textAlign: "center" }}>Sandbox</h1>
           <p style={styles.subtitle}>
             Choose a destination below to preview the settlement, then enter it.
           </p>
@@ -957,7 +957,7 @@ function SandboxMenu({
               key={town.key}
               label={town.name}
               description={undefined}
-              imageSrc={undefined}
+              imageSrc={town.image}
               backgroundColor="rgba(30, 41, 59, 0.88)"
               color="#e2e8f0"
               delay="0s"


### PR DESCRIPTION
### Motivation
- Ensure each Sandbox town button displays the correct image above its label and make the Sandbox header explicitly centered for consistent layout.

### Description
- In `src/Map.tsx` updated the `SandboxMenu` so each town button receives `imageSrc={town.image}` when rendering `FloatingButton` so the image appears above the text.
- In `src/Map.tsx` applied `textAlign: "center"` to the `Sandbox` title by merging it into the existing `styles.title` inline style.

### Testing
- Ran `npm run build` successfully (production build completed; unrelated ESLint warnings remain in other files).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc9088be248329bcd30127837cb124)