### PR TITLE
Center Sandbox title and show town images in sandbox buttons

### DIFF
--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -939,7 +939,7 @@ function SandboxMenu({
       <div style={styles.sandboxContent}>
         <div style={styles.sandboxHero}>
           <p style={styles.sandboxEyebrow}>Welcome to</p>
-          <h1 style={styles.title}>Sandbox</h1>
+          <h1 style={{ ...styles.title, textAlign: "center" }}>Sandbox</h1>
           <p style={styles.subtitle}>
             Choose a destination below to preview the settlement, then enter it.
           </p>
@@ -957,7 +957,7 @@ function SandboxMenu({
               key={town.key}
               label={town.name}
               description={undefined}
-              imageSrc={undefined}
+              imageSrc={town.image}
               backgroundColor="rgba(30, 41, 59, 0.88)"
               color="#e2e8f0"
               delay="0s"
@@ -1113,6 +1113,8 @@ const styles: Record<string, React.CSSProperties> = {
     display: "flex",
     flexDirection: "column",
     alignItems: "center",
+    justifyContent: "center",
+    textAlign: "center",
     gap: "0.85rem",
     width: "100%",
     maxWidth: "100%",


### PR DESCRIPTION
### Motivation
- Improve the Sandbox menu's visual layout and clarity by centering the header and showing each town's preview image on its floating button.

### Description
- Centered the Sandbox header by applying `textAlign: "center"` to the title element, passed `town.image` into the `FloatingButton` `imageSrc` prop so sandbox towns display images, and adjusted button layout by adding `justifyContent: "center"` and `textAlign: "center"` to `styles.button`.

### Testing
- Ran unit tests with `yarn test` and a production build with `yarn build`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc9088be248329bcd30127837cb124)