### PR TITLE
Center Sandbox header text

### DIFF
--- a/src/Map.tsx
+++ b/src/Map.tsx
@@ -1083,7 +1083,9 @@ const styles: Record<string, React.CSSProperties> = {
     fontSize: "2.5rem",
     fontWeight: "bold",
     color: "#ffffffff",
-    marginBottom: "1rem",
+    margin: "0 0 1rem",
+    textAlign: "center",
+    width: "100%",
   },
   subtitle: {
     margin: "0 0 2rem",

--- a/src/SandboxMenu.module.css
+++ b/src/SandboxMenu.module.css
@@ -55,6 +55,8 @@
   margin: 0;
   font-size: 2.4rem;
   color: #f8fafc;
+  text-align: center;
+  width: 100%;
 }
 
 .subtitle {


### PR DESCRIPTION
### Motivation
- The Sandbox page title was not reliably centered in all render paths, so make the header explicitly centered in both the inline styles used by `Map.tsx` and the dedicated `SandboxMenu` CSS for consistent presentation.

### Description
- In `src/Map.tsx` updated the `styles.title` object to normalize the margin and add `textAlign: "center"` and `width: "100%"` so the inline-styled Sandbox header centers correctly.
- In `src/SandboxMenu.module.css` updated the `.title` rule to include `text-align: center;` and `width: 100%;` so the Sandbox menu component title is also centered.

### Testing
- Ran `npm run build` and the production build completed successfully (build succeeded; existing lint warnings are unrelated to this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc98a1b0f883299c8f925b591e82c2)