### PR TITLE
Place Horse Racing after Black Market and update button color to green-cyan

### DIFF
--- a/src/ReadySetBet.tsx
+++ b/src/ReadySetBet.tsx
@@ -451,7 +451,7 @@ export const readySetBetMapButton = {
   key: "ReadySetBet",
   label: "Horse Racing",
   delay: "50s",
-  backgroundColor: "rgba(250, 204, 21, 0.9)",
+  backgroundColor: "rgba(45, 212, 191, 0.9)",
   imageSrc: raceTrackImage,
 } as const;
 

--- a/src/shopButtonStyles.ts
+++ b/src/shopButtonStyles.ts
@@ -24,6 +24,7 @@ const colorRules: ColorRule[] = [
 const styleMap: Record<string, ShopButtonStyle> = {
   "auction house": { backgroundColor: "rgba(138, 253, 244, 0.712)" },
   "black market": { backgroundColor: "rgba(0, 0, 0, 0.712)", color: "white" },
+  "horse racing": { backgroundColor: "rgba(45, 212, 191, 0.9)", color: "#052e2b" },
   "goblin market": { backgroundColor: "rgba(250, 204, 21, 0.9)" },
   goblins: { backgroundColor: "rgba(250, 204, 21, 0.9)" },
   "applegarth guild": { backgroundColor: "rgba(250, 204, 21, 0.9)" },
@@ -135,6 +136,18 @@ export function sortShopButtons<T extends { label: string; backgroundColor?: str
   buttons: T[]
 ): T[] {
   return [...buttons].sort((a, b) => {
+    const labelA = normalizeLabel(a.label);
+    const labelB = normalizeLabel(b.label);
+    const horseLabel = "horse racing";
+    const blackMarketLabel = "black market";
+
+    if (labelA === horseLabel && labelB === blackMarketLabel) {
+      return 1;
+    }
+    if (labelA === blackMarketLabel && labelB === horseLabel) {
+      return -1;
+    }
+
     const colorRankA = getColorRank(
       a.backgroundColor ?? getShopButtonStyle(a.label).backgroundColor
     );
@@ -144,6 +157,6 @@ export function sortShopButtons<T extends { label: string; backgroundColor?: str
     if (colorRankA !== colorRankB) {
       return colorRankA - colorRankB;
     }
-    return normalizeLabel(a.label).localeCompare(normalizeLabel(b.label));
+    return labelA.localeCompare(labelB);
   });
 }


### PR DESCRIPTION
### Motivation
- Ensure the Horse Racing map button appears immediately after Black Market in the Every Shop ordering and update its appearance to a green-cyan tone for visual consistency.

### Description
- Added a `"horse racing"` entry to `styleMap` in `src/shopButtonStyles.ts` with `backgroundColor: rgba(45, 212, 191, 0.9)` and `color: #052e2b` so label-based styling is consistent.
- Adjusted `sortShopButtons` in `src/shopButtonStyles.ts` to special-case ordering so `Horse Racing` sorts directly after `Black Market` when both are present.
- Updated `readySetBetMapButton.backgroundColor` in `src/ReadySetBet.tsx` to `rgba(45, 212, 191, 0.9)` so the exported map metadata matches the new style.

### Testing
- Ran `npm run build` which completed successfully (build produced only lint warnings).
- Ran `npm test -- --watchAll=false --runInBand App.test.tsx` which failed due to pre-existing test expectations and a jsdom `HTMLCanvasElement.getContext` limitation that appears unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc9a532670832982acec21cea84792)