### PR TITLE
Add Calidris Rooming Roomba image under New Calidris title

### DIFF
--- a/src/CalidrisFisk.module.css
+++ b/src/CalidrisFisk.module.css
@@ -59,6 +59,16 @@
   color: #f8fafc;
 }
 
+.roomingRoombaImage {
+  width: min(340px, 100%);
+  height: auto;
+  margin: 0 auto 0.2rem;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: rgba(15, 23, 42, 0.5);
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.35);
+}
+
 .subtitle {
   margin: 0;
   color: #cbd5e1;

--- a/src/CalidrisFisk.tsx
+++ b/src/CalidrisFisk.tsx
@@ -9,6 +9,7 @@ import bulletsBuffsBeyondImage from "./Bullets Buffs and Beyond.webp";
 import supremeSmithyImage from "./Supreme Smithy.png";
 import willsWeaponsImage from "./Wills Weapons.png";
 import nmeImage from "./N.M.E.png";
+import calidrisRoomingRoombaImage from "./Calidris_Rooming_Roomba.webp";
 import { BackButton } from "./BackButton";
 import styles from "./CalidrisFisk.module.css";
 import { ShopButton } from "./ShopButton";
@@ -104,6 +105,11 @@ export function CalidrisFisk({
         <div className={styles.hero}>
           <p className={styles.eyebrow}>Sandbox</p>
           <h1 className={styles.title}>New Calidris</h1>
+          <img
+            className={styles.roomingRoombaImage}
+            src={calidrisRoomingRoombaImage}
+            alt="Calidris Rooming Roomba"
+          />
           <p className={styles.subtitle}>
             A new frontier, lead by an unusual bunch, will this up and coming place survive and thrive? or implode from internal conflict? Only time will tell.
           </p>


### PR DESCRIPTION
### Motivation
- Add the Calidris "Rooming Roomba" artwork to the Calidris hero so the image appears between the page title and the shop buttons for improved visual context.

### Description
- Import `Calidris_Rooming_Roomba.webp` and render it in `CalidrisFisk.tsx` directly below the `New Calidris` `<h1>` and above the hero subtitle.
- Add a `.roomingRoombaImage` rule to `CalidrisFisk.module.css` to make the image responsive and match the hero styling (max width, border, background and shadow).
- No other layout or button logic was changed; shop buttons remain rendered from the existing `sortedShops` list.

### Testing
- Ran `npm run test -- --watchAll=false` and the test suite failed with 1 failing test in `src/App.test.tsx` (failures are due to an existing heading text expectation mismatch and a jsdom `HTMLCanvasElement.getContext` limitation in `Map.tsx`, not caused by these layout changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdd8b3b59083299aa9c1aae558edb8)