### PR TITLE
Add QuickTime fullscreen toggle and preference; update hotkey help

### DIFF
--- a/src/Project Nonsense/project_nonsense_player.py
+++ b/src/Project Nonsense/project_nonsense_player.py
@@ -148,7 +148,7 @@ print("Movie exists:", os.path.exists(MOVIE_FOLDER))
 print("VLC_PATH:", VLC_PATH)
 print("VLC exists:", os.path.exists(VLC_PATH) if VLC_PATH else False)
 print("Player plan:", "Use VLC first, fall back to QuickTime Player if VLC is missing")
-print("Hotkeys:", "backtick stops the program")
+print("Hotkeys:", "backtick: stop program | |: skip clip | _: toggle fullscreen")
 
 # =====================
 # LOAD VIDEO LISTS
@@ -276,6 +276,7 @@ stop_program = False
 skip_current_video = False
 current_process = None
 current_player = None
+quicktime_should_be_fullscreen = False
 
 
 def close_quicktime_documents(close_all=True):
@@ -305,6 +306,87 @@ def close_quicktime_documents(close_all=True):
         pass
 
 
+def toggle_quicktime_fullscreen():
+    """
+    Toggle QuickTime Player fullscreen/presentation mode for document 1.
+    If presentation mode scripting is unavailable, fall back to the
+    standard fullscreen keystroke (Control + Command + F) via System Events.
+    """
+    script = '''
+    tell application "QuickTime Player"
+        if (count of documents) = 0 then
+            return "NO_DOCUMENTS"
+        end if
+
+        try
+            set isPresenting to presenting of document 1
+            set presenting of document 1 to (not isPresenting)
+            return "TOGGLED_PRESENTATION"
+        on error
+            -- Fallback: send the common fullscreen toggle shortcut.
+        end try
+    end tell
+
+    tell application "System Events"
+        keystroke "f" using {command down, control down}
+    end tell
+    return "TOGGLED_KEYSTROKE"
+    '''
+
+    try:
+        result = subprocess.run(
+            ["osascript", "-e", script],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return result.stdout.strip()
+    except Exception:
+        return ""
+
+
+def apply_quicktime_fullscreen_preference():
+    """
+    If QuickTime fullscreen preference is enabled, attempt to put document 1
+    into presentation/fullscreen mode. This keeps the next clips fullscreen.
+    """
+    global quicktime_should_be_fullscreen
+
+    if not quicktime_should_be_fullscreen:
+        return ""
+
+    script = '''
+    tell application "QuickTime Player"
+        if (count of documents) = 0 then
+            return "NO_DOCUMENTS"
+        end if
+
+        try
+            set presenting of document 1 to true
+            return "APPLIED_PRESENTATION"
+        on error
+            -- Fallback: send the common fullscreen toggle shortcut.
+        end try
+    end tell
+
+    tell application "System Events"
+        keystroke "f" using {command down, control down}
+    end tell
+    return "APPLIED_KEYSTROKE"
+    '''
+
+    try:
+        result = subprocess.run(
+            ["osascript", "-e", script],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return result.stdout.strip()
+    except Exception:
+        return ""
+
+
 def on_press(key):
     """
     This function runs whenever a key is pressed.
@@ -313,7 +395,7 @@ def on_press(key):
     - kill the current VLC video
     - stop listening for more keys
     """
-    global stop_program, skip_current_video, current_process, current_player
+    global stop_program, skip_current_video, current_process, current_player, quicktime_should_be_fullscreen
     try:
         if key.char == '`':  # backtick pressed
             print("Backtick pressed! Stopping program...")
@@ -330,6 +412,12 @@ def on_press(key):
                 close_quicktime_documents(close_all=False)
             elif current_player == "vlc" and current_process:
                 current_process.terminate()
+        if key.char == '_' and current_player == "quicktime":
+            toggle_result = toggle_quicktime_fullscreen()
+            if toggle_result == "NO_DOCUMENTS":
+                print("No QuickTime document is open to toggle fullscreen.")
+            elif toggle_result in ("TOGGLED_PRESENTATION", "TOGGLED_KEYSTROKE"):
+                quicktime_should_be_fullscreen = not quicktime_should_be_fullscreen
 
     except AttributeError:
         pass
@@ -450,6 +538,7 @@ def play_with_quicktime(video):
     )
     current_process.wait()
     current_process = None
+    apply_quicktime_fullscreen_preference()
     near_end_counter = 0
 
     while not stop_program:


### PR DESCRIPTION
### Motivation
- Provide a way to toggle QuickTime Player fullscreen/presentation mode from the script and remember that preference for subsequent clips to improve playback control when VLC is not used.
- Make the on-screen hotkey help reflect the additional controls available for QuickTime playback.

### Description
- Add a global `quicktime_should_be_fullscreen` flag and call `apply_quicktime_fullscreen_preference()` after launching a QuickTime document to enforce the fullscreen preference.
- Introduce `toggle_quicktime_fullscreen()` which attempts to toggle presentation mode via QuickTime scripting and falls back to sending the Control+Command+F keystroke via `System Events` when needed.
- Implement `apply_quicktime_fullscreen_preference()` to set presentation mode on document 1 (or fall back to the keystroke) when the preference is enabled.
- Update `on_press()` to handle the `"_"` key for toggling QuickTime fullscreen and flip the `quicktime_should_be_fullscreen` flag when toggling succeeds, and update the printed hotkeys help string to include the new mappings.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea43efedf88329ada7e0a4bd551ed6)