### PR TITLE
Add 'TV Time' mode to auto-select TV presets by local time

### DIFF
--- a/src/Project Nonsense/project_nonsense_player.py
+++ b/src/Project Nonsense/project_nonsense_player.py
@@ -4,6 +4,7 @@ import subprocess          # Lets Python launch another program, like VLC
 from pynput import keyboard  # Lets Python listen for keyboard presses
 import time                # Lets Python pause between clips
 import shutil              # Lets Python look for programs in common locations
+from datetime import datetime  # Lets Python read the computer's current local time
 
 # to start use this
 #.  /usr/bin/python3 "/Volumes/Bag O Holdn/Videos (Project Nonsense)/project_nonsense_player.py"
@@ -90,6 +91,10 @@ INDIE_SHOWS = [
     "Youtube",
 ]
 
+
+TV_TIME_MODE = False
+CURRENT_TV_TIME_PRESET = None
+
 # =====================
 # VLC FINDER
 # =====================
@@ -173,6 +178,7 @@ def get_videos(folder):
 
 
 def choose_tv_shows():
+    global TV_TIME_MODE
     """
     Ask the user which show folders should be included.
     Return chosen show names from SHOW_OPTIONS or a preset group.
@@ -182,7 +188,8 @@ def choose_tv_shows():
     print("Type 'all' to include every show option.\n")
     print("Type 'cartoon' to run only cartoon shows.")
     print("Type 'anime' to run only anime shows.")
-    print("Type 'indie' to run only indie shows.\n")
+    print("Type 'indie' to run only indie shows.")
+    print("Type 'tv time' to auto-pick by current time: cartoon after 5 AM, indie after 1 PM, anime after 7 PM.\n")
 
     for index, show_name in enumerate(SHOW_OPTIONS, start=1):
         print(f"{index}. {show_name}")
@@ -192,13 +199,22 @@ def choose_tv_shows():
         lowered = raw_choice.lower()
 
         if lowered == "all":
+            TV_TIME_MODE = False
             return SHOW_OPTIONS[:]
         if lowered == "cartoon":
+            TV_TIME_MODE = False
             return CARTOON_SHOWS[:]
         if lowered == "anime":
+            TV_TIME_MODE = False
             return ANIME_SHOWS[:]
         if lowered == "indie":
+            TV_TIME_MODE = False
             return INDIE_SHOWS[:]
+        if lowered == "tv time":
+            TV_TIME_MODE = True
+            preset_name, preset_shows = choose_tv_time_preset()
+            print(f"\nTV Time selected {preset_name} preset based on your current local time.")
+            return preset_shows
 
         selected_indexes = []
         valid = True
@@ -217,12 +233,46 @@ def choose_tv_shows():
             selected_indexes.append(number - 1)
 
         if not valid or not selected_indexes:
-            print("Invalid choice. Enter numbers like 1,3,5 or type 'all', 'cartoon', 'anime', or 'indie'.")
+            print("Invalid choice. Enter numbers like 1,3,5 or type 'all', 'cartoon', 'anime', 'indie', or 'tv time'.")
             continue
 
         # Preserve order while removing duplicates
         unique_indexes = list(dict.fromkeys(selected_indexes))
         return [SHOW_OPTIONS[i] for i in unique_indexes]
+
+
+
+
+def choose_tv_time_preset():
+    """
+    Decide which preset should run for "tv time" based on local clock time.
+    """
+    current_hour = datetime.now().hour
+
+    if current_hour >= 19 or current_hour < 5:
+        return "anime", ANIME_SHOWS[:]
+    if current_hour >= 13:
+        return "indie", INDIE_SHOWS[:]
+    return "cartoon", CARTOON_SHOWS[:]
+
+def refresh_tv_time_selection_if_needed(tv_history):
+    """
+    Re-check local time after each clip and refresh TV presets when in TV Time mode.
+    """
+    global selected_tv_shows, tv_videos, TV_TO_MOVIE_RATIO, CURRENT_TV_TIME_PRESET
+
+    if not TV_TIME_MODE:
+        return
+
+    preset_name, preset_shows = choose_tv_time_preset()
+    if preset_name != CURRENT_TV_TIME_PRESET:
+        CURRENT_TV_TIME_PRESET = preset_name
+        selected_tv_shows = preset_shows
+        tv_videos = get_tv_videos_from_selected_shows(selected_tv_shows)
+        tv_history.clear()
+        TV_TO_MOVIE_RATIO = max(1, round(len(tv_videos) / len(movie_videos)))
+        print(f"\nTV Time switched to {preset_name} preset based on current local time.")
+        print("Dynamic TV-to-movie ratio:", TV_TO_MOVIE_RATIO, "TV clips per movie clip")
 
 
 def get_tv_videos_from_selected_shows(selected_shows):
@@ -248,6 +298,9 @@ def get_tv_videos_from_selected_shows(selected_shows):
 
 
 selected_tv_shows = choose_tv_shows()
+if TV_TIME_MODE:
+    CURRENT_TV_TIME_PRESET, _ = choose_tv_time_preset()
+
 print("\nSelected shows:")
 for show in selected_tv_shows:
     print("-", show)
@@ -634,6 +687,7 @@ while not stop_program:
             break
         video = choose_video(tv_videos, tv_history)
         play_video(video)
+        refresh_tv_time_selection_if_needed(tv_history)
 
     if stop_program:
         break
@@ -641,5 +695,6 @@ while not stop_program:
     # Play 1 Movie clip
     video = choose_video(movie_videos, movie_history)
     play_video(video)
+    refresh_tv_time_selection_if_needed(tv_history)
 
 print("Program stopped safely.")


### PR DESCRIPTION
### Motivation

- Provide an option to automatically pick TV show presets based on the computer's local time so playback can switch between cartoon, indie, and anime blocks without manual selection. 

### Description

- Add `datetime` import and global flags `TV_TIME_MODE` and `CURRENT_TV_TIME_PRESET` to track time-based mode and current preset. 
- Extend `choose_tv_shows()` to accept a new `tv time` command and to enable time-driven preset selection by calling `choose_tv_time_preset()`. 
- Implement `choose_tv_time_preset()` to return a preset name and show list based on the local hour (cartoon before 13:00, indie 13:00–18:59, anime 19:00+ / overnight). 
- Add `refresh_tv_time_selection_if_needed()` which re-evaluates the preset after each clip when `TV_TIME_MODE` is active and updates `selected_tv_shows`, `tv_videos`, clears `tv_history`, and recalculates `TV_TO_MOVIE_RATIO`. 

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3997441d08329bc062e819b604fab)